### PR TITLE
Refactoring Operator.coffee phase2

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -86,21 +86,6 @@
   'ctrl-e': 'vim-mode-plus:scroll-down'
   'ctrl-y': 'vim-mode-plus:scroll-up'
 
-  'z enter': 'vim-mode-plus:scroll-cursor-to-top'
-  'z t': 'vim-mode-plus:scroll-cursor-to-top-leave'
-  'z .': 'vim-mode-plus:scroll-cursor-to-middle'
-  'z z': 'vim-mode-plus:scroll-cursor-to-middle-leave'
-  'z -': 'vim-mode-plus:scroll-cursor-to-bottom'
-  'z b': 'vim-mode-plus:scroll-cursor-to-bottom-leave'
-  'z s': 'vim-mode-plus:scroll-cursor-to-left'
-  'z e': 'vim-mode-plus:scroll-cursor-to-right'
-
-  'z M': 'editor:fold-all'
-  'z R': 'editor:unfold-all'
-  'z c': 'editor:fold-current-row'
-  'z o': 'editor:unfold-current-row'
-  'z a': 'vim-mode-plus:toggle-fold'
-
   'G': 'vim-mode-plus:move-to-last-line'
   'g g': 'vim-mode-plus:move-to-first-line'
   'H': 'vim-mode-plus:move-to-top-of-screen'
@@ -231,6 +216,22 @@
 
   # 'g n': 'vim-mode-plus:move-to-next-number'
   # 'g N': 'vim-mode-plus:move-to-previous-number'
+
+'atom-text-editor.vim-mode-plus:not(.insert-mode):not(.operator-pending-mode)':
+  'z enter': 'vim-mode-plus:scroll-cursor-to-top'
+  'z t': 'vim-mode-plus:scroll-cursor-to-top-leave'
+  'z .': 'vim-mode-plus:scroll-cursor-to-middle'
+  'z z': 'vim-mode-plus:scroll-cursor-to-middle-leave'
+  'z -': 'vim-mode-plus:scroll-cursor-to-bottom'
+  'z b': 'vim-mode-plus:scroll-cursor-to-bottom-leave'
+  'z s': 'vim-mode-plus:scroll-cursor-to-left'
+  'z e': 'vim-mode-plus:scroll-cursor-to-right'
+
+  'z M': 'editor:fold-all'
+  'z R': 'editor:unfold-all'
+  'z c': 'editor:fold-current-row'
+  'z o': 'editor:unfold-current-row'
+  'z a': 'vim-mode-plus:toggle-fold'
 
 'atom-text-editor.vim-mode-plus-input-char-waiting':
   'a': 'vim-mode-plus:set-input-char-a'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -34,7 +34,6 @@ vimStateMethods = [
   "onDidCancelSelectList"
   "subscribe"
   "isMode"
-  "hasCount"
   "getBlockwiseSelections"
   "updateSelectionProperties"
 ]

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -23,10 +23,14 @@ vimStateMethods = [
   "onDidCancelSearch"
   "onDidUnfocusSearch"
   "onDidCommandSearch"
+
+  "onDidSetTarget"
   "onWillSelectTarget"
   "onDidSelectTarget"
-  "onDidSetTarget"
+  "onDidRestoreCursorPositions"
+
   "onDidFinishOperation"
+
   "onDidCancelSelectList"
   "subscribe"
   "isMode"
@@ -222,6 +226,9 @@ class Base
 
   emitDidSetTarget: (operator) ->
     @vimState.emitter.emit('did-set-target', operator)
+
+  emitDidRestoreCursorPositions: ->
+    @vimState.emitter.emit('did-restore-cursor-positions')
 
   # Class methods
   # -------------------------

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -27,6 +27,7 @@ vimStateMethods = [
   "onDidSetTarget"
   "onWillSelectTarget"
   "onDidSelectTarget"
+  "preemptDidSelectTarget"
   "onDidRestoreCursorPositions"
 
   "onDidFinishOperation"

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -37,7 +37,6 @@ vimStateMethods = [
   "hasCount"
   "getBlockwiseSelections"
   "updateSelectionProperties"
-  "preserveCount"
 ]
 
 class Base

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -27,6 +27,7 @@ vimStateMethods = [
   "onDidSetTarget"
   "onWillSelectTarget"
   "onDidSelectTarget"
+  "preemptWillSelectTarget"
   "preemptDidSelectTarget"
   "onDidRestoreCursorPositions"
 

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -46,7 +46,6 @@ class Base
 
   constructor: (@vimState, properties) ->
     {@editor, @editorElement} = @vimState
-    @preserveCount()
     _.extend(this, properties)
     if settings.get('showHoverOnOperate')
       hover = @hover?[settings.get('showHoverOnOperateIcon')]

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -145,11 +145,11 @@ class Base
     unless @vimState.isMode(mode, submode)
       @activateMode(mode, submode)
 
-  addHover: (text, {replace}={}) ->
+  addHover: (text, {replace}={}, point=null) ->
     if replace ? false
-      @vimState.hover.replaceLastSection(text)
+      @vimState.hover.replaceLastSection(text, point)
     else
-      @vimState.hover.add(text)
+      @vimState.hover.add(text, point)
 
   new: (name, properties={}) ->
     klass = Base.getClass(name)

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -26,6 +26,7 @@ vimStateMethods = [
   "onWillSelectTarget"
   "onDidSelectTarget"
   "onDidSetTarget"
+  "onDidRestoreStartOfSelections"
   "onDidFinishOperation"
   "onDidCancelSelectList"
   "subscribe"
@@ -222,6 +223,9 @@ class Base
 
   emitDidSetTarget: (operator) ->
     @vimState.emitter.emit('did-set-target', operator)
+
+  emitDidRestoreStartOfSelections: ->
+    @vimState.emitter.emit('did-restore-start-of-selections')
 
   # Class methods
   # -------------------------

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -26,7 +26,6 @@ vimStateMethods = [
   "onWillSelectTarget"
   "onDidSelectTarget"
   "onDidSetTarget"
-  "onDidRestoreStartOfSelections"
   "onDidFinishOperation"
   "onDidCancelSelectList"
   "subscribe"
@@ -223,9 +222,6 @@ class Base
 
   emitDidSetTarget: (operator) ->
     @vimState.emitter.emit('did-set-target', operator)
-
-  emitDidRestoreStartOfSelections: ->
-    @vimState.emitter.emit('did-restore-start-of-selections')
 
   # Class methods
   # -------------------------

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -228,6 +228,9 @@ class Base
   emitDidRestoreCursorPositions: ->
     @vimState.emitter.emit('did-restore-cursor-positions')
 
+  emitDidFailToSetTarget: ->
+    @vimState.emitter.emit('did-fail-to-set-target')
+
   # Class methods
   # -------------------------
   @init: (service) ->

--- a/lib/cursor-position-manager.coffee
+++ b/lib/cursor-position-manager.coffee
@@ -1,0 +1,39 @@
+swrap = require './selection-wrapper'
+
+module.exports =
+class CursorPositionManager
+  editor: null
+  pointsBySelection: null
+  constructor: (@editor) ->
+    @pointsBySelection = new Map
+
+  save: (which, options={}) ->
+    for selection in @editor.getSelections()
+      point = swrap(selection).getBufferPositionFor(which, options)
+      @pointsBySelection.set(selection, point)
+
+  updateBy: (fn) ->
+    @pointsBySelection.forEach (point, selection) =>
+      @pointsBySelection.set(selection, fn(selection, point))
+
+  restore: ({strict}={}) ->
+    selections = @editor.getSelections()
+
+    # unless occurence-mode we go strict mode.
+    # in vB mode, vB range is reselected on @target.selection
+    # so selection.id is change in that case we won't restore.
+    selectionNotFound = (selection) => not @pointsBySelection.has(selection)
+    return if strict and selections.some(selectionNotFound)
+
+    for selection in selections
+      if point = @pointsBySelection.get(selection)
+        selection.cursor.setBufferPosition(point)
+      else
+        # only when none-strict mode can reach here
+        selection.destroy()
+
+    @destroy()
+
+  destroy: ->
+    @pointsBySelection.clear()
+    [@pointsBySelection, @editor] = []

--- a/lib/cursor-position-manager.coffee
+++ b/lib/cursor-position-manager.coffee
@@ -17,6 +17,7 @@ class CursorPositionManager
       @pointsBySelection.set(selection, fn(selection, point))
 
   restore: ({strict}={}) ->
+    strict ?= true
     selections = @editor.getSelections()
 
     # unless occurence-mode we go strict mode.

--- a/lib/developer.coffee
+++ b/lib/developer.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 path = require 'path'
+fs = require 'fs-plus'
 {Emitter, Disposable, BufferedProcess, CompositeDisposable} = require 'atom'
 
 Base = require './base'
@@ -22,6 +23,7 @@ class Developer
       'generate-introspection-report': => @generateIntrospectionReport()
       'generate-command-summary-table': => @generateCommandSummaryTable()
       'toggle-dev-environment': => @toggleDevEnvironment()
+      'clear-debug-output': => @clearDebugOutput()
       'reload-packages': => @reloadPackages()
       'toggle-reload-packages-on-save': => @toggleReloadPackagesOnSave()
 
@@ -81,6 +83,13 @@ class Developer
 
   addCommand: (name, fn) ->
     atom.commands.add('atom-text-editor', "#{packageScope}:#{name}", fn)
+
+  clearDebugOutput: (name, fn) ->
+    filePath = fs.normalize(settings.get('debugOutputFilePath'))
+    options = {searchAllPanes: true, activatePane: false}
+    atom.workspace.open(filePath, options).then (editor) ->
+      editor.setText('')
+      editor.save()
 
   toggleDebug: ->
     settings.set('debug', not settings.get('debug'))

--- a/lib/hover.coffee
+++ b/lib/hover.coffee
@@ -26,7 +26,7 @@ class Hover extends HTMLElement
     @text.push(text)
     @show(point)
 
-  replaceLastSection: (text) ->
+  replaceLastSection: (text, point) ->
     @text.pop()
     @add(text)
 

--- a/lib/insert-mode.coffee
+++ b/lib/insert-mode.coffee
@@ -14,6 +14,7 @@ class InsertRegister extends InsertMode
   requireInput: true
 
   initialize: ->
+    super
     @focusInput()
 
   execute: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -151,6 +151,7 @@ module.exports =
       'operator-modifier-characterwise': -> @setOperatorModifier(wise: 'characterwise')
       'operator-modifier-linewise': -> @setOperatorModifier(wise: 'linewise')
       'operator-modifier-occurrence': -> @setOperatorModifier(occurence: true)
+      'repeat': -> @reapatRecordedOperation()
       'set-count-0': -> @setCount(0)
       'set-count-1': -> @setCount(1)
       'set-count-2': -> @setCount(2)

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -97,6 +97,10 @@ class ModeManager
     new Disposable =>
       replaceModeDeactivator?.dispose()
       replaceModeDeactivator = null
+
+      if settings.get('clearMultipleCursorsOnEscapeInsertMode')
+        @editor.clearSelections()
+
       # When escape from insert-mode, cursor move Left.
       needSpecialCareToPreventWrapLine = atom.config.get('editor.atomicSoftTabs') ? true
       for cursor in @editor.getCursors()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -654,26 +654,25 @@ class ScrollFullScreenDown extends Motion
   @extend()
   amountOfPage: +1
 
-  initialize: ->
-    super
+  calculateScrollRow: ->
     amountOfRows = Math.ceil(@amountOfPage * @editor.getRowsPerPage() * @getCount())
     @cursorRow = @editor.getCursorScreenPosition().row + amountOfRows
     @newTopRow = @editor.getFirstVisibleScreenRow() + amountOfRows
 
-  scroll: ->
-    @editor.setFirstVisibleScreenRow(@newTopRow)
-
   select: ->
+    @calculateScrollRow()
     super
-    @scroll()
 
   execute: ->
+    @calculateScrollRow()
     super
-    @scroll()
+    @editor.setFirstVisibleScreenRow(@newTopRow)
 
   moveCursor: (cursor) ->
     point = [getValidVimScreenRow(@editor, @cursorRow), 0]
     cursor.setScreenPosition(point, autoscroll: false)
+
+    @editor.setFirstVisibleScreenRow(@newTopRow)
 
 # keymap: ctrl-b
 class ScrollFullScreenUp extends ScrollFullScreenDown

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -123,7 +123,6 @@ class Motion extends Base
 class CurrentSelection extends Motion
   @extend(false)
   selectionExtent: null
-  pointBySelection: null
   inclusive: true
 
   initialize: ->

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {Point, Range} = require 'atom'
+Select = null
 
 globalState = require './global-state'
 {
@@ -69,7 +70,8 @@ class Motion extends Base
       @moveCursor(cursor)
 
   select: ->
-    @vimState.modeManager.normalizeSelections() if @isMode('visual')
+    if @isMode('visual')
+      @vimState.modeManager.normalizeSelections()
 
     for selection in @editor.getSelections()
       if @isInclusive() or @isLinewise()
@@ -82,7 +84,12 @@ class Motion extends Base
     @editor.mergeIntersectingSelections()
 
     # Update characterwise properties on each movement.
-    @updateSelectionProperties() if @isMode('visual')
+    if @isMode('visual')
+      Select ?= Base.getClass('Select')
+      unless @getOperator() instanceof Select
+        console.log "= updating: #{@getOperator()?.toString()}"
+      # console.log "= updating: #{@toString()}"
+      @updateSelectionProperties()
 
     switch
       when @isLinewise() then @vimState.selectLinewise()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -120,10 +120,6 @@ class OperationStack
     @record(operation) if operation?.isRecordable()
     @vimState.emitter.emit('did-finish-operation')
 
-    # FIXME
-    if operation?.isRecordable() and operation.isOperator()
-      operation._restoreStartOfSelections = null
-
     if @vimState.isMode('normal')
       @ensureAllSelectionsAreEmpty(operation)
       @ensureAllCursorsAreNotAtEndOfLine()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -42,8 +42,9 @@ class OperationStack
           #  e.g. `dd`, `cc`, `gUgU`
           klass = MoveToRelativeLine if (@peekTop()?.constructor is klass)
           operation = @composeOperation(new klass(@vimState, properties))
-        when 'object'
+        when 'object' # . repeat case
           operation = klass
+          console.log operation.getName()
         else
           throw new Error('Unsupported type of operation')
 
@@ -80,7 +81,7 @@ class OperationStack
       top = @peekTop()
 
       if top.isComplete()
-        # debug  [top.getName(), top.target?.getName()]
+        # console.log [top.getName(), top.target?.getName()]
         @execute(@stack.pop())
       else
         if @vimState.isMode('normal') and top.isOperator()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -59,7 +59,10 @@ class OperationStack
         count = @getCount()
         operation.count = count
         operation.target?.count = count # Some opeartor have no target like ctrl-a(increase).
-      @run(operation)
+
+      # [FIXME] Degradation, this `transact` should not be necessary
+      @editor.transact =>
+        @run(operation)
 
   handleError: (error) ->
     @vimState.reset()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -63,8 +63,7 @@ class OperationStack
       top = @peekTop()
 
       if top.isComplete()
-        if settings.get('debug')
-          console.log  [top.getName(), top.target?.getName()]
+        # debug  [top.getName(), top.target?.getName()]
         @execute(@stack.pop())
       else
         if @vimState.isMode('normal') and top.isOperator()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -188,10 +188,7 @@ class OperationStack
 
   getCount: ->
     if @hasCount()
-      console.log @count
-      v = (@count['normal'] ? 1) * (@count['operator-pending'] ? 1)
-      console.log 'getCount', v
-      v
+      (@count['normal'] ? 1) * (@count['operator-pending'] ? 1)
     else
       null
 

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -36,7 +36,6 @@ class OperationStack
     try
       switch type = typeof(klass)
         when 'string', 'function'
-          @vimState.preserveCount()
           klass = Base.getClass(klass) if type is 'string'
           # When identical operator repeated, it set target to MoveToRelativeLine.
           #  e.g. `dd`, `cc`, `gUgU`
@@ -44,7 +43,7 @@ class OperationStack
           operation = @composeOperation(new klass(@vimState, properties))
         when 'object' # . repeat case
           operation = klass
-          console.log operation.getName()
+          # console.log operation.getName()
         else
           throw new Error('Unsupported type of operation')
 
@@ -57,10 +56,9 @@ class OperationStack
     if operation = @getRecorded()
       operation.setRepeated()
       if @vimState.hasCount()
-        @vimState.preserveCount()
         count = @vimState.getCount()
         operation.count = count
-        operation.target.count = count
+        operation.target?.count = count # Some opeartor have no target like ctrl-a(increase).
       @run(operation)
 
   handleError: (error) ->

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -22,7 +22,7 @@ class OperationStack
     {mode} = @vimState
     switch
       when operation.isOperator()
-        if (mode is 'visual') and operation.isRequireTarget()
+        if (mode is 'visual') and not operation.hasTarget() # don't want to override target
           operation = operation.setTarget(new CurrentSelection(@vimState))
       when operation.isTextObject()
         unless mode is 'operator-pending'
@@ -119,6 +119,10 @@ class OperationStack
   finish: (operation=null) ->
     @record(operation) if operation?.isRecordable()
     @vimState.emitter.emit('did-finish-operation')
+
+    # FIXME
+    if operation?.isRecordable() and operation.isOperator()
+      operation._restoreStartOfSelections = null
 
     if @vimState.isMode('normal')
       @ensureAllSelectionsAreEmpty(operation)

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -40,7 +40,7 @@ class OperationStack
     console.log "= run start: #{hasProperty}"
 
   run: (klass, properties={}) ->
-    @reportSelectionProperties()
+    # @reportSelectionProperties()
     try
       switch type = typeof(klass)
         when 'string', 'function'

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -74,7 +74,6 @@ class ActivateInsertMode extends Operator
       return unless text = @getInsertedText()
       unless @instanceof('Change')
         @flashTarget = @trackChange = true
-        @observeSelectTarget()
         @emitDidSelectTarget()
       @editor.transact =>
         for selection in @editor.getSelections()
@@ -217,6 +216,7 @@ class Change extends ActivateInsertMode
   supportInsertionCount: false
 
   execute: ->
+    console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
     @selectTarget()
     text = ''
     if @target.isTextObject() or @target.isMotion()

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -79,6 +79,10 @@ class ActivateInsertMode extends Operator
         for selection in @editor.getSelections()
           @repeatInsert(selection, text)
           moveCursorLeft(selection.cursor)
+
+      if settings.get('clearMultipleCursorsOnEscapeInsertMode')
+        @editor.clearSelections()
+
     else
       if @getInsertionCount() > 0
         range = getNewTextRangeFromCheckpoint(@editor, @getCheckpoint('undo'))
@@ -224,11 +228,14 @@ class Change extends ActivateInsertMode
     else
       text = "\n" if @target.isLinewise?()
 
+
     @editor.transact =>
       for selection in @editor.getSelections()
         @setTextToRegisterForSelection(selection)
         range = selection.insertText(text, autoIndent: true)
         selection.cursor.moveLeft() unless range.isEmpty()
+    # FIXME calling super on OUTSIDE of editor.transact.
+    # That's why repeatRecorded() need transact.wrap
     super
 
 class ChangeOccurrence extends Change

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -220,7 +220,10 @@ class Change extends ActivateInsertMode
   supportInsertionCount: false
 
   execute: ->
-    # console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
+    console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
+    if @isRepeated()
+      @flashTarget = true
+
     selected = @selectTarget()
     if @isWithOccurrence() and not selected
       @vimState.activate('normal')
@@ -231,7 +234,6 @@ class Change extends ActivateInsertMode
       text = "\n" if (swrap.detectVisualModeSubmode(@editor) is 'linewise')
     else
       text = "\n" if @target.isLinewise?()
-
 
     @editor.transact =>
       for selection in @editor.getSelections()

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -216,7 +216,7 @@ class Change extends ActivateInsertMode
   supportInsertionCount: false
 
   execute: ->
-    console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
+    # console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
     @selectTarget()
     text = ''
     if @target.isTextObject() or @target.isMotion()

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -74,7 +74,7 @@ class ActivateInsertMode extends Operator
       return unless text = @getInsertedText()
       unless @instanceof('Change')
         @flashTarget = @trackChange = true
-        @observeSelectAction()
+        @observeSelectTarget()
         @emitDidSelectTarget()
       @editor.transact =>
         for selection in @editor.getSelections()
@@ -252,13 +252,8 @@ class ChangeToLastCharacterOfLine extends Change
   @extend()
   target: 'MoveToLastCharacterOfLine'
 
-  initialize: ->
-    if @isVisualBlockwise = @isMode('visual', 'blockwise')
-      @requireTarget = false
-    super
-
   execute: ->
     # Ensure all selections to un-reversed
-    if @isVisualBlockwise
+    if @isMode('visual', 'blockwise')
       swrap.setReversedState(@editor, false)
     super

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -220,7 +220,6 @@ class Change extends ActivateInsertMode
   supportInsertionCount: false
 
   execute: ->
-    console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
     if @isRepeated()
       @flashTarget = true
 

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -221,7 +221,11 @@ class Change extends ActivateInsertMode
 
   execute: ->
     # console.log "== Execution start #{@getName()}:#{@getTarget()?.getName()}"
-    @selectTarget()
+    selected = @selectTarget()
+    if @isWithOccurrence() and not selected
+      @vimState.activate('normal')
+      return
+
     text = ''
     if @target.isTextObject() or @target.isMotion()
       text = "\n" if (swrap.detectVisualModeSubmode(@editor) is 'linewise')

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -2,11 +2,7 @@ LineEndingRegExp = /(?:\n|\r\n)$/
 _ = require 'underscore-plus'
 {BufferedProcess} = require 'atom'
 
-{
-  haveSomeSelection
-  isSingleLine
-  saveCursorPositions
-} = require './utils'
+{haveSomeSelection, isSingleLine, saveCursorPositions} = require './utils'
 swrap = require './selection-wrapper'
 settings = require './settings'
 Base = require './base'

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -293,8 +293,8 @@ class Indent extends TransformString
   stayOnLinewise: false
   indentFunction: "indentSelectedRows"
 
-  initialize: ->
-    @onDidRestoreStartOfSelections =>
+  onDidRestoreCursorPosition: ->
+    unless @needStay()
       for cursor in @editor.getCursors()
         cursor.moveToFirstCharacterOfLine()
 

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -191,9 +191,7 @@ class TransformStringByExternalCommand extends TransformString
           @stdoutBySelection.set(selection, output)
         exit = (code) ->
           processFinished++
-          if (processRunning is processFinished)
-            console.log 'resolving'
-            resolve()
+          resolve() if (processRunning is processFinished)
         @runExternalCommand {command, args, stdout, exit, stdin}
 
   runExternalCommand: (options) ->

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -51,7 +51,7 @@ class ToggleCaseAndMoveRight extends ToggleCase
   hover: null
   stayAtSamePosition: false
   target: 'MoveRight'
-  restoreStartOfSelections: ->
+  restoreCursorPositions: ->
     # [FIXME] just for do nothing
 
 class UpperCase extends TransformString
@@ -181,7 +181,7 @@ class TransformStringByExternalCommand extends TransformString
   collect: (resolve) ->
     @stdoutBySelection = new Map
     unless @isMode('visual')
-      @updateSelectionProperties()
+      @updateSelectionProperties() # [FIXME]
       @target.select()
 
     running = finished = 0
@@ -293,7 +293,7 @@ class Indent extends TransformString
   stayOnLinewise: false
   indentFunction: "indentSelectedRows"
 
-  onDidRestoreCursorPosition: ->
+  onDidRestoreCursorPositions: ->
     unless @needStay()
       for cursor in @editor.getCursors()
         cursor.moveToFirstCharacterOfLine()
@@ -441,11 +441,11 @@ class ChangeSurroundAnyPair extends ChangeSurround
   charsMax: 1
   target: "AAnyPair"
   cursorPositions: null
-  restoreCursorPositions: null
+  _restoreCursorPositions: null
 
   initialize: ->
     @onDidSetTarget =>
-      @restoreCursorPositions = saveCursorPositions(@editor)
+      @_restoreCursorPositions = saveCursorPositions(@editor)
       @target.select()
       unless haveSomeSelection(@editor)
         @vimState.input.cancel()
@@ -455,8 +455,8 @@ class ChangeSurroundAnyPair extends ChangeSurround
 
   onConfirm: (@char) ->
     # Clear pre-selected selection to start mutation from non-selection.
-    @restoreCursorPositions()
-    @restoreCursorPositions = null
+    @_restoreCursorPositions()
+    @_restoreCursorPositions = null
     @input = @char
     @processOperation()
 

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -166,7 +166,7 @@ class TransformStringByExternalCommand extends TransformString
 
   execute: ->
     # We need to preserve selection before selection is cleared as a result of mutation.
-    @updatePreviousSelection() if @isMode('visual')
+    @updatePreviousSelectionIfVisualMode()
     # Mutation phase
     if @selectTarget()
       new Promise (resolve) =>

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -285,10 +285,12 @@ class Indent extends TransformString
   stayOnLinewise: false
   indentFunction: "indentSelectedRows"
 
-  onDidRestoreCursorPositions: ->
-    unless @needStay()
-      for cursor in @editor.getCursors()
-        cursor.moveToFirstCharacterOfLine()
+  execute: ->
+    @onDidRestoreCursorPositions =>
+      unless @needStay()
+        for cursor in @editor.getCursors()
+          cursor.moveToFirstCharacterOfLine()
+    super
 
   mutateSelection: (selection) ->
     selection[@indentFunction]()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -34,7 +34,6 @@ class ToggleCase extends TransformString
   @description: "`Hello World` -> `hELLO wORLD`"
   displayName: 'Toggle ~'
   hover: icon: ':toggle-case:', emoji: ':clap:'
-  stayAtSamePosition: true
 
   toggleCase: (char) ->
     charLower = char.toLowerCase()
@@ -49,10 +48,9 @@ class ToggleCase extends TransformString
 class ToggleCaseAndMoveRight extends ToggleCase
   @extend()
   hover: null
-  stayAtSamePosition: false
+  flashTarget: false
+  restorePositions: false
   target: 'MoveRight'
-  restoreCursorPositions: ->
-    # [FIXME] just for do nothing
 
 class UpperCase extends TransformString
   @extend()
@@ -60,7 +58,6 @@ class UpperCase extends TransformString
   @description: "`Hello World` -> `HELLO WORLD`"
   hover: icon: ':upper-case:', emoji: ':point_up:'
   displayName: 'Upper'
-  stayAtSamePosition: true
   getNewText: (text) ->
     text.toUpperCase()
 
@@ -70,7 +67,6 @@ class LowerCase extends TransformString
   @description: "`Hello World` -> `hello world`"
   hover: icon: ':lower-case:', emoji: ':point_down:'
   displayName: 'Lower'
-  stayAtSamePosition: true
   getNewText: (text) ->
     text.toLowerCase()
 
@@ -474,8 +470,7 @@ class Join extends TransformString
   @extend()
   target: "MoveToRelativeLine"
   flashTarget: false
-
-  needStay: -> false
+  restorePositions: false
 
   mutateSelection: (selection) ->
     if swrap(selection).isLinewise()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -402,16 +402,10 @@ class ToggleRangeMarker extends CreateRangeMarker
     for rangeMarker in @vimState.getRangeMarkers() when containsPoint(rangeMarker, point)
       return rangeMarker
 
-  initialize: ->
-    rangeMarker = @getRangeMarkerAtCursor()
-    if rangeMarker?
-      rangeMarker.destroy()
-      @vimState.removeRangeMarker(rangeMarker)
-      @abort()
-
   execute: ->
     if rangeMarker = @getRangeMarkerAtCursor()
       rangeMarker.destroy()
+      @vimState.removeRangeMarker(rangeMarker)
     else
       super
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -384,7 +384,12 @@ class Delete extends Operator
   wasLinewise: null
 
   initialize: ->
+    super
     @wasLinewise = null
+    if @instanceof('DeleteLine')
+      @wasLinewise = true
+    else if @isMode('visual') and not @isMode('visual', 'linewise')
+      @stayAtSamePosition = false
 
   mutateSelection: (selection) =>
     {cursor} = selection
@@ -401,12 +406,12 @@ class Delete extends Operator
         cursor.setBufferPosition([vimEof.row, 0])
 
       if @needStay()
-        headPosition = swrap(selection).getBufferPositionFor('head', fromProperty: true)
-        cursor.setBufferPosition([cursor.getBufferRow(), headPosition.column])
-        cursor.goalColumn = headPosition.column
+        head = swrap(selection).getBufferPositionFor('head', fromProperty: true)
+        start = swrap(selection).getBufferPositionFor('start', fromProperty: true)
+        cursor.setBufferPosition([start.row, head.column])
+        cursor.goalColumn = head.column
       else
         cursor.skipLeadingWhitespace()
-
 
 class DeleteRight extends Delete
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -151,8 +151,8 @@ class Operator extends Base
         if ranges.length
           @editor.setSelectedBufferRanges(ranges)
         else
-          # Resotoring cursor position also clear selection
-          # Clearing selection is important here to prevent unwanted mutation.
+          # Restoring cursor position also clear selection
+          # Unless clearing selection, we mutate original selection(e.g. paragraph) rather than occurrence.
           @restoreCursorPositions()
 
   setTextToRegisterForSelection: (selection) ->

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -82,6 +82,11 @@ class Operator extends Base
   constructor: ->
     super
     @initialize()
+
+    #[FIXME] ensure call @setTarget on NG case.
+    # OK: new Select(@vimState).setTarget(operation)
+    # NG: new Select(@vimState, target: operation}
+
     @setTarget(@new(@target)) if _.isString(@target)
 
   # target is TextObject or Motion to operate on.
@@ -176,6 +181,7 @@ class Operator extends Base
     @patternForOccurence ?= @getPatternForOccurrence()
 
   selectOccurrence: ->
+    console.log "CALLED!"
     @scanRangesForOccurrence ?= @editor.getSelectedBufferRanges()
     ranges = scanInRanges(@editor, @patternForOccurence, @scanRangesForOccurrence)
     if ranges.length
@@ -194,15 +200,15 @@ class Operator extends Base
     if @isWithOccurrence()
       @capturePatternForOccurrence()
       @target.select()
-      @selectOccurrence()
+      if haveSomeSelection(@editor)
+        @selectOccurrence()
     else
       @target.select()
 
-    @selectOccurrence() if @isWithOccurrence()
-    @emitDidSelectTarget()
-    @flashIfNecessary(@editor.getSelectedBufferRanges())
-    @trackChangeIfNecessary()
-
+    if haveSomeSelection(@editor)
+      @emitDidSelectTarget()
+      @flashIfNecessary(@editor.getSelectedBufferRanges())
+      @trackChangeIfNecessary()
     haveSomeSelection(@editor)
 
   updatePreviousSelectionIfVisualMode: ->
@@ -222,15 +228,15 @@ class Operator extends Base
     wasVisual = @isMode('visual')
 
     if @needStay() and wasVisual
-      # console.log 'case-1'
+      console.log 'case-1'
       @cursorPositionManager.save('head', fromProperty: true, allowFallback: true) # visual-stay
 
     else if @needStay() and not wasVisual
-      # console.log 'case-2'
+      console.log 'case-2'
       @cursorPositionManager.save('head') unless @instanceof('Select') # stay
 
     else
-      # console.log 'case-3'
+      console.log 'case-3'
       @preemptDidSelectTarget =>
         @cursorPositionManager.save('start')
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -392,7 +392,10 @@ class CreateRangeMarker extends Operator
 
 class ToggleRangeMarker extends CreateRangeMarker
   @extend()
+
   getRangeMarkerAtCursor: ->
+    return unless @vimState.hasRangeMarkers()
+    
     point = @editor.getCursorBufferPosition()
 
     containsPoint = (rangeMarker, point) ->

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -210,22 +210,17 @@ class Operator extends Base
     @pointBySelection = new Map
     wasVisual = @isMode('visual')
 
-    if @needStay()
-      if wasVisual
-        console.log 'case-1'
-        @saveCursorPositions('head', fromProperty: true, allowFallback: true) # visual-stay
-      else
-        console.log 'case-2'
-        @saveCursorPositions('head') unless @instanceof('Select') # stay
+    if @needStay() and wasVisual
+      console.log 'case-1'
+      @saveCursorPositions('head', fromProperty: true, allowFallback: true) # visual-stay
+
+    else if @needStay() and not wasVisual
+      console.log 'case-2'
+      @saveCursorPositions('head') unless @instanceof('Select') # stay
+
     else
-      if wasVisual
-        console.log 'case-3'
-        @saveCursorPositions('start') # visual-notStay
-      else
-        console.log 'case-4'
-        # normal-mode
-        @preemptDidSelectTarget =>
-          @saveCursorPositions('start')
+      console.log 'case-3'
+      @preemptDidSelectTarget => @saveCursorPositions('start')
 
     @emitWillSelectTarget()
     @target.select()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -31,7 +31,9 @@ class Operator extends Base
 
   patternForOccurence: null
 
+  stayOnLinewise: false
   stayAtSamePosition: null
+  restorePositions: true
   flashTarget: true
   trackChange: false
 
@@ -205,7 +207,7 @@ class Operator extends Base
       @editor.transact =>
         @mutateSelection(selection) for selection in @editor.getSelections()
 
-    @restoreCursorPositions()
+    @restoreCursorPositions() if @restorePositions
     @onDidRestoreCursorPositions?() # FIXME
     @activateMode(@finalMode, @finalSubmode)
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -189,7 +189,8 @@ class Operator extends Base
       # Restoring cursor position also clear selection
       # Unless clearing selection, we mutate original selection(e.g. paragraph) rather than occurrence.
       console.log "Fail to select occurrence"
-      @restoreCursorPositions()
+      # @restoreCursorPositions()
+      @editor.clearSelections()
       return false
 
   # Return true unless all selection is empty.

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -181,7 +181,6 @@ class Operator extends Base
     @patternForOccurence ?= @getPatternForOccurrence()
 
   selectOccurrence: ->
-    console.log "CALLED!"
     @scanRangesForOccurrence ?= @editor.getSelectedBufferRanges()
     ranges = scanInRanges(@editor, @patternForOccurence, @scanRangesForOccurrence)
     if ranges.length

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -303,8 +303,7 @@ class SelectOccurrence extends Select
   @description: "Add selection onto each matching word within target range"
   withOccurrence: true
   initialize: ->
-    console.log 'mode!', @vimState.mode
-    # FIXME don't trying to do everytin in event
+    super
     @onDidSelectTarget =>
       swrap.clearProperties(@editor)
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -205,20 +205,7 @@ class Operator extends Base
       @editor.transact =>
         @mutateSelection(selection) for selection in @editor.getSelections()
 
-    # Cursor position placement [same as before OR start of original selection]
-
-    if @needStay()
-      # same as before
-      for selection in @editor.getSelections()
-        if @isRestorableCursorPositionForSelection(selection)
-          @restoreCursorPositionForSelection(selection)
-        else
-          selection.destroy()
-    else
-      # start of original selection
-      @restoreCursorPositions()
-
-    @pointBySelection = null
+    @restoreCursorPositions()
     @onDidRestoreCursorPositions?() # FIXME
     @activateMode(@finalMode, @finalSubmode)
 
@@ -249,11 +236,10 @@ class Operator extends Base
     @emitWillSelectTarget()
     @target.select()
     saveCursorsToRestoreAfterSelect?()
-
+    @emitDidSelectTarget()
     @flashIfNecessary(@editor.getSelectedBufferRanges())
     @trackChangeIfNecessary()
 
-    @emitDidSelectTarget()
     haveSomeSelection(@editor)
 
   updatePreviousSelection: ->

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -405,12 +405,11 @@ class ToggleRangeMarker extends CreateRangeMarker
     for rangeMarker in @vimState.getRangeMarkers() when containsPoint(rangeMarker, point)
       return rangeMarker
 
-  execute: ->
+  initialize: ->
     if rangeMarker = @getRangeMarkerAtCursor()
       rangeMarker.destroy()
       @vimState.removeRangeMarker(rangeMarker)
-    else
-      super
+      @abort()
 
 class ToggleRangeMarkerOnInnerWord extends ToggleRangeMarker
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -302,6 +302,7 @@ class Operator extends Base
 
     @pointBySelection.clear()
     @pointBySelection = null
+    @emitDidRestoreCursorPositions() # not called on early return [FIXME?]
 
   removeSavedCursorPosition: (selection=null) ->
     if selection?
@@ -395,7 +396,7 @@ class ToggleRangeMarker extends CreateRangeMarker
 
   getRangeMarkerAtCursor: ->
     return unless @vimState.hasRangeMarkers()
-    
+
     point = @editor.getCursorBufferPosition()
 
     containsPoint = (rangeMarker, point) ->

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -83,18 +83,8 @@ class Operator extends Base
     else
       selection.destroy()
 
+  # now only for occurence
   observeSelectTarget: ->
-    unless @instanceof('Select')
-      if @needStay()
-        @onWillSelectTarget =>
-          unless @isMode('visual')
-            @updateSelectionProperties()
-            console.log 'update prop on will-select-target'
-      # else
-      #   @onDidSelectTarget =>
-      #     console.log 'update prop on did-select-target'
-      #     @updateSelectionProperties()
-
     if @isWithOccurrence()
       scanRanges = null
       @onWillSelectTarget =>
@@ -164,6 +154,10 @@ class Operator extends Base
     @observeSelectTarget()
     @saveStartOfSelections() if @isMode('visual')
 
+    if not @instanceof('Select') and @needStay()
+      unless @isMode('visual')
+        @updateSelectionProperties()
+        console.log 'update prop on will-select-target'
     @emitWillSelectTarget()
     @target.select()
     @saveStartOfSelections() unless @_restoreStartOfSelections?

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -252,7 +252,7 @@ class Operator extends Base
   restoreCursorPositions: ->
     @cursorPositionManager.restore(strict: not @isWithOccurrence())
     @cursorPositionManager = null
-    @emitDidRestoreCursorPositions() # not called on early return [FIXME?]
+    @emitDidRestoreCursorPositions()
 
 # Select
 # When text-object is invoked from normal or viusal-mode, operation would be

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -681,15 +681,3 @@ class Replace extends Operator
         selection.destroy()
 
     @activateMode('normal')
-
-# [SHOULD remove?]
-class SetCursorsToStartOfTarget extends Operator
-  @extend()
-  flashTarget: false
-  mutateSelection: (selection) ->
-    swrap(selection).setBufferPositionTo('start')
-
-class SetCursorsToStartOfRangeMarker extends SetCursorsToStartOfTarget
-  @extend()
-  flashTarget: false
-  target: "RangeMarker"

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -210,7 +210,6 @@ class Operator extends Base
     @pointBySelection = new Map
     wasVisual = @isMode('visual')
 
-    saveCursorsToRestoreAfterSelect = null
     if @needStay()
       if wasVisual
         console.log 'case-1'
@@ -225,12 +224,11 @@ class Operator extends Base
       else
         console.log 'case-4'
         # normal-mode
-        saveCursorsToRestoreAfterSelect = =>
+        @preemptDidSelectTarget =>
           @saveCursorPositions('start')
 
     @emitWillSelectTarget()
     @target.select()
-    saveCursorsToRestoreAfterSelect?()
 
     # # === debug
     # debug '# ---------- start'

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -65,7 +65,7 @@ class Operator extends Base
     return if @isMode('visual')
     return unless @flashTarget
     return unless settings.get('flashOnOperate')
-    return @getName() in settings.get('flashOnOperateBlacklist')
+    return if @getName() in settings.get('flashOnOperateBlacklist')
 
     highlightRanges @editor, ranges,
       class: 'vim-mode-plus-flash'

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -125,8 +125,9 @@ class Operator extends Base
       pattern = _.escapeRegExp(@getRegisterValueAsText())
     else
       {range, kind} = getCurrentWordBufferRangeAndKind(@editor.getLastCursor())
-      pattern = _.escapeRegExp(@editor.getTextInBufferRange(range))
-      pattern = "\\b#{pattern}\\b" if kind is 'word'
+      cursorWord = @editor.getTextInBufferRange(range)
+      pattern = _.escapeRegExp(cursorWord)
+      pattern = "\\b" + pattern + "\\b" if kind is 'word'
     new RegExp(pattern, 'g')
 
   setTextToRegisterForSelection: (selection) ->

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -6,9 +6,13 @@ propertyStore = new Map
 class SelectionWrapper
   constructor: (@selection) ->
 
-  hasProperties: -> propertyStore.has(@selection)
+  hasProperties: ->
+    console.log 'hasProperties', @selection.id
+    propertyStore.has(@selection)
   getProperties: -> propertyStore.get(@selection) ? {}
-  setProperties: (prop) -> propertyStore.set(@selection, prop)
+  setProperties: (prop) ->
+    # console.log 'setProp', @selection.id
+    propertyStore.set(@selection, prop)
   clearProperties: -> propertyStore.delete(@selection)
 
   setBufferRangeSafely: (range) ->
@@ -139,6 +143,8 @@ class SelectionWrapper
       editor.bufferRangeForScreenRange([start, end])
 
   preserveCharacterwise: ->
+    basename = require('path').basename
+    # console.log "PRESERVING", basename(@selection.editor.getPath())
     properties = @detectCharacterwiseProperties()
     unless @selection.isEmpty()
       endPoint = if @selection.isReversed() then 'tail' else 'head'

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -7,7 +7,7 @@ class SelectionWrapper
   constructor: (@selection) ->
 
   hasProperties: ->
-    console.log 'hasProperties', @selection.id
+    # console.log 'hasProperties', @selection.id
     propertyStore.has(@selection)
   getProperties: -> propertyStore.get(@selection) ? {}
   setProperties: (prop) ->

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -37,6 +37,10 @@ module.exports = new Settings 'vim-mode-plus',
     items: type: 'string'
     default: []
     description: 'Start in insert-mode whan editorElement matches scope'
+  clearMultipleCursorsOnEscapeInsertMode:
+    type: 'boolean'
+    default: true
+    description: 'when tStart in insert-mode whan editorElement matches scope'
   wrapLeftRightMotion:
     type: 'boolean'
     default: false

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -40,7 +40,6 @@ module.exports = new Settings 'vim-mode-plus',
   clearMultipleCursorsOnEscapeInsertMode:
     type: 'boolean'
     default: true
-    description: 'when tStart in insert-mode whan editorElement matches scope'
   wrapLeftRightMotion:
     type: 'boolean'
     default: false

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -42,8 +42,9 @@ class TextObject extends Base
       @vimState.submode is 'linewise'
 
   select: ->
-    for selection in @editor.getSelections()
-      @selectTextObject(selection)
+    @countTimes =>
+      for selection in @editor.getSelections()
+        @selectTextObject(selection)
     @updateSelectionProperties() if @isMode('visual')
 
 # -------------------------

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -580,6 +580,7 @@ class Paragraph extends TextObject
       selection.selectToBufferPosition point if point?
 
   selectTextObject: (selection) ->
+    # FIXME: don't manage count on each child
     firstTime = true
     _.times @getCount(), =>
       @selectParagraph(selection, {firstTime})

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -34,16 +34,18 @@ include = (klass, module) ->
   for key, value of module
     klass::[key] = value
 
-debug = (message...) ->
+debug = (messages...) ->
   return unless settings.get('debug')
-  message += "\n"
+  # messages += "\n"
+  # console.log messages
   switch settings.get('debugOutput')
     when 'console'
-      console.log message...
+      # console.log "HEY!"
+      console.log messages...
     when 'file'
       filePath = fs.normalize settings.get('debugOutputFilePath')
       if fs.existsSync(filePath)
-        fs.appendFileSync filePath, message
+        fs.appendFileSync filePath, messages
 
 getView = (model) ->
   atom.views.getView(model)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -70,25 +70,6 @@ saveCursorPositions = (editor) ->
       point = points.get(cursor)
       cursor.setBufferPosition(point)
 
-# Return function
-# Which function set selection.cursor to stored start position, yes selection is cleard
-saveStartOfSelections = (editor) ->
-  points = new Map
-  for selection in editor.getSelections()
-    point = selection.getBufferRange().start
-    points.set(selection, point)
-  ->
-    selectionIsNotFound = (selection) ->
-      not points.has(selection)
-
-    # strict. in vB mode, vB range is reselected on @target.selection
-    # so selection.id is change in that case we won't restore.
-    return if editor.getSelections().some(selectionIsNotFound)
-
-    for selection in editor.getSelections()
-      point = points.get(selection)
-      selection.cursor.setBufferPosition(point)
-
 getKeystrokeForEvent = (event) ->
   keyboardEvent = event.originalEvent.originalEvent ? event.originalEvent
   atom.keymaps.keystrokeForKeyboardEvent(keyboardEvent)
@@ -693,7 +674,6 @@ module.exports = {
   getView
   saveEditorState
   saveCursorPositions
-  saveStartOfSelections
   getKeystrokeForEvent
   getCharacterForEvent
   isLinewiseRange

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -630,6 +630,25 @@ withTrackingCursorPositionChange = (cursor, fn) ->
   unless cursorBefore.isEqual(cursorAfter)
     console.log "Changed: #{cursorBefore.toString()} -> #{cursorAfter.toString()}"
 
+selectedRanges = (editor) ->
+  editor.getSelectedBufferRanges().map(toString).join("\n")
+
+selectedRange = (editor) ->
+  editor.getSelectedBufferRange().toString()
+
+{inspect} = require 'util'
+
+selectedText = (editor) ->
+  editor.getSelectedBufferRanges()
+    .map (range) ->
+      editor.getTextInBufferRange(range)
+      # inspect(editor.getTextInBufferRange(range))
+    .join("\n")
+
+toString = (obj) ->
+  if _.isFunction(obj.toString)
+    obj.toString()
+
 # Reloadable registerElement
 registerElement = (name, options) ->
   element = document.createElement(name)
@@ -755,4 +774,9 @@ module.exports = {
   reportCursor
   withTrackingCursorPositionChange
   logGoalColumnForSelection
+
+  selectedRanges
+  selectedRange
+  selectedText
+  toString
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -610,16 +610,19 @@ isSingleLine = (text) ->
 #   - ON white-space: Includs only white-spaces.
 #   - ON non-word: Includs only non word char(=excludes normal word char).
 getCurrentWordBufferRangeAndKind = (cursor) ->
-  options = {}
   if cursorIsOnWhiteSpace(cursor)
     kind = 'white-space'
-    options.wordRegex = /[\t ]+/
+    source = "[\t ]+"
   else if cursorIsOnNonWordCharacter(cursor)
+    kind = 'non-word'
     nonWordCharacters = _.escapeRegExp(getNonWordCharactersForCursor(cursor))
-    options.wordRegex = ///[#{nonWordCharacters}]+///
+    source = "[#{nonWordCharacters}]+"
   else
     kind = 'word'
-  range = cursor.getCurrentWordBufferRange(options)
+    nonWordCharacters = _.escapeRegExp(getNonWordCharactersForCursor(cursor))
+    source = "^[\t ]*$|[^\\s#{nonWordCharacters}]+"
+  wordRegex = new RegExp(source)
+  range = cursor.getCurrentWordBufferRange({wordRegex})
   {range, kind}
 
 scanInRanges = (editor, pattern, scanRanges) ->

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -34,12 +34,12 @@ include = (klass, module) ->
   for key, value of module
     klass::[key] = value
 
-debug = (message) ->
+debug = (message...) ->
   return unless settings.get('debug')
   message += "\n"
   switch settings.get('debugOutput')
     when 'console'
-      console.log message
+      console.log message...
     when 'file'
       filePath = fs.normalize settings.get('debugOutputFilePath')
       if fs.existsSync(filePath)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -175,9 +175,6 @@ class VimState
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
 
-  # [TEMPROARY]
-  onDidRestoreStartOfSelections: (fn) -> @subscribe @emitter.on('did-restore-start-of-selections', fn)
-
   # Event for operation execution life cycle.
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -144,6 +144,7 @@ class VimState
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
   onWillSelectTarget: (fn) -> @subscribe @emitter.on('will-select-target', fn)
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
+  preemptWillSelectTarget: (fn) -> @subscribe @emitter.preempt('will-select-target', fn)
   preemptDidSelectTarget: (fn) -> @subscribe @emitter.preempt('did-select-target', fn)
   onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -144,6 +144,7 @@ class VimState
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
   onWillSelectTarget: (fn) -> @subscribe @emitter.on('will-select-target', fn)
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
+  preemptDidSelectTarget: (fn) -> @subscribe @emitter.preempt('did-select-target', fn)
   onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
 
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -238,7 +238,12 @@ class VimState
     @editorElement.addEventListener('mouseup', checkSelection)
     @subscriptions.add new Disposable =>
       @editorElement.removeEventListener('mouseup', checkSelection)
-    @subscriptions.add atom.commands.onWillDispatch(preserveCharacterwise)
+
+    # [FIXME]
+    # Hover position get wired when focus-change between more than two pane.
+    # commenting out is far better than introducing Buggy behavior.
+    # @subscriptions.add atom.commands.onWillDispatch(preserveCharacterwise)
+
     @subscriptions.add atom.commands.onDidDispatch(checkSelection)
 
   resetNormalMode: ({userInvocation}={}) ->

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -32,6 +32,7 @@ class VimState
 
   @delegatesProperty('mode', 'submode', toProperty: 'modeManager')
   @delegatesMethods('isMode', 'activate', toProperty: 'modeManager')
+  @delegatesMethods('getCount', 'setCount', 'hasCount', toProperty: 'operationStack')
 
   constructor: (@main, @editor, @statusBarManager) ->
     @editorElement = @editor.element
@@ -93,37 +94,6 @@ class VimState
 
   setOperatorModifier: (modifier) ->
     @operationStack.setOperatorModifier(modifier)
-
-  # Count
-  # -------------------------
-  # keystroke `3d2w` delete 6(3*2) words.
-  #  2nd number(2 in this case) is always enterd in operator-pending-mode.
-  #  So count have two timing to be entered. that's why here we manage counter by mode.
-  count: {}
-
-  hasCount: ->
-    @count['normal']? or @count['operator-pending']?
-
-  getCount: ->
-    if @hasCount()
-      (@count['normal'] ? 1) * (@count['operator-pending'] ? 1)
-    else
-      null
-
-  setCount: (number) ->
-    if @mode is 'operator-pending'
-      mode = @mode
-    else
-      mode = 'normal'
-
-    @count[mode] ?= 0
-    @count[mode] = (@count[mode] * 10) + number
-    @hover.add(number)
-    @toggleClassList('with-count', @hasCount())
-
-  resetCount: ->
-    @count = {}
-    @toggleClassList('with-count', @hasCount())
 
   # Mark
   # -------------------------
@@ -278,7 +248,6 @@ class VimState
     @activate('normal')
 
   reset: ->
-    @resetCount()
     @resetCharInput()
     @register.reset()
     @searchHistory.reset()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -103,6 +103,8 @@ class VimState
   count: null
   counts: []
   hasCount: -> @count?
+
+  # FIXME: unnecessary complexity?
   preserveCount: ->
     if @hasCount()
       @counts.push(@count)
@@ -328,6 +330,11 @@ class VimState
     if settings.get('highlightSearch') and @main.highlightSearchPattern?
       @highlightSearchMarkers = @highlightSearch(@main.highlightSearchPattern, scanRange)
 
+  # Repeat
+  # -------------------------
+  reapatRecordedOperation: ->
+    @operationStack.runRecorded()
+
   # rangeMarkers for narrowRange
   # -------------------------
   addRangeMarkers: (markers) ->
@@ -341,6 +348,12 @@ class VimState
   removeRangeMarker: (rangeMarker) ->
     _.remove(@rangeMarkers, rangeMarker)
     @updateHasRangeMarkerState()
+
+  getRangeMarkerAtBufferPosition: (point) ->
+    exclusive = false
+    for rangeMarker in @getRangeMarkers()
+      if rangeMarker.getBufferRange().containsPoint(point, exclusive)
+        return rangeMarker
 
   updateHasRangeMarkerState: ->
     @toggleClassList('with-range-marker', @hasRangeMarkers())

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -175,6 +175,9 @@ class VimState
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
 
+  # [TEMPROARY]
+  onDidRestoreStartOfSelections: (fn) -> @subscribe @emitter.on('did-restore-start-of-selections', fn)
+
   # Event for operation execution life cycle.
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -171,11 +171,11 @@ class VimState
   onDidCommandSearch: (fn) -> @subscribe @searchInput.onDidCommand(fn)
 
   # Select and text mutation(Change)
+  onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
   onWillSelectTarget: (fn) -> @subscribe @emitter.on('will-select-target', fn)
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
-  onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
+  onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
 
-  # Event for operation execution life cycle.
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)
 
   # Select list view

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -96,35 +96,33 @@ class VimState
 
   # Count
   # -------------------------
-  # keystroke `3d2w` delete 6(3*2) words
-  #  Each time, operation instantiated(new Operation), count are preserved.
-  #  pushed to @counts, then while operation executed, operation::getCount()
-  #  call vimState::getCount which return multiplied value for each of preserved counts.
-  count: null
-  counts: []
-  hasCount: -> @count?
+  # keystroke `3d2w` delete 6(3*2) words.
+  #  2nd number(2 in this case) is always enterd in operator-pending-mode.
+  #  So count have two timing to be entered. that's why here we manage counter by mode.
+  count: {}
 
-  # FIXME: unnecessary complexity?
-  preserveCount: ->
-    if @hasCount()
-      @counts.push(@count)
-      @count = null
+  hasCount: ->
+    @count['normal']? or @count['operator-pending']?
 
   getCount: ->
-    if @counts.length > 0
-      @counts.reduce (a, b) -> a * b
+    if @hasCount()
+      (@count['normal'] ? 1) * (@count['operator-pending'] ? 1)
     else
       null
 
   setCount: (number) ->
-    @count ?= 0
-    @count = (@count * 10) + number
+    if @mode is 'operator-pending'
+      mode = @mode
+    else
+      mode = 'normal'
+
+    @count[mode] ?= 0
+    @count[mode] = (@count[mode] * 10) + number
     @hover.add(number)
     @toggleClassList('with-count', @hasCount())
 
   resetCount: ->
-    @count = null
-    @counts = []
+    @count = {}
     @toggleClassList('with-count', @hasCount())
 
   # Mark

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -479,6 +479,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure 'escape', text: "abc123\nabc4567"
       editor.addSelectionBelow()
       ensure '.',      text: "ababcc123\nababcc4567"
+      editor.addSelectionBelow()
       ensure '.',      text: "abababccc123\nabababccc4567"
 
     describe 'with nonlinear input', ->

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -449,7 +449,10 @@ describe "Operator ActivateInsertMode family", ->
   describe "the i keybinding", ->
     beforeEach ->
       set
-        text: '123\n4567'
+        text: """
+          123
+          4567
+          """
         cursorBuffer: [[0, 0], [1, 0]]
 
     it "allows undoing an entire batch of typing", ->
@@ -460,6 +463,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure 'escape', text: "abc123\nabc4567"
 
       keystroke 'i'
+      editor.addSelectionBelow()
       editor.insertText "d"
       editor.insertText "e"
       editor.insertText "f"
@@ -473,6 +477,7 @@ describe "Operator ActivateInsertMode family", ->
       editor.backspace()
       editor.backspace()
       ensure 'escape', text: "abc123\nabc4567"
+      editor.addSelectionBelow()
       ensure '.',      text: "ababcc123\nababcc4567"
       ensure '.',      text: "abababccc123\nabababccc4567"
 

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -347,7 +347,7 @@ describe "Operator general", ->
           text: "d\nabc\nd"
           cursorBuffer: [[0, 0], [1, 0], [2, 0]]
 
-    describe "stayOnDelete setting", ->
+    xdescribe "stayOnDelete setting", ->
       beforeEach ->
         settings.set('stayOnDelete', true)
         set

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -910,7 +910,7 @@ describe "Operator general", ->
     it "composes with motions", ->
       ensure 'd d 2 .', text: "78"
 
-  fdescribe "the r keybinding", ->
+  describe "the r keybinding", ->
     beforeEach ->
       set
         text: "12\n34\n\n"

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -444,7 +444,6 @@ describe "Operator modifier", ->
       it 'change all assignment("=") of current-function to "?="', ->
         set cursor: [0, 0]
         ensure ['j f', input: '='], cursor: [1, 17]
-        selectOccurrence =
 
         withMockPlatform searchEditorElement, 'platform-darwin' , ->
           keystroke [

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -90,7 +90,7 @@ describe "Operator modifier", ->
         editor.insertText('!!!')
         ensure "escape",
           mode: 'normal'
-          numCursors: 8
+          numCursors: 1
           text: """
 
           !!!: xxx: !!!:

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -106,7 +106,7 @@ describe "Operator modifier", ->
           """
         ensure "} j .",
           mode: 'normal'
-          numCursors: 8
+          numCursors: 1
           text: """
 
           !!!: xxx: !!!:

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -177,17 +177,22 @@ describe "Operator modifier", ->
       beforeEach ->
         set
           text: """
-          ooo: xxx: ooo:
+          vim-mode-plus vim-mode-plus
           """
       describe "what the cursor-word", ->
-        describe "cursor is at normal word [by select-occurrence]", ->
-          it "pick word but not pick partially matched one and re-use cached cursor-word on repeat", ->
-            set cursor: [0, 0]
-            ensure "g cmd-d i p", selectedText: ['ooo', 'ooo']
-        describe "cursor is at nonWordCharacters [by select-occurrence]", ->
-          it "select that char only", ->
-            set cursor: [0, 3]
-            ensure "g cmd-d i p", selectedText: [':', ':', ':']
+        ensureCursorWord = (initialPoint, {selectedText}) ->
+          set cursor: initialPoint
+          ensure "g cmd-d i p",
+            selectedText: selectedText
+            mode: ['visual', 'characterwise']
+          ensure "escape", mode: "normal"
+
+        describe "cursor is on normal word", ->
+          it "pick word but not pick partially matched one [by select]", ->
+            ensureCursorWord([0, 0], selectedText: ['vim', 'vim'])
+            ensureCursorWord([0, 3], selectedText: ['-', '-', '-', '-'])
+            ensureCursorWord([0, 4], selectedText: ['mode', 'mode'])
+            ensureCursorWord([0, 9], selectedText: ['plus', 'plus'])
         describe "cursor is at single white space [by delete]", ->
           it "pick single white space only", ->
             set

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -480,7 +480,7 @@ describe "Operator TransformString", ->
             keystroke 'j'
             ensure ['y s i w', input: ']'], text: "(apple)\n{orange}\n[lemmon]"
 
-    describe 'map-surround', ->
+    xdescribe 'map-surround', ->
       beforeEach ->
         set
           text: """

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -177,12 +177,12 @@ describe "VimState", ->
         0 23456
         1 23456
         """
-        cursor: [[0, 0], [1, 2]]
-      ensure 'i', mode: 'insert', cursor: [[0, 0], [1, 2]]
+        cursor: [0, 2]
+      ensure 'i', mode: 'insert', cursor: [0, 2]
 
     it "activate normal mode without moving cursors left, then back to insert-mode once some command executed", ->
-      ensure 'ctrl-o', cursor: [[0, 0], [1, 2]], mode: 'normal'
-      ensure 'l', cursor: [[0, 1], [1, 3]], mode: 'insert'
+      ensure 'ctrl-o', cursor: [0, 2], mode: 'normal'
+      ensure 'l', cursor: [0, 3], mode: 'insert'
 
   describe "insert-mode", ->
     beforeEach -> keystroke 'i'

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -23,6 +23,16 @@ describe "Visual Blockwise", ->
     6-------------------
     """
 
+  textAfterInserted = """
+    01234567890123456789
+    1-------------------
+    2----!!!
+    3----!!!
+    4----!!!
+    5----!!!
+    6-------------------
+    """
+
   blockTexts = [
     '56789012345' # 0
     '-----------' # 1
@@ -32,11 +42,24 @@ describe "Visual Blockwise", ->
     'C---------D' # 5
     '-----------' # 6
   ]
+
   textData = new TextData(textInitial)
 
   selectBlockwise = ->
     set cursor: [2, 5]
     ensure 'v 3 j 1 0 l ctrl-v',
+      mode: ['visual', 'blockwise']
+      selectedBufferRange: [
+        [[2, 5], [2, 16]]
+        [[3, 5], [3, 16]]
+        [[4, 5], [4, 16]]
+        [[5, 5], [5, 16]]
+      ]
+      selectedText: blockTexts[2..5]
+
+  selectBlockwiseReversely = ->
+    set cursor: [2, 15]
+    ensure 'v 3 j 1 0 h ctrl-v',
       mode: ['visual', 'blockwise']
       selectedBufferRange: [
         [[2, 5], [2, 16]]
@@ -118,37 +141,40 @@ describe "Visual Blockwise", ->
       ensure 'k', selectedTextOrdered: blockTexts[3..5]
       ensure '2 k', selectedTextOrdered: blockTexts[3]
 
+  # FIXME add C, D spec for selectBlockwiseReversely() situation
   describe "C", ->
-    beforeEach ->
-      selectBlockwise()
-    it "change-to-last-character-of-line for each selection", ->
+    ensureChange = ->
       ensure 'C',
         mode: 'insert'
         cursor: [[2, 5], [3, 5], [4, 5], [5, 5] ]
         text: textAfterDeleted
-
       editor.insertText("!!!")
       ensure
         mode: 'insert'
         cursor: [[2, 8], [3, 8], [4, 8], [5, 8]]
-        text: """
-          01234567890123456789
-          1-------------------
-          2----!!!
-          3----!!!
-          4----!!!
-          5----!!!
-          6-------------------
-          """
+        text: textAfterInserted
+
+    it "change-to-last-character-of-line for each selection", ->
+      selectBlockwise()
+      ensureChange()
+
+    it "[selection reversed] change-to-last-character-of-line for each selection", ->
+      selectBlockwiseReversely()
+      ensureChange()
 
   describe "D", ->
-    beforeEach ->
-      selectBlockwise()
-    it "delete-to-last-character-of-line for each selection", ->
+    ensureDelete = ->
       ensure 'D',
         text: textAfterDeleted
         cursor: [2, 4]
         mode: 'normal'
+
+    it "delete-to-last-character-of-line for each selection", ->
+      selectBlockwise()
+      ensureDelete()
+    it "[selection reversed] delete-to-last-character-of-line for each selection", ->
+      selectBlockwiseReversely()
+      ensureDelete()
 
   describe "I", ->
     beforeEach ->


### PR DESCRIPTION
continuation of #368

# TODO
- [ ] Update vmp-plugins to follow new way of how operator processed.
- [x] Elminate misuse of `initialize()`, it's only called at `new`. not called on `.` repat, so do mutation stuf in `execute()`. basically `onDidSelect`, `onWillSelect` like on time subscription should be called in `exclute`.
- [x] Don't overuse overriding function to do nothing. e.g `restoreStartOfSelections: -> null` in child class
- [ ] Make sure selection properties is cleared
- [x] Don't overuse event hook
- [x] Don't depend selection property too much
- [x] Make sure `operation._restoreStartOfSelections = null`
- [x] Should remove `onDidRestoreStartOfSelections` after refactoring finished.
- [x] `StayOnDelete` is broken. on multi-line selection
- [ ] Don't call `modeManger.deactivate` just for restoreing cursor position in visual-mode
- [ ] Don't call `modeManger.activate` just for update selection's wise
- [ ] Create mechanizm to cleanup instance var on each operation run(subscribe/dispose on OpStack?)
- [x] Eliminate `vimState.preserveCount`. Can simplify.

# DONE
Removed manual requireTarget = false on `D` and `C` in vB mode. this
was required because of wrong condition check on operation.stack, was
checked with operator.requireTarget() but should be
operator.hasTarget().

- restorePoint is no longer processed within mutateSelection
it was processed each selection one by one per mutation.
But occurrence like multiply selection’s number introduce very complex
situation.
So to workaround this I differed restore timing in older version.
But now, restorePoint is handled in bulk, after all mutation was
finished.
So don’t have to conditional differing. simplified