### PR TITLE
Fix mouse select getting stuck in visual mode

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -123,13 +123,15 @@ class VimState
       @showCursors()
 
     selectionWatcher = null
-    handleMouseDown = =>
+    handleMouseDown = (evt) =>
+      return unless evt.button is 0 # Only care about left button
       point = @editor.getLastCursor().getBufferPosition()
       tailRange = Range.fromPointWithDelta(point, 0, +1)
       selectionWatcher = @editor.onDidChangeSelectionRange ({selection}) ->
         selection.setBufferRange(selection.getBufferRange().union(tailRange))
 
-    handleMouseUp = ->
+    handleMouseUp = (evt) ->
+      return unless evt.button is 0 # Only care about left button
       handleSelectionChange()
       selectionWatcher?.dispose()
       selectionWatcher = null


### PR DESCRIPTION
If you use a different mouse button during a 'drag' or instead of a left drag you can get stuck in visual mode.

Without the fix:
![select_bug](https://cloud.githubusercontent.com/assets/45890/11088016/ec22f290-8899-11e5-8d7c-5e960c7b4422.gif)

Changing the code to only care about left button mouse events for both up and down seemed to fix it right up and I can't get the state stuck by using the mouse anymore.