### PR TITLE
test extending linewise-visual-mode with a search

### DIFF
--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -76,6 +76,12 @@ describe "Motion Search", ->
         ensure 'n',
           selectedBufferRange: [[0, 0], [2, 1]]
 
+      it 'searches to the correct column in visual linewise mode', ->
+        ensure ['V/', {search: 'ef'}],
+          selectedText: "abc\ndef\n",
+          selectedBufferRange: [[0, 0], [2, 0]],
+          cursor: [1, 1]
+
       describe "case sensitivity", ->
         beforeEach ->
           set


### PR DESCRIPTION
This is just a curiosity...  vim-mode-plus works correctly so I'm guessing something is wrong with the unit test. Feel free to just close.

I wrote this test to reproduce #83.

The test starts with

```
abc
def
```

With the cursor on the `a`.  Then it types `V` `/` `ef` `<return>`.

I would expect both lines to be selected, with the cursor being placed on the `e`.  And, when you test this by hand, it's indeed what happens.

However, the test thinks the cursor ends up at the start of line 3, instead it actually ending up in the middle of line 2 at the start of the match:

```
Motion Search
  the / keybinding
    as a motion
      it searches to the correct column in visual linewise mode
        Expected [ { row : 2, column : 0 } ] to equal [ [ 1, 1 ] ].
          at VimEditor.ensureCursor (/Users/bronson/.atom/packages/vim-mode-plus/spec/spec-helper.coffee:249:20)
          at VimEditor.ensure (/Users/bronson/.atom/packages/vim-mode-plus/spec/spec-helper.coffee:231:7)
          at /Users/bronson/.atom/packages/vim-mode-plus/spec/spec-helper.coffee:2:1
          at [object Object].<anonymous> (/Users/bronson/vim-mode-plus/spec/motion-search-spec.coffee:80:9)
```
