### PR TITLE
add preference for creating undo checkpoint on leaving insert mode

### DIFF
--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -1113,7 +1113,8 @@ class ActivateInsertMode extends Operator
           selection.insertText(text, autoIndent: true)
 
       # grouping changes for undo checkpoint need to come last
-      @editor.groupChangesSinceCheckpoint(@getCheckpoint('undo'))
+      if settings.get('createUndoCheckpointWhenLeavingInsert')
+        @editor.groupChangesSinceCheckpoint(@getCheckpoint('undo'))
 
   initialize: ->
     @checkpoint = {}

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -17,10 +17,6 @@ class Settings
     atom.config.observe "#{@scope}.#{param}", fn
 
 module.exports = new Settings 'vim-mode-plus',
-  setCursorToStartOfChangeOnUndoRedo:
-    order: 1
-    type: 'boolean'
-    default: true
   useClipboardAsDefaultRegister:
     order: 2
     type: 'boolean'
@@ -166,6 +162,10 @@ module.exports = new Settings 'vim-mode-plus',
     description: "Duration(msec) for hover search counter"
   hideTabBarOnMaximizePane:
     order: 32
+    type: 'boolean'
+    default: true
+  createUndoCheckpointWhenLeavingInsert:
+    order: 33
     type: 'boolean'
     default: true
   throwErrorOnNonEmptySelectionInNormalMode:


### PR DESCRIPTION
I tend to spend most of my time in insert mode, only switching to normal mode for a quick motion or command. When I do something like that and hit Undo, huge amounts of changes are undone with no way to get back to an intermediate state other than manually editing.

This is probably the cause of issues like #307.