### PR TITLE
Implement change surround with space

### DIFF
--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -551,6 +551,7 @@ class Surround extends TransformString
     ['{', '}']
     ['<', '>']
   ]
+  spaceSurroundedRegExp: /^\s([\s|\S]+)\s$/
   input: null
   charsMax: 1
   hover: icon: ':surround:', emoji: ':two_women_holding_hands:'
@@ -582,17 +583,16 @@ class Surround extends TransformString
       open += "\n"
       close += "\n"
 
-    SpaceSurroundedRegExp = /^\s([\s|\S]+)\s$/
-    isSurroundedBySpace = (text) ->
-      SpaceSurroundedRegExp.test(text)
-
-    if @input in settings.get('charactersToAddSpaceOnSurround') and not isSurroundedBySpace(text)
+    if @input in settings.get('charactersToAddSpaceOnSurround') and not @isSurroundedBySpace(text)
       open + ' ' + text + ' ' + close
     else
       open + text + close
 
   getNewText: (text) ->
     @surround text, @getPair(@input)
+
+  isSurroundedBySpace: (text) ->
+    @spaceSurroundedRegExp.test(text)
 
 class SurroundWord extends Surround
   @extend()
@@ -662,7 +662,13 @@ class ChangeSurround extends DeleteSurround
 
   getNewText: (text) ->
     [open, close] = @getPair(@char)
-    open + text[1...-1] + close
+    bodyText = text[1...-1]
+    bodyText = bodyText.trim() if @input in settings.get('charactersToAddSpaceOnSurround')
+    if @char in settings.get('charactersToAddSpaceOnSurround') and not @isSurroundedBySpace(bodyText)
+      open + ' ' + bodyText + ' ' + close
+    else
+      open + bodyText + close
+
 
 class ChangeSurroundAnyPair extends ChangeSurround
   @extend()

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -494,7 +494,7 @@ describe "Operator TransformString", ->
               ""
             ].join("\n")
 
-    describe 'change srurround', ->
+    describe 'change surround', ->
       beforeEach ->
         atom.keymaps.add "surround-test",
           'atom-text-editor.vim-mode-plus.normal-mode':
@@ -555,6 +555,21 @@ describe "Operator TransformString", ->
               hello: world
             )
             """
+
+      describe 'charactersToAddSpaceOnSurround setting', ->
+        beforeEach ->
+          set
+            text: "(  apple  )"
+            cursorBuffer: [0, 0]
+
+        it "add or remove additional space inside pair char when change surround", ->
+          settings.set('charactersToAddSpaceOnSurround', ['(', '{', '['])
+          ensure ['c s', input: '({'], text: "{ apple }"
+          ensure ['c s', input: '}{'], text: "{ apple }"
+          ensure ['c s', input: '{}'], text: "{apple}"
+          ensure ['c s', input: '{{'], text: "{ apple }"
+          ensure ['c s', input: '{{'], text: "{ apple }"
+          ensure ['c s', input: '})'], text: "( apple )"
 
     describe 'surround-word', ->
       beforeEach ->


### PR DESCRIPTION
#171 does not include feature to "change" space of surround.
With this PR `cs{)` changes `html{ lang: 'en' }` to `html(lang: 'en')`, and `cs){` does reverse operation.
(I want this to migrate my haml file into jade syntax :)