### PR TITLE
preset-occurrence continue visual-mode when is-narrowed

### DIFF
--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -141,8 +141,9 @@ class Operator extends Base
 
   addOccurrencePattern: (pattern=null) ->
     pattern ?= @patternForOccurrence
-    point = @editor.getCursorBufferPosition()
-    pattern ?= getWordPatternAtBufferPosition(@editor, point, singleNonWordChar: true)
+    unless pattern?
+      point = @editor.getCursorBufferPosition()
+      pattern = getWordPatternAtBufferPosition(@editor, point, singleNonWordChar: true)
     @occurrenceManager.addPattern(pattern)
 
   resetOccurrencePatterns: ->
@@ -364,10 +365,17 @@ class PresetOccurrence extends Operator
       marker.destroy()
     else
       pattern = null
-      if @isMode('visual') and text = @editor.getSelectedText()
-        pattern = new RegExp(_.escapeRegExp(text), 'g')
+      if @isMode('visual')
+        if isNarrowed = @vimState.modeManager.isNarrowed()
+          options = {fromProperty: true, allowFallback: true}
+          point = swrap(@editor.getLastSelection()).getBufferPositionFor('head', options)
+          pattern = getWordPatternAtBufferPosition(@editor, point, singleNonWordChar: true)
+        else
+          text = @editor.getSelectedText()
+          pattern = new RegExp(_.escapeRegExp(text), 'g')
+
       @addOccurrencePattern(pattern)
-      @activateMode('normal')
+      @activateMode('normal') unless isNarrowed
 
 # Delete
 # ================================

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -539,6 +539,28 @@ describe "Occurrence", ->
           it 'set selected-text as preset occurrence marker and not move cursor', ->
             ensure 'w v l', mode: ['visual', 'characterwise'], selectedText: 'te'
             ensure 'g o', mode: 'normal', occurrenceText: ['te', 'te', 'te']
+        describe "is-narrowed selection", ->
+          [textOriginal] = []
+          beforeEach ->
+            textOriginal = """
+              This text have 3 instance of 'text' in the whole text
+              This text have 3 instance of 'text' in the whole text
+              """
+            set
+              cursor: [0, 0]
+              text: textOriginal
+          it "pick ocurrence-word from cursor position and continue visual-mode", ->
+            ensure 'w V j', mode: ['visual', 'linewise'], selectedText: textOriginal
+            ensure 'g o',
+              mode: ['visual', 'linewise']
+              selectedText: textOriginal
+              occurrenceText: ['text', 'text', 'text', 'text', 'text', 'text']
+            ensure ['r', input: '!'],
+              mode: 'normal'
+              text: """
+              This !!!! have 3 instance of '!!!!' in the whole !!!!
+              This !!!! have 3 instance of '!!!!' in the whole !!!!
+              """
 
       describe "in incremental-search", ->
         [searchEditor, searchEditorElement] = []


### PR DESCRIPTION
:gift:
preset-occurrence continue visual-mode when is-narrowed

is-narrowed selection specific behavior.
is-narrowed selection is multi-line selection(currently).

- not-narrowed selection(single line selection)
  - pick occurrence pattern from selected text.
  - return to `normal-mode`

- narrowed selection
  - pick occurrence pattern from selected text.
  - not return to `normal-mode`(continue `visual-mode`).

## What we can do?

Visual-mode is the way to specify manually specify arbitrary range of target.
Operator is applied to occurrence-marker intersecting target(in this case, target is selection).
Preset-occurrence maker is good friendship with visual-mode.

Following gif is doing.
1. `v` start `visual-mode`
2. While moving around by extending selected area, set `text` and `instance` as occurrence by `g o` on these words.
3. then I further extend selection area.
4. `U`(uppercase) is applied to the preset-occurrence-marked-text included in target(=selection).


![preset-occurrence-in-is-narrowed](https://cloud.githubusercontent.com/assets/155205/18892075/10234b26-8543-11e6-8a03-c8d16bd719bd.gif)


