### PR TITLE
Refactoring Operator.coffee

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -278,7 +278,7 @@
 
 'atom-text-editor.vim-mode-plus.with-range-marker:not(.insert-mode)':
   'cmd-d': 'vim-mode-plus:select-occurrence-in-a-range-marker'
-  'ctrl-cmd-g': 'vim-mode-plus:convert-range-marker-to-selection'
+  'ctrl-cmd-g': 'vim-mode-plus:select-range-marker'
 
 'atom-text-editor.vim-mode-plus.visual-mode.is-narrowed':
   'ctrl-cmd-c': 'vim-mode-plus:change-occurrence'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -138,6 +138,10 @@ class Base
     @onDidFinishOperation =>
       @vimState.activate(mode, submode)
 
+  activateModeIfNecessary: (mode, submode) ->
+    unless @vimState.isMode(mode, submode)
+      @activateMode(mode, submode)
+
   addHover: (text, {replace}={}) ->
     if replace ? false
       @vimState.hover.replaceLastSection(text)

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -98,6 +98,12 @@ class BlockwiseSelection
   getTailBufferPosition: ->
     @getTailSelection().getTailBufferPosition()
 
+  getStartBufferPosition: ->
+    @getStartSelection().getBufferRange().start
+
+  getEndBufferPosition: ->
+    @getStartSelection().getBufferRange().end
+
   getBufferRowRange: ->
     startRow = @getStartSelection().getBufferRowRange()[0]
     endRow = @getEndSelection().getBufferRowRange()[0]

--- a/lib/global-state.coffee
+++ b/lib/global-state.coffee
@@ -3,4 +3,7 @@ module.exports =
   currentSearch: null
   lastSearchPattern: null
   currentFind: null
+  previousSelection:
+    properties: null
+    submode: null
   register: {}

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -6,7 +6,6 @@ _ = require 'underscore-plus'
 {moveCursorRight} = require './utils'
 
 {
-  isLinewiseRange
   pointIsAtEndOfLine
   mergeIntersectingRanges
   highlightRanges

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -177,7 +177,7 @@ class ModeManager
       @vimState.mark.setRange('<', '>', range)
     @selectCharacterwise()
 
-    swrap.resetProperties(@editor)
+    swrap.clearProperties(@editor)
 
     if preservePreviousSelection and not @editor.getLastSelection().isEmpty()
       @preservePreviousSelection(@editor.getLastSelection())

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -30,6 +30,8 @@ class ModeManager
     else
       @mode is mode
 
+  # Event
+  # -------------------------
   onWillActivateMode: (fn) -> @emitter.on('will-activate-mode', fn)
   onDidActivateMode: (fn) -> @emitter.on('did-activate-mode', fn)
   onWillDeactivateMode: (fn) -> @emitter.on('will-deactivate-mode', fn)
@@ -52,6 +54,7 @@ class ModeManager
 
     @deactivator = switch mode
       when 'normal' then @activateNormalMode()
+      when 'operator-pending' then @activateOperatorPendingMode()
       when 'insert' then @activateInsertMode(submode)
       when 'visual' then @activateVisualMode(submode)
 
@@ -81,7 +84,12 @@ class ModeManager
     @editorElement.component?.setInputEnabled(false)
     new Disposable
 
-  # ActivateInsertMode
+  # Operator Pending
+  # -------------------------
+  activateOperatorPendingMode: ->
+    new Disposable
+
+  # Insert
   # -------------------------
   activateInsertMode: (submode=null) ->
     @editorElement.component.setInputEnabled(true)

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -61,6 +61,9 @@ class OperationStack
     try
       @reduce()
       if @peekTop().isComplete()
+        if settings.get('debug')
+          top = @peekTop()
+          console.log  [top.getName(), top.target?.getName()]
         @execute(@stack.pop())
       else
         if @vimState.isMode('normal') and @peekTop().isOperator()
@@ -112,7 +115,7 @@ class OperationStack
   finish: (operation=null) ->
     @record(operation) if operation?.isRecordable()
     @vimState.emitter.emit('did-finish-operation')
-    
+
     if @vimState.isMode('normal')
       @ensureAllSelectionsAreEmpty(operation)
       @ensureAllCursorsAreNotAtEndOfLine()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -60,19 +60,19 @@ class OperationStack
 
     try
       @reduce()
-      topOperation = @peekTop()
+      top = @peekTop()
 
-      if topOperation.isComplete()
+      if top.isComplete()
         if settings.get('debug')
-          console.log  [topOperation.getName(), topOperation.target?.getName()]
+          console.log  [top.getName(), top.target?.getName()]
         @execute(@stack.pop())
       else
-        if @vimState.isMode('normal') and topOperation.isOperator()
+        if @vimState.isMode('normal') and top.isOperator()
           @vimState.activate('operator-pending')
-          @addToClassList('with-occurrence') if topOperation.isWithOccurrence()
+          @addToClassList('with-occurrence') if top.isWithOccurrence()
 
         # Temporary set while command is running
-        if commandName = topOperation.constructor.getCommandNameWithoutPrefix?()
+        if commandName = top.constructor.getCommandNameWithoutPrefix?()
           @addToClassList(commandName + "-pending")
     catch error
       switch

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -314,7 +314,7 @@ class SelectOccurrence extends Select
   initialize: ->
     # FIXME don't trying to do everytin in event
     @onDidSelectTarget =>
-      swrap.resetProperties(@editor)
+      swrap.clearProperties(@editor)
 
 class SelectOccurrenceInARangeMarker extends SelectOccurrence
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -533,6 +533,7 @@ class TransformStringByExternalCommand extends TransformString
       # Suppress command not found error intentionally.
       if error.code is 'ENOENT' and error.syscall.indexOf('spawn') is 0
         commandName = @constructor.getCommandName()
+        console.log "#{commandName}: Failed to spawn command #{error.path}."
       @cancelOperation()
       handle()
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -13,6 +13,7 @@ _ = require 'underscore-plus'
   getCurrentWordBufferRange
   getBufferRangeForPatternFromPoint
   cursorIsOnWhiteSpace
+  cursorIsAtEmptyRow
   scanInRanges
   getCharacterAtCursor
 } = require './utils'
@@ -1087,7 +1088,7 @@ class PutBefore extends Operator
       selection.insertText(text)
 
   pasteCharacterwise: (selection, text) ->
-    if @location is 'after' and selection.isEmpty() and not selection.cursor.isAtEndOfLine()
+    if @location is 'after' and selection.isEmpty() and not cursorIsAtEmptyRow(selection.cursor)
       selection.cursor.moveRight()
     selection.insertText(text)
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -250,11 +250,16 @@ class Select extends Operator
   recordable: false
   execute: ->
     @selectTarget()
-    if @isMode('visual') and (not @target.isAllowSubmodeChange?())
-      return
-    else
+    if @isWithOccurrence()
+      @updateSelectionProperties()
       submode = swrap.detectVisualModeSubmode(@editor)
       @activateModeIfNecessary('visual', submode)
+    else
+      if @isMode('visual') and (not @target.isAllowSubmodeChange?())
+        return
+      else
+        submode = swrap.detectVisualModeSubmode(@editor)
+        @activateModeIfNecessary('visual', submode)
 
 class SelectLatestChange extends Select
   @extend()
@@ -1150,26 +1155,18 @@ class Replace extends Operator
 
     @activateMode('normal')
 
-class SelectOccurrence extends Operator
+class SelectOccurrence extends Select
   @extend()
   @description: "Add selection onto each matching word within target range"
   withOccurrence: true
 
-  execute: ->
-    if @selectTarget()
-      unless @isMode('visual', 'characterwise')
-        swrap.resetProperties(@editor)
-        @activateMode('visual', 'characterwise')
-
 class SelectOccurrenceInARangeMarker extends SelectOccurrence
   @extend()
   target: "ARangeMarker"
-  flashTarget: false
 
 class SelectOccurrenceInAll extends SelectOccurrence
   @extend()
   target: "All"
-  flashTarget: false
 
 class SetCursorsToStartOfTarget extends Operator
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -301,9 +301,10 @@ class SelectOccurrence extends Select
   @extend()
   @description: "Add selection onto each matching word within target range"
   withOccurrence: true
-  esecute: ->
+  initialize: ->
+    # FIXME don't trying to do everytin in event
     @onDidSelectTarget =>
-      @updateSelectionProperties()
+      swrap.resetProperties(@editor)
 
 class SelectOccurrenceInARangeMarker extends SelectOccurrence
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -313,14 +313,12 @@ class SelectOccurrenceInAll extends SelectOccurrence
   @extend()
   target: "All"
 
-class ConvertRangeMarkerToSelection extends Select
+class SelectRangeMarker extends Select
   @extend()
-  flashTarget: false
   target: "ARangeMarker"
   execute: ->
     super
     @vimState.clearRangeMarkers()
-
 
 # Range Marker
 # =========================

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -394,23 +394,22 @@ class DeleteToLastCharacterOfLine extends Delete
   @extend()
   target: 'MoveToLastCharacterOfLine'
   initialize: ->
-    super
-    if @isVisualBlockwise = @isMode('visual', 'blockwise')
+    @isVisualBlockwise = @isMode('visual', 'blockwise')
+    if @isVisualBlockwise
       @requireTarget = false
+    super
 
   execute: ->
     if @isVisualBlockwise
-      pointByBlockwiseSelection = new Map
-      @getBlockwiseSelections().forEach (bs) ->
-        bs.removeEmptySelections()
-        bs.setPositionForSelections('start')
-        pointByBlockwiseSelection.set(bs, bs.getStartSelection().getHeadBufferPosition())
+      # Ensure all selections is un-reversed to start deletion from start of selection.
+      swrap.setReversedState(@editor, false)
 
     super
 
     if @isVisualBlockwise
-      pointByBlockwiseSelection.forEach (point, bs) ->
-        bs.setHeadBufferPosition(point)
+      @getBlockwiseSelections().forEach (blockwiseSelection) ->
+        startPosition = blockwiseSelection.getStartBufferPosition()
+        blockwiseSelection.setHeadBufferPosition(startPosition)
 
 class DeleteLine extends Delete
   @extend()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -9,7 +9,7 @@ class SelectionWrapper
   hasProperties: -> propertyStore.has(@selection)
   getProperties: -> propertyStore.get(@selection) ? {}
   setProperties: (prop) -> propertyStore.set(@selection, prop)
-  resetProperties: -> propertyStore.delete(@selection)
+  clearProperties: -> propertyStore.delete(@selection)
 
   setBufferRangeSafely: (range) ->
     if range
@@ -185,7 +185,7 @@ class SelectionWrapper
     end = editor.bufferPositionForScreenPosition(screenPoint, clipDirection: 'forward')
 
     @setBufferRange([start, end], {preserveFolds: true})
-    @resetProperties()
+    @clearProperties()
     @selection.cursor.goalColumn = goalColumn if goalColumn
 
   # Only for setting autoscroll option to false by default
@@ -239,9 +239,9 @@ swrap.reverse = (editor) ->
   editor.getSelections().forEach (selection) ->
     swrap(selection).reverse()
 
-swrap.resetProperties = (editor) ->
+swrap.clearProperties = (editor) ->
   editor.getSelections().forEach (selection) ->
-    swrap(selection).resetProperties()
+    swrap(selection).clearProperties()
 
 swrap.detectVisualModeSubmode = (editor) ->
   selections = editor.getSelections()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -1,6 +1,5 @@
 _ = require 'underscore-plus'
 {Range, Disposable} = require 'atom'
-{isLinewiseRange} = require './utils'
 
 propertyStore = new Map
 
@@ -214,13 +213,16 @@ class SelectionWrapper
     startRow is endRow
 
   isLinewise: ->
-    isLinewiseRange(@getBufferRange())
+    {start, end} = @getBufferRange()
+    (start.row isnt end.row) and (start.column is end.column is 0)
 
   detectVisualModeSubmode: ->
-    switch
-      when @isLinewise() then 'linewise'
-      when not @selection.isEmpty() then 'characterwise'
-      else null
+    if @selection.isEmpty()
+      null
+    else if @isLinewise()
+      'linewise'
+    else
+      'characterwise'
 
 swrap = (selection) ->
   new SelectionWrapper(selection)

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -100,6 +100,10 @@ module.exports = new Settings 'vim-mode-plus',
     type: 'boolean'
     default: false
     description: "Don't move cursor after Yank"
+  stayOnDelete:
+    type: 'boolean'
+    default: false
+    description: "Don't move cursor after Delete"
   flashOnUndoRedo:
     type: 'boolean'
     default: true

--- a/lib/status-bar-manager.coffee
+++ b/lib/status-bar-manager.coffee
@@ -1,6 +1,6 @@
 {ElementBuilder} = require './utils'
 
-modeToContent =
+modeStringToContent =
   "normal": "Normal"
   'insert': "Insert"
   'insert.replace': "Replace"
@@ -8,6 +8,7 @@ modeToContent =
   "visual.characterwise": "Visual Char"
   "visual.linewise": "Visual Line"
   "visual.blockwise": "Visual Block"
+  "operator-pending": "Operator Pending"
 
 module.exports =
 class StatusBarManager
@@ -24,7 +25,7 @@ class StatusBarManager
     modeString = mode
     modeString += "." + submode if submode?
     @element.className = "#{@prefix}-#{mode}"
-    @element.textContent = modeToContent[modeString]
+    @element.textContent = modeStringToContent[modeString]
 
   attach: ->
     @tile = @statusBar.addRightTile(item: @container, priority: 20)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -787,13 +787,16 @@ class SearchMatchBackward extends SearchMatchForward
         stop()
     found
 
-# [FIXME] Currently vB range is treated as vC range, how I should do?
+# [Limitation: won't fix]: Selected range is not submode aware. always characterwise.
+# So even if original selection was vL or vB, selected range by this text-object
+# is always vC range.
 class PreviousSelection extends TextObject
   @extend()
-
   select: ->
-    return unless range = @vimState.mark.getRange('<', '>')
-    @editor.getLastSelection().setBufferRange(range)
+    {properties, @submode} = globalState.previousSelection
+    if properties? and @submode?
+      selection = @editor.getLastSelection()
+      swrap(selection).selectByProperties(properties)
 
 class RangeMarker extends TextObject
   @extend(false)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -790,7 +790,6 @@ class SearchMatchBackward extends SearchMatchForward
 # [FIXME] Currently vB range is treated as vC range, how I should do?
 class PreviousSelection extends TextObject
   @extend()
-  backward: true
 
   select: ->
     return unless range = @vimState.mark.getRange('<', '>')

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -247,10 +247,12 @@ pointIsAtVimEndOfFile = (editor, point) ->
 cursorIsAtVimEndOfFile = (cursor) ->
   pointIsAtVimEndOfFile(cursor.editor, cursor.getBufferPosition())
 
+isEmptyRow = (editor, row) ->
+  {start, end} = editor.bufferRangeForBufferRow(row)
+  start.column is 0 and end.column is 0
+
 cursorIsAtEmptyRow = (cursor) ->
-  row = cursor.getBufferRow()
-  {start, end} = cursor.editor.bufferRangeForBufferRow(row)
-  (start.column is 0) and (end.column is 0)
+  isEmptyRow(cursor.editor, cursor.getBufferRow())
 
 getVimLastBufferRow = (editor) ->
   getVimEofBufferPosition(editor).row
@@ -704,6 +706,7 @@ module.exports = {
   pointIsBetweenWordAndNonWord
   pointIsSurroundedByWhitespace
   moveCursorToNextNonWhitespace
+  isEmptyRow
   cursorIsAtEmptyRow
   getCodeFoldRowRanges
   getCodeFoldRowRangesContainesForRow

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -21,7 +21,7 @@ ModeManager = require './mode-manager'
 RegisterManager = require './register-manager'
 SearchHistoryManager = require './search-history-manager'
 CursorStyleManager = require './cursor-style-manager'
-BlockwiseSelection = null # delay
+BlockwiseSelection = require './blockwise-selection'
 
 packageScope = 'vim-mode-plus'
 
@@ -81,13 +81,9 @@ class VimState
   clearBlockwiseSelections: ->
     @blockwiseSelections = []
 
-  addBlockwiseSelectionFromSelection: (selection) ->
-    BlockwiseSelection ?= require './blockwise-selection'
-    @blockwiseSelections.push(new BlockwiseSelection(selection))
-
   selectBlockwise: ->
     for selection in @editor.getSelections()
-      @addBlockwiseSelectionFromSelection(selection)
+      @blockwiseSelections.push(new BlockwiseSelection(selection))
     @updateSelectionProperties()
 
   # Other

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -115,26 +115,31 @@ describe "Operator general", ->
         ensure 'X', text: "012345\nabcdef", cursor: [0, 5]
 
   describe "the d keybinding", ->
+    beforeEach ->
+      set
+        text: """
+          12345
+          abcde
+
+          ABCDE\n
+          """
+        cursor: [1, 1]
+
     it "enters operator-pending mode", ->
       ensure 'd', mode: 'operator-pending'
 
     describe "when followed by a d", ->
       it "deletes the current line and exits operator-pending mode", ->
-        set text: "12345\nabcde\n\nABCDE", cursor: [1, 1]
+        set cursor: [1, 1]
         ensure 'd d',
-          text: '12345\n\nABCDE'
+          text: "12345\n\nABCDE\n"
           cursor: [1, 0]
           register: '"': text: 'abcde\n'
           mode: 'normal'
 
       it "deletes the last line and always make non-blank-line last line", ->
-        set text: """
-          12345
-          abcde
-          ABCDE\n
-          """
-          , cursor: [2, 1]
-        ensure 'd d', text: "12345\nabcde\n", cursor: [1, 0]
+        set cursor: [2, 0]
+        ensure '2 d d', text: "12345\nabcde\n", cursor: [1, 0]
 
       it "leaves the cursor on the first nonblank character", ->
         set text: '12345\n  abcde\n', cursor: [0, 4]
@@ -143,7 +148,6 @@ describe "Operator general", ->
     describe "undo behavior", ->
       originalText = "12345\nabcde\nABCDE\nQWERT"
       beforeEach ->
-
         set text: originalText, cursor: [1, 1]
 
       it "undoes both lines", ->
@@ -342,6 +346,32 @@ describe "Operator general", ->
         ensure ['d t', input: 'd'],
           text: "d\nabc\nd"
           cursorBuffer: [[0, 0], [1, 0], [2, 0]]
+
+    describe "stayOnDelete setting", ->
+      beforeEach ->
+        settings.set('stayOnDelete', true)
+        set
+          text: """
+              0000
+            1111
+          2222
+            3333
+              4444\n
+          """
+          cursor: [0, 5]
+
+      describe "target range is linewise range", ->
+        it "keep original column after delete and keep goalColumn", ->
+          ensure "d d", cursor: [0, 5], text: "  1111\n2222\n  3333\n    4444\n"
+          ensure "d d", cursor: [0, 3], text: "2222\n  3333\n    4444\n"
+          ensure "j", cursor: [1, 5], text: "2222\n  3333\n    4444\n"
+          ensure ".", cursor: [1, 5], text: "2222\n    4444\n"
+
+        it "v_D also keep original column after delete and keep goalColumn", ->
+          ensure "v D", cursor: [0, 5], text: "  1111\n2222\n  3333\n    4444\n"
+          ensure "v D", cursor: [0, 3], text: "2222\n  3333\n    4444\n"
+          ensure "j", cursor: [1, 5], text: "2222\n  3333\n    4444\n"
+          ensure "v D", cursor: [1, 5], text: "2222\n    4444\n"
 
   describe "the D keybinding", ->
     beforeEach ->

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -473,7 +473,7 @@ describe "Operator modifier", ->
           keystroke "m" # clear rangeMarker at cursor which is = sign part of fat arrow.
           expect(vimState.getRangeMarkers()).toHaveLength(10)
           keystroke [
-            'ctrl-cmd-g' # convert-range-marker-to-selection
+            'ctrl-cmd-g' # select-range-marker
             'I'          # Insert at start of selection
           ]
           editor.insertText('?')

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -178,25 +178,16 @@ describe "Operator modifier", ->
         set
           text: """
           ooo: xxx: ooo:
-
-          |||: ooo: xxx: ooo: ooo: oooo:
-
-          xxx: |||: ooo:
-
           """
       describe "what the cursor-word", ->
         describe "cursor is at normal word [by select-occurrence]", ->
           it "pick word but not pick partially matched one and re-use cached cursor-word on repeat", ->
             set cursor: [0, 0]
-            ensure "g cmd-d o i p", selectedText: ['ooo', 'ooo']
-            ensure "escape escape 2 j .", selectedText: ['ooo', 'ooo', 'ooo']
-            ensure "escape escape 2 j .", selectedText: 'ooo'
+            ensure "g cmd-d i p", selectedText: ['ooo', 'ooo']
         describe "cursor is at nonWordCharacters [by select-occurrence]", ->
           it "select that char only", ->
             set cursor: [0, 3]
-            ensure "g cmd-d o i p", selectedText: [':', ':', ':']
-            ensure "escape escape 2 j .", -> selectedText: [':', ':', ':', ':', ':']
-            ensure "escape escape 2 j .", -> selectedText: [':', ':', ':']
+            ensure "g cmd-d i p", selectedText: [':', ':', ':']
         describe "cursor is at single white space [by delete]", ->
           it "pick single white space only", ->
             set


### PR DESCRIPTION
🚧 WIP 🚧 

Purpose is

- Bring consistency of all operator. Eliminate unimportant/unnecessary inconsistency.
- Remove execute() function scattered in several operator. Instead only Operator class have execute
- Don't depends hook like `onWIllSelectTarget`, `onDidSelectTargt`, it's order matter, increase complexity I use it too much internally.
- Properly clear/restore selection properties, especially ensure to clearout property on each operation.
- By consolidating execute
  - Saving original cursor position, restore original cursor position if `stayOnOperate`
  - Save `start` of selection just after `selectTarget()` then set cursor position to saved `start` of selection, when not `stayOnOperate`
  - If there is some selection when operation start, save visually selected range as `<` and `>`  mark before mutating selection state.
  - If operator mutate buffer text, save change as mark `[` and `]`.
- Some logic is better to move `operationStack` not sure, so will experiment/evaluate it.
