### PR TITLE
add spec for incorrect quote detection with black slash

### DIFF
--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -317,6 +317,15 @@ describe "TextObject", ->
           text: "' something in here and in 'here' ' and over here"
           cursor: [0, 9]
 
+      it "applies operators inside the current string with backslash", ->
+        set
+          text: "'some-key-here\\': 'here-is-the-val' # comment here"
+          cursor: [0, 2]
+
+        ensure "di'",
+          text: "'': 'here-is-the-val' # comment here"
+          cursor: [0, 1]
+
       it "applies operators inside the current string in operator-pending mode", ->
         ensure "di'",
           text: "''here' ' and over here"


### PR DESCRIPTION
Hi there, I've found a bug with quote detection 

If you have `\` in you quoted string it's going to be missed 

```javascript
'key-map-\\': 'value'
```

`ci'` will change inside `'value'` not in `'key-map-\\'` as expected

I filed to fix it, but wrote a test to prove it :) 