### PR TITLE
Set occurence for next operation

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -342,8 +342,7 @@
   'V': 'vim-mode-plus:operator-modifier-linewise'
   'o': 'vim-mode-plus:operator-modifier-occurrence'
 
-# operator-pending.with-occurrence
-# [Experimental]
+# operator-pending.with-occurrence [Experimental]
 # -------------------------
 'atom-text-editor.vim-mode-plus.operator-pending-mode.with-occurrence':
   'p': 'vim-mode-plus:inner-paragraph'
@@ -351,6 +350,12 @@
   'f': 'vim-mode-plus:a-function'
   'l': 'vim-mode-plus:inner-current-line'
   'z': 'vim-mode-plus:a-fold'
+
+# normal.occurrence-pending [Experimental]
+# -------------------------
+'atom-text-editor.vim-mode-plus.normal-mode.occurrence-pending':
+  'i': 'vim-mode-plus:insert-at-start-of-occurrence'
+  'a': 'vim-mode-plus:insert-at-end-of-occurrence'
 
 # operator-pending, visual
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -357,9 +357,11 @@
 'atom-text-editor.vim-mode-plus.normal-mode.occurrence-pending':
   'i': 'vim-mode-plus:insert-at-start-of-occurrence-in-a-function-or-inner-paragraph'
   'a': 'vim-mode-plus:insert-at-end-of-occurrence-in-a-function-or-inner-paragraph'
-  'I': 'vim-mode-plus:insert-at-start-of-occurrence'
-  'A': 'vim-mode-plus:insert-at-end-of-occurrence'
-  'v': 'vim-mode-plus:select-occurrence'
+  'C': 'vim-mode-plus:change-occurrence-in-a-function-or-inner-paragraph'
+  'D': 'vim-mode-plus:delete-occurrence-in-a-function-or-inner-paragraph'
+  'v': 'vim-mode-plus:select-occurrence-in-a-function-or-inner-paragraph'
+  # 'I': 'vim-mode-plus:insert-at-start-of-occurrence'
+  # 'A': 'vim-mode-plus:insert-at-end-of-occurrence'
 
 # operator-pending, visual
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -354,8 +354,8 @@
 # normal.occurrence-pending [Experimental]
 # -------------------------
 'atom-text-editor.vim-mode-plus.normal-mode.occurrence-pending':
-  'i': 'vim-mode-plus:insert-at-start-of-occurrence'
-  'a': 'vim-mode-plus:insert-at-end-of-occurrence'
+  'I': 'vim-mode-plus:insert-at-start-of-occurrence'
+  'A': 'vim-mode-plus:insert-at-end-of-occurrence'
 
 # operator-pending, visual
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -464,6 +464,9 @@
   'i r': 'vim-mode-plus:inner-range-marker'
   'a r': 'vim-mode-plus:a-range-marker'
 
+  'i v': 'vim-mode-plus:inner-visible-area'
+  'a v': 'vim-mode-plus:a-visible-area'
+
 # visual
 # -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode':

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -288,6 +288,7 @@
 '.platform-darwin atom-text-editor.vim-mode-plus-search':
   'ctrl-cmd-c': 'vim-mode-plus:change-occurrence-from-search'
   'cmd-d': 'vim-mode-plus:select-occurrence-from-search'
+  'cmd-o': 'vim-mode-plus:set-occurrence-for-next-operation-from-search'
 
 # normal
 # -------------------------
@@ -354,8 +355,9 @@
 # normal.occurrence-pending [Experimental]
 # -------------------------
 'atom-text-editor.vim-mode-plus.normal-mode.occurrence-pending':
-  'I': 'vim-mode-plus:insert-at-start-of-occurrence'
-  'A': 'vim-mode-plus:insert-at-end-of-occurrence'
+  'i': 'vim-mode-plus:insert-at-start-of-occurrence'
+  'a': 'vim-mode-plus:insert-at-end-of-occurrence'
+  'v': 'vim-mode-plus:select-occurrence'
 
 # operator-pending, visual
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -355,8 +355,10 @@
 # normal.occurrence-pending [Experimental]
 # -------------------------
 'atom-text-editor.vim-mode-plus.normal-mode.occurrence-pending':
-  'i': 'vim-mode-plus:insert-at-start-of-occurrence'
-  'a': 'vim-mode-plus:insert-at-end-of-occurrence'
+  'i': 'vim-mode-plus:insert-at-start-of-occurrence-in-a-function-or-inner-paragraph'
+  'a': 'vim-mode-plus:insert-at-end-of-occurrence-in-a-function-or-inner-paragraph'
+  'I': 'vim-mode-plus:insert-at-start-of-occurrence'
+  'A': 'vim-mode-plus:insert-at-end-of-occurrence'
   'v': 'vim-mode-plus:select-occurrence'
 
 # operator-pending, visual

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -38,6 +38,7 @@ vimStateMethods = [
   "isMode"
   "getBlockwiseSelections"
   "updateSelectionProperties"
+  "hasRegisterName"
 ]
 
 class Base
@@ -121,9 +122,6 @@ class Base
 
   isDefaultRegisterName: ->
     @vimState.register.isDefaultName()
-
-  hasRegisterName: ->
-    @vimState.register.hasName()
 
   # Misc
   # -------------------------

--- a/lib/cursor-position-manager.coffee
+++ b/lib/cursor-position-manager.coffee
@@ -26,7 +26,7 @@ class CursorPositionManager
     strict ?= true
     selections = @editor.getSelections()
 
-    # unless occurence-mode we go strict mode.
+    # unless occurrence-mode we go strict mode.
     # in vB mode, vB range is reselected on @target.selection
     # so selection.id is change in that case we won't restore.
     selectionNotFound = (selection) => not @pointsBySelection.has(selection)

--- a/lib/input.coffee
+++ b/lib/input.coffee
@@ -131,6 +131,7 @@ class SearchInput extends Input
       "search-visit-prev": => @emitter.emit('did-command', name: 'visit', direction: 'prev')
       "select-occurrence-from-search": => @emitter.emit('did-command', name: 'run', operation: 'SelectOccurrence')
       "change-occurrence-from-search": => @emitter.emit('did-command', name: 'run', operation: 'ChangeOccurrence')
+      "set-occurrence-for-next-operation-from-search": => @emitter.emit('did-command', name: 'set-occurrence-for-next-operation')
 
       "search-insert-wild-pattern": => @editor.insertText('.*?')
       "search-activate-literal-mode": => @activateLiteralMode()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -148,9 +148,10 @@ module.exports =
       'activate-blockwise-visual-mode': -> @activate('visual', 'blockwise')
       'reset-normal-mode': -> @resetNormalMode(userInvocation: true)
       'set-register-name': -> @register.setName() # "
-      'operator-modifier-characterwise': -> @setOperatorModifier(wise: 'characterwise')
-      'operator-modifier-linewise': -> @setOperatorModifier(wise: 'linewise')
-      'operator-modifier-occurrence': -> @setOperatorModifier(occurence: true)
+      'operator-modifier-characterwise': -> @operationStack.setOperatorModifier(wise: 'characterwise')
+      'operator-modifier-linewise': -> @operationStack.setOperatorModifier(wise: 'linewise')
+      'operator-modifier-occurrence': -> @operationStack.setOperatorModifier(occurrence: true)
+      'set-occurrence-for-next-operation': -> @setOccurrenceForNextOperation()
       'repeat': -> @reapatRecordedOperation()
       'set-count-0': -> @setCount(0)
       'set-count-1': -> @setCount(1)

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -617,11 +617,18 @@ class MoveToTopOfScreen extends Motion
   getPoint: ->
     getFirstCharacterBufferPositionForScreenRow(@editor, @getRow())
 
+  getScrolloff: ->
+    if @isAsOperatorTarget()
+      0
+    else
+      @scrolloff
+
   getRow: ->
     row = getFirstVisibleScreenRow(@editor)
-    offset = @scrolloff
+    offset = @getScrolloff()
     offset = 0 if (row is 0)
-    row + Math.max(@getCount(), offset)
+    offset = Math.max(@getCount(), offset)
+    row + offset
 
 # keymap: M
 class MoveToMiddleOfScreen extends MoveToTopOfScreen
@@ -643,9 +650,10 @@ class MoveToBottomOfScreen extends MoveToTopOfScreen
     # So I intentionally use editor.getLastScreenRow here.
     vimLastScreenRow = @getVimLastScreenRow()
     row = Math.min(@editor.getLastVisibleScreenRow(), vimLastScreenRow)
-    offset = @scrolloff + 1
-    offset = 0 if (row is vimLastScreenRow)
-    row - Math.max(@getCount(), offset)
+    offset = @getScrolloff() + 1
+    offset = 0 if row is vimLastScreenRow
+    offset = Math.max(@getCount(), offset)
+    row - offset
 
 # Scrolling
 # Half: ctrl-d, ctrl-u

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -1016,6 +1016,12 @@ class Search extends SearchBase
           @vimState.searchHistory.save(@input)
           @vimState.searchInput.cancel()
           @vimState.operationStack.run(command.operation, options)
+        when 'set-occurrence-for-next-operation'
+          # Order is important: we have to call AFTER cancel() otherwise occur markers are immediately reset.
+          # since cancellation includes vimState.reset()
+          pattern = @matches.pattern
+          @vimState.searchInput.cancel()
+          @vimState.setOccurrenceForNextOperation(pattern)
 
   visitCursors: ->
     visitCursor = (cursor) =>

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -783,12 +783,12 @@ class MoveToMark extends Motion
   @extend()
   requireInput: true
   hover: icon: ":move-to-mark:`", emoji: ":round_pushpin:`"
+  input: null # set when instatntiated via vimState::moveToMark()
 
   initialize: ->
     super
     @focusInput() unless @isComplete()
 
-  input: null # set when instatntiated via vimState::moveToMark()
   getPoint: (fromPoint) ->
     input = @getInput()
     point = null

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -196,8 +196,8 @@ class OperationStack
     @recorded
 
   setOperatorModifier: (modifiers) ->
-    # console.log '  -- [start] setOperatorModifier', @vimState.mode
-    
+    console.log '  -- [start] setOperatorModifier', @vimState.mode
+
     # In operator-pending-mode, stack length is always 1 and its' operator.
     # So either of @stack[0] or @peekTop() is OK.
     operator = @stack[0]
@@ -209,7 +209,7 @@ class OperationStack
     if occurrence
       @addToClassList('with-occurrence')
       @highlightOccurrenceIfNecessary()
-    # console.log '  -- [end] setOperatorModifier'
+    console.log '  -- [end] setOperatorModifier'
 
   # Count
   # -------------------------
@@ -243,14 +243,15 @@ class OperationStack
   hasOccurrenceMarkers: ->
     @occurrenceMarkers?
 
-  highlightOccurrenceIfNecessary: ->
+  highlightOccurrenceIfNecessary: (pattern=null) ->
+    console.log 'PT', pattern
     if @hasOccurrenceMarkers()
       console.log 'already highlighted so return'
       return
     else
       console.log 'ya I\'ll highlight'
 
-    pattern = getWordPatternAtCursor(@editor.getLastCursor())
+    pattern ?= getWordPatternAtCursor(@editor.getLastCursor())
     scanRanges = [getVisibleBufferRange(@editor)]
     ranges = scanInRanges(@editor, pattern, scanRanges)
 

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -258,6 +258,10 @@ class ChangeOccurrence extends Change
   @description: "Change all matching word within target range"
   withOccurrence: true
 
+class ChangeOccurrenceInAFunctionOrInnerParagraph extends ChangeOccurrence
+  @extend()
+  target: 'AFunctionOrInnerParagraph'
+
 class ChangeOccurrenceInARangeMarker extends ChangeOccurrence
   @extend()
   target: "ARangeMarker"

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -170,21 +170,21 @@ class InsertAtEndOfTarget extends InsertByTarget
 
 class InsertAtStartOfOccurrence extends InsertAtStartOfTarget
   @extend()
-  withOccurrence: true
+  occurrence: true
 
 class InsertAtEndOfOccurrence extends InsertAtEndOfTarget
   @extend()
-  withOccurrence: true
+  occurrence: true
 
 class InsertAtStartOfOccurrenceInAFunctionOrInnerParagraph extends InsertAtStartOfTarget
   @extend()
   target: "AFunctionOrInnerParagraph"
-  withOccurrence: true
+  occurrence: true
 
 class InsertAtEndOfOccurrenceInAFunctionOrInnerParagraph extends InsertAtEndOfTarget
   @extend()
   target: "AFunctionOrInnerParagraph"
-  withOccurrence: true
+  occurrence: true
 
 # Alias for backward compatibility
 class InsertAtEndOfSelection extends InsertAtEndOfTarget
@@ -234,7 +234,7 @@ class Change extends ActivateInsertMode
       @flashTarget = true
 
     selected = @selectTarget()
-    if @isWithOccurrence() and not selected
+    if @isOccurrence() and not selected
       @vimState.activate('normal')
       return
 
@@ -256,7 +256,7 @@ class Change extends ActivateInsertMode
 class ChangeOccurrence extends Change
   @extend()
   @description: "Change all matching word within target range"
-  withOccurrence: true
+  occurrence: true
 
 class ChangeOccurrenceInAFunctionOrInnerParagraph extends ChangeOccurrence
   @extend()

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -176,6 +176,16 @@ class InsertAtEndOfOccurrence extends InsertAtEndOfTarget
   @extend()
   withOccurrence: true
 
+class InsertAtStartOfOccurrenceInAFunctionOrInnerParagraph extends InsertAtStartOfTarget
+  @extend()
+  target: "AFunctionOrInnerParagraph"
+  withOccurrence: true
+
+class InsertAtEndOfOccurrenceInAFunctionOrInnerParagraph extends InsertAtEndOfTarget
+  @extend()
+  target: "AFunctionOrInnerParagraph"
+  withOccurrence: true
+
 # Alias for backward compatibility
 class InsertAtEndOfSelection extends InsertAtEndOfTarget
   @extend()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -21,9 +21,9 @@ class TransformString extends Operator
   @registerToSelectList: ->
     transformerRegistry.push(this)
 
-  mutateSelection: (selection) ->
-    text = @getNewText(selection.getText(), selection)
-    selection.insertText(text, {@autoIndent})
+  mutateSelection: (selection, stopMutation) ->
+    if text = @getNewText(selection.getText(), selection, stopMutation)
+      selection.insertText(text, {@autoIndent})
 
 class ToggleCase extends TransformString
   @extend()
@@ -407,7 +407,7 @@ class SurroundSmartWord extends Surround
 class MapSurround extends Surround
   @extend()
   @description: "Surround each word(`/\w+/`) within target"
-  withOccurrence: true
+  occurrence: true
   patternForOccurence: /\w+/g
 
 class DeleteSurround extends Surround

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -282,6 +282,10 @@ class SelectOccurrenceInARangeMarker extends SelectOccurrence
   @extend()
   target: "ARangeMarker"
 
+class SelectOccurrenceInAFunctionOrInnerParagraph extends SelectOccurrence
+  @extend()
+  target: "AFunctionOrInnerParagraph"
+
 # Range Marker
 # =========================
 class CreateRangeMarker extends Operator
@@ -365,6 +369,11 @@ class DeleteLine extends Delete
   execute: ->
     @vimState.activate('visual', 'linewise')
     super
+
+class DeleteOccurrenceInAFunctionOrInnerParagraph extends Delete
+  @extend()
+  withOccurrence: true
+  target: "AFunctionOrInnerParagraph"
 
 # Yank
 # =========================

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -99,6 +99,10 @@ module.exports = new Settings 'vim-mode-plus',
     type: 'boolean'
     default: false
     description: "Don't move cursor after TransformString e.g Toggle, Surround"
+  # stayOnIncrease:
+  #   type: 'boolean'
+  #   default: false
+  #   description: "Don't move cursor after Increase/Decrease `ctrl-a` or `ctrl-x`"
   stayOnYank:
     type: 'boolean'
     default: false

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -20,6 +20,7 @@ globalState = require './global-state'
   getWordRegExpForPointWithCursor
   getStartPositionForPattern
   getEndPositionForPattern
+  getVisibleBufferRange
 } = require './utils'
 
 class TextObject extends Base
@@ -839,6 +840,28 @@ class ARangeMarker extends RangeMarker
 class InnerRangeMarker extends RangeMarker
   @extend()
 
+# -------------------------
+class VisibleArea extends TextObject # 822 to 863
+  @extend(false)
+
+  getRange: (selection) ->
+    range = getVisibleBufferRange(selection.editor)
+    # [BUG?] Need translate to shilnk top and bottom to fit actual row.
+    # The reason I need -2 at bottom is because of status bar?
+    range.translate([+1, 0], [-3, 0])
+
+  selectTextObject: (selection) ->
+    range = @getRange(selection)
+    console.log range.toString()
+    swrap(selection).setBufferRangeSafely(range)
+
+class AVisibleArea extends VisibleArea
+  @extend()
+
+class InnerVisibleArea extends VisibleArea
+  @extend()
+
+# -------------------------
 # [TODO] This class expects member have "getRange = (selection) ->" method
 class UnionTextObject extends TextObject
   @extend(false)
@@ -862,6 +885,7 @@ class AFunctionOrInnerParagraph extends UnionTextObject
   @extend()
   member: ['AFunction', 'InnerParagraph']
 
+# -------------------------
 class SomeTextObject extends TextObject
   @extend(false)
   member: []

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -624,6 +624,15 @@ getCurrentWordBufferRangeAndKind = (cursor) ->
   range = cursor.getCurrentWordBufferRange({wordRegex})
   {range, kind}
 
+getWordPatternAtCursor = (cursor) ->
+  editor = cursor.editor
+  {range, kind} = getCurrentWordBufferRangeAndKind(cursor)
+  cursorWord = editor.getTextInBufferRange(range)
+  pattern = _.escapeRegExp(cursorWord)
+  if kind is 'word'
+    pattern = "\\b" + pattern + "\\b"
+  new RegExp(pattern, 'g')
+
 scanInRanges = (editor, pattern, scanRanges) ->
   ranges = []
   for scanRange in scanRanges
@@ -790,6 +799,7 @@ module.exports = {
   isSurroundedBySpace
   isSingleLine
   getCurrentWordBufferRangeAndKind
+  getWordPatternAtCursor
   scanInRanges
   isRangeContainsSomePoint
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -42,7 +42,7 @@ debug = (messages...) ->
     when 'file'
       filePath = fs.normalize settings.get('debugOutputFilePath')
       if fs.existsSync(filePath)
-        fs.appendFileSync filePath, messages
+        fs.appendFileSync filePath, messages + "\n"
 
 getView = (model) ->
   atom.views.getView(model)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -458,9 +458,9 @@ getCodeFoldRowRangesContainesForRow = (editor, bufferRow, exclusive=false) ->
       startRow <= bufferRow <= endRow
 
 getBufferRangeForRowRange = (editor, rowRange) ->
-  [rangeStart, rangeEnd] = rowRange.map (row) ->
+  [startRange, endRange] = rowRange.map (row) ->
     editor.bufferRangeForBufferRow(row, includeNewline: true)
-  rangeStart.union(rangeEnd)
+  startRange.union(endRange)
 
 getTokenizedLineForRow = (editor, row) ->
   editor.tokenizedBuffer.tokenizedLineForRow(row)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -377,12 +377,10 @@ class VimState
   hasRegisterName: ->
     @register.hasName()
 
-  setOccurrenceForNextOperation: ->
+  setOccurrenceForNextOperation: (patternForOccurence=null) ->
     scope = "occurrence-pending"
-    patternForOccurence = null
-    if @isMode('visual')
-      if text = @editor.getSelectedText()
-        patternForOccurence = new RegExp(_.escapeRegExp(text), 'g')
+    if not patternForOccurence? and @isMode('visual') and text = @editor.getSelectedText()
+      patternForOccurence = new RegExp(_.escapeRegExp(text), 'g')
       @activate('normal')
 
     @onDidPushOperation (operation) =>

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -378,10 +378,14 @@ class VimState
     @register.hasName()
 
   setOccurrenceForNextOperation: ->
+    scope = "occurrence-pending"
+
     @onDidPushOperation (operation) =>
-      console.log "PUSHED", operation.getName()
+      console.log "pushed", operation.getName(), 'isOperator? =', operation.isOperator()
+      @toggleClassList(scope, false)
       if operation.isOperator()
-        console.log "SET!"
+        console.log '-- [boocked] setOperatorModifier'
         @operationStack.setOperatorModifier(occurrence: true)
 
-    @operationStack.highlightOccurrence()
+    @toggleClassList(scope, true)
+    @operationStack.highlightOccurrenceIfNecessary()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -94,9 +94,6 @@ class VimState
   selectLinewise: ->
     swrap.expandOverLine(@editor, preserveGoalColumn: true)
 
-  setOperatorModifier: (modifier) ->
-    @operationStack.setOperatorModifier(modifier)
-
   # Mark
   # -------------------------
   startCharInput: (@charInputAction) ->
@@ -151,6 +148,7 @@ class VimState
   onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
 
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)
+  onDidPushOperation: (fn) -> @subscribe @emitter.on('did-push-operation', fn)
 
   # Select list view
   onDidConfirmSelectList: (fn) -> @subscribe @emitter.on('did-confirm-select-list', fn)
@@ -373,3 +371,17 @@ class VimState
       rangeMarker.destroy()
     @rangeMarkers = []
     @toggleClassList('with-range-marker', @hasRangeMarkers())
+
+  # Occurrence request for next operation
+  # -------------------------
+  hasRegisterName: ->
+    @register.hasName()
+
+  setOccurrenceForNextOperation: ->
+    @onDidPushOperation (operation) =>
+      console.log "PUSHED", operation.getName()
+      if operation.isOperator()
+        console.log "SET!"
+        @operationStack.setOperatorModifier(occurrence: true)
+
+    @operationStack.highlightOccurrence()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -379,13 +379,22 @@ class VimState
 
   setOccurrenceForNextOperation: ->
     scope = "occurrence-pending"
+    patternForOccurence = null
+    if @isMode('visual')
+      if text = @editor.getSelectedText()
+        patternForOccurence = new RegExp(_.escapeRegExp(text), 'g')
+      @activate('normal')
 
     @onDidPushOperation (operation) =>
       console.log "pushed", operation.getName(), 'isOperator? =', operation.isOperator()
-      @toggleClassList(scope, false)
       if operation.isOperator()
+        operation.patternForOccurence = patternForOccurence if patternForOccurence?
         console.log '-- [boocked] setOperatorModifier'
         @operationStack.setOperatorModifier(occurrence: true)
 
+    @subscribe new Disposable =>
+      @toggleClassList(scope, false)
+
+
     @toggleClassList(scope, true)
-    @operationStack.highlightOccurrenceIfNecessary()
+    @operationStack.highlightOccurrenceIfNecessary(patternForOccurence)

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -279,21 +279,21 @@ describe "Motion Search", ->
         cursorBuffer: [0, 0]
 
     describe "as a motion", ->
-      it "moves cursor to next occurence of word under cursor", ->
+      it "moves cursor to next occurrence of word under cursor", ->
         ensure '*', cursorBuffer: [2, 0]
 
       it "repeats with the n key", ->
         ensure '*', cursorBuffer: [2, 0]
         ensure 'n', cursorBuffer: [0, 0]
 
-      it "doesn't move cursor unless next occurence is the exact word (no partial matches)", ->
+      it "doesn't move cursor unless next occurrence is the exact word (no partial matches)", ->
         set
           text: "abc\ndef\nghiabc\njkl\nabcdef"
           cursorBuffer: [0, 0]
         ensure '*', cursorBuffer: [0, 0]
 
       describe "with words that contain 'non-word' characters", ->
-        it "moves cursor to next occurence of word under cursor", ->
+        it "moves cursor to next occurrence of word under cursor", ->
           set
             text: """
             abc
@@ -390,7 +390,7 @@ describe "Motion Search", ->
 
   describe "the hash keybinding", ->
     describe "as a motion", ->
-      it "moves cursor to previous occurence of word under cursor", ->
+      it "moves cursor to previous occurrence of word under cursor", ->
         set
           text: "abc\n@def\nabc\ndef\n"
           cursorBuffer: [2, 1]
@@ -404,14 +404,14 @@ describe "Motion Search", ->
         ensure 'n', cursorBuffer: [4, 0]
         ensure 'n', cursorBuffer: [2, 0]
 
-      it "doesn't move cursor unless next occurence is the exact word (no partial matches)", ->
+      it "doesn't move cursor unless next occurrence is the exact word (no partial matches)", ->
         set
           text: "abc\ndef\nghiabc\njkl\nabcdef"
           cursorBuffer: [0, 0]
         ensure '#', cursorBuffer: [0, 0]
 
       describe "with words that containt 'non-word' characters", ->
-        it "moves cursor to next occurence of word under cursor", ->
+        it "moves cursor to next occurrence of word under cursor", ->
           set
             text: "abc\n@def\nabc\n@def\n"
             cursorBuffer: [3, 0]

--- a/spec/operator-increase-spec.coffee
+++ b/spec/operator-increase-spec.coffee
@@ -16,7 +16,13 @@ describe "Operator Increase", ->
   describe "the ctrl-a/ctrl-x keybindings", ->
     beforeEach ->
       set
-        text: '123\nab45\ncd-67ef\nab-5\na-bcdef'
+        text: """
+        123
+        ab45
+        cd-67ef
+        ab-5
+        a-bcdef
+        """
         cursorBuffer: [[0, 0], [1, 0], [2, 0], [3, 3], [4, 0]]
 
     describe "increasing numbers", ->

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1457,7 +1457,7 @@ describe "TextObject", ->
             4 abc
             """
     describe 'as operator target', ->
-      it 'delete next occurence of last search pattern', ->
+      it 'delete next occurrence of last search pattern', ->
         ensure 'd g n',
           cursor: [1, 2]
           mode: 'normal'
@@ -1488,7 +1488,7 @@ describe "TextObject", ->
             3 xxx_
             4 \n
             """
-      it 'change next occurence of last search pattern', ->
+      it 'change next occurrence of last search pattern', ->
         ensure 'c g n',
           cursor: [1, 2]
           mode: 'insert'

--- a/styles/vim-mode-plus-icons.less
+++ b/styles/vim-mode-plus-icons.less
@@ -42,7 +42,7 @@
 .oc(yank,        f035);
 .oc(delete,      f081);
 .oc(replace,     f0d2);
-.oc(occurence,   f04e);
+.oc(occurrence,   f04e);
 .fa(mark,        f041);
 .fa(indent,      f101);
 .fa(outdent,     f100);


### PR DESCRIPTION
PR for #385


- [x] Move highlight occurrence logic to operationStack.
- [x] store oprationStack the special instruction(request) for next operation.
- [x] operationStack pops the request(if exsit), and apply to operator processed.
- [x] highlight occurrence should be happened **immediately** on request is pushed(subscribed) and request have occurrence instruction(save markers to clear on next operation finished).
- [x] If operation executed at **next** was motion, just simply pop and ignore(don't apply request)
- [x] let incremental-search allows to set `patternForOccurrence`. new command `set-occurrence-for-next-operation-from-search`. keymap to `ctrl-cmd-o`?
- [x] take visual-mode's selected text as `patternForOccurrence`
- [x] set `occurrence-pending` scope to `editorElement`.
- [x] create TextObject `AFunctionOrInnerParagraph` which try to find `a-function` , `inner-pargraph` in sequence.
- [x] keymap in `occurrence-pending` scpe, from `I`, `A` to `insert-at-start(or end)-of-a-function-or-inner-pargraph` which allows you to use `I` and `A` to insert at occurrence. EXPERIMENTAL
- [ ] evaluate making `occurrence-pending` is as submode of `normal-mode`?
- [ ] also evaluate `with-occurrence` is as submode of `operator-pending` so that ensuring scope reset, disposing in `modeManager.dactivate()` phase.
- [x] fix occurr marker should respect patternForOccurrence when invoked from search