### PR TITLE
split-out hlseyrch management

### DIFF
--- a/lib/highlight-search-manager.coffee
+++ b/lib/highlight-search-manager.coffee
@@ -1,0 +1,48 @@
+{CompositeDisposable} = require 'atom'
+{scanEditor, matchScopes} = require './utils'
+settings = require './settings'
+
+# General purpose utility class to make Atom's marker management easier.
+module.exports =
+class HighlightSearchManager
+  patterns: null
+
+  constructor: (@vimState) ->
+    {@editor, @editorElement} = @vimState
+    @disposables = new CompositeDisposable
+    @disposables.add @vimState.onDidDestroy(@destroy.bind(this))
+    @patterns = []
+
+    @markerLayer = @editor.addMarkerLayer()
+    options =
+      type: 'highlight'
+      invalidate: 'inside'
+      class: 'vim-mode-plus-highlight-search'
+    @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, options)
+
+  destroy: ->
+    @decorationLayer.destroy()
+    @disposables.dispose()
+    @markerLayer.destroy()
+
+  # Markers
+  # -------------------------
+  hasMarkers: ->
+    @markerLayer.getMarkerCount() > 0
+
+  getMarkers: ->
+    @markerLayer.getMarkers()
+
+  clearMarkers: ->
+    marker.destroy() for marker in @markerLayer.getMarkers()
+
+  refresh: ->
+    @clearMarkers()
+    if matchScopes(@editorElement, settings.get('highlightSearchExcludeScopes'))
+      return
+
+    unless settings.get('highlightSearch') and @vimState.main.highlightSearchPattern?
+      return
+
+    for range in scanEditor(@editor, @vimState.main.highlightSearchPattern)
+      @markerLayer.markBufferRange(range)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,7 +24,6 @@ module.exports =
     @registerCommands()
     @registerVimStateCommands()
 
-
     if atom.inDevMode()
       developer = (new (require './developer'))
       @subscribe(developer.init(service))
@@ -49,7 +48,7 @@ module.exports =
         @vimStatesByEditor.delete(editor)
 
       editorSubscriptions.add editor.onDidStopChanging ->
-        vimState.refreshHighlightSearch()
+        vimState.highlightSearch.refresh()
       @subscribe(editorSubscriptions)
       @emitter.emit('did-add-vim-state', vimState)
 
@@ -57,7 +56,7 @@ module.exports =
       if atom.workspace.isTextEditor(item)
         # Still there is possibility editor is destroyed and don't have corresponding
         # vimState #196.
-        @getEditorState(item)?.refreshHighlightSearch()
+        @getEditorState(item)?.highlightSearch.refresh()
 
     workspaceClassList = atom.views.getView(atom.workspace).classList
     @subscribe atom.workspace.onDidChangeActivePane ->
@@ -97,11 +96,11 @@ module.exports =
 
   refreshHighlightSearchForVisibleEditors: ->
     for editor in getVisibleEditors()
-      @getEditorState(editor).refreshHighlightSearch()
+      @getEditorState(editor).highlightSearch.refresh()
 
   clearHighlightSearchForEditors: ->
     for editor in atom.workspace.getTextEditors()
-      @getEditorState(editor).clearHighlightSearch()
+      @getEditorState(editor).highlightSearch.clearMarkers()
     @highlightSearchPattern = null
 
   clearRangeMarkerForEditors: ->

--- a/lib/occurrence-manager.coffee
+++ b/lib/occurrence-manager.coffee
@@ -17,6 +17,7 @@ class OccurrenceManager
     options = {type: 'highlight', class: 'vim-mode-plus-occurrence-match'}
     @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, options)
 
+    # @patterns is single source of truth (SSOT)
     # All maker create/destroy/css-update is done by reacting @patters's change.
     # -------------------------
     @onDidChangePatterns ({newPattern}) =>

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -234,7 +234,7 @@ describe "Motion Search", ->
         editor.getTextInBufferRange(marker.getBufferRange())
 
       ensureHightlightSearch = (options) ->
-        markers = vimState.getHighlightSearch()
+        markers = vimState.highlightSearch.getMarkers()
         if options.length?
           expect(markers).toHaveLength(options.length)
 
@@ -248,14 +248,14 @@ describe "Motion Search", ->
       beforeEach ->
         jasmine.attachToDOM(getView(atom.workspace))
         settings.set('highlightSearch', true)
-        expect(vimState.hasHighlightSearch()).toBe(false)
+        expect(vimState.highlightSearch.hasMarkers()).toBe(false)
         ensure ['/', search: 'def'], cursor: [1, 0]
 
       describe "clearHighlightSearch command", ->
         it "clear highlightSearch marker", ->
           ensureHightlightSearch length: 2, text: ["def", "def"], mode: 'normal'
           dispatch(editorElement, 'vim-mode-plus:clear-highlight-search')
-          expect(vimState.hasHighlightSearch()).toBe(false)
+          expect(vimState.highlightSearch.hasMarkers()).toBe(false)
 
       describe "clearHighlightSearchOnResetNormalMode", ->
         describe "default setting", ->
@@ -269,7 +269,7 @@ describe "Motion Search", ->
             settings.set('clearHighlightSearchOnResetNormalMode', true)
             ensureHightlightSearch length: 2, text: ["def", "def"], mode: 'normal'
             dispatch(editorElement, 'vim-mode-plus:reset-normal-mode')
-            expect(vimState.hasHighlightSearch()).toBe(false)
+            expect(vimState.highlightSearch.hasMarkers()).toBe(false)
             ensure mode: 'normal'
 
   describe "the * keybinding", ->


### PR DESCRIPTION
No longer use visibleArea only rendering.
Create markers against whole buffer.

Which impact performance?
Not sure but I don’t think so,
Native displayLayer and marker management effectively rendering decoration only when it’s needed.
