### PR TITLE
adds support for ex-mode

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -342,3 +342,9 @@ class VimState
     marker.destroy() for marker in @rangeMarkers
     @rangeMarkers = []
     @toggleClassList('with-range-marker', @hasRangeMarkers())
+
+  pushSearchHistory: (input) ->
+    @searchHistory.save(input)
+
+  getSearchHistoryItem: (prev) ->
+    @searchHistory.get(prev)


### PR DESCRIPTION
I Have added pushSearchHistory and getSearchHistoryItem definitions in vim-state.cofee so that i can easily modify ex-mode to support vim-mode-plus completely 