### PR TITLE
Fix #154

### DIFF
--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -3,7 +3,7 @@
 settings = require './settings'
 swrap = require './selection-wrapper'
 
-RowHeightInEm = 1.5
+RowHeightInEm = atom.config.get('editor.lineHeight')
 
 getDomNode = (editorElement, cursor) ->
   cursorsComponent = editorElement.component.linesComponent.cursorsComponent

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -3,8 +3,6 @@
 settings = require './settings'
 swrap = require './selection-wrapper'
 
-RowHeightInEm = atom.config.get('editor.lineHeight')
-
 getDomNode = (editorElement, cursor) ->
   cursorsComponent = editorElement.component.linesComponent.cursorsComponent
   cursorsComponent.cursorNodesById[cursor.id]
@@ -14,6 +12,7 @@ getDomNode = (editorElement, cursor) ->
 getOffset = (submode, selection) ->
   {top, left} = {}
   {cursor} = selection
+  RowHeightInEm = atom.config.get('editor.lineHeight')
   switch submode
     when 'characterwise', 'blockwise'
       unless selection.isReversed()


### PR DESCRIPTION
Get config value of editor.lineHeight instead of hardcoding the default of 1.5em