### PR TITLE
Cleanup selection normalization

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -51,10 +51,14 @@
   'l': 'vim-mode-plus:move-right'
   'space': 'vim-mode-plus:move-right'
   'right': 'vim-mode-plus:move-right'
+
   'k': 'vim-mode-plus:move-up'
   'up': 'vim-mode-plus:move-up'
   'j': 'vim-mode-plus:move-down'
   'down': 'vim-mode-plus:move-down'
+
+  'g k': 'vim-mode-plus:move-screen-up'
+  'g j': 'vim-mode-plus:move-screen-down'
 
   'w': 'vim-mode-plus:move-to-next-word'
   # 'w':     'vim-mode-plus:move-to-next-alphanumeric-word'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -166,11 +166,12 @@ class Base
     new klass(@vimState, properties)
 
   clone: (vimState) ->
-    object = _.clone(this)
-    object.vimState = vimState
-    object.editor = vimState.editor
-    object.editorElement = vimState.editorElement
-    object
+    properties = {}
+    excludeProperties = ['editor', 'editorElement', 'globalState']
+    for own key, value of this when key not in excludeProperties
+      properties[key] = value
+    klass = this.constructor
+    new klass(vimState, properties)
 
   cancelOperation: ->
     @vimState.operationStack.cancel()

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -19,8 +19,8 @@ getOffset = (submode, cursor, isSoftWrapped) ->
       if not selection.isReversed() and not cursor.isAtBeginningOfLine()
         traversal.column -= 1
     when 'linewise'
-      bufferPoint = swrap(selection).getCharacterwiseHeadPosition()
-      # FIXME need to update original getCharacterwiseHeadPosition?
+      bufferPoint = swrap(selection).getBufferPositionFor('head', fromProperty: true)
+      # FIXME need to update original selection property?
       # to reflect outer vmp command modify linewise selection?
       [startRow, endRow] = selection.getBufferRowRange()
       if selection.isReversed()

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -131,14 +131,15 @@ class ModeManager
   # -------------------------
   # At this point @submode is not yet updated to final submode.
   activateVisualMode: (submode) ->
-    if @submode?
-      @normalizeSelections(normalizeEndPosition: false)
-    else
-      if @editor.getLastSelection().isEmpty()
-        for selection in @editor.getSelections()
-          swrap(selection).translateSelectionEndAndClip('forward')
+    @normalizeSelections() if @submode?
 
-    swrap.updateSelectionProperties(@editor, unknownOnly: true)
+    # We only select-forwad only when
+    #  -  submode shift(@submode? is true)
+    #  -  initial activation(@submode? is false) and selection was empty.
+    for selection in @editor.getSelections() when @submode? or selection.isEmpty()
+      swrap(selection).translateSelectionEndAndClip('forward')
+
+    @vimState.updateSelectionProperties()
 
     switch submode
       when 'linewise'
@@ -166,7 +167,6 @@ class ModeManager
 
     if normalizeEndPosition ? true
       swrap.clearProperties(@editor)
-      # for selection in @editor.getSelections() when swrap(selection).isForwarding()
       for selection in @editor.getSelections() when not selection.isEmpty()
         swrap(selection).translateSelectionEndAndClip('backward')
 

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -152,7 +152,7 @@ class ModeManager
       selection.clear(autoscroll: false) for selection in @editor.getSelections()
       @updateNarrowedState(false)
 
-  normalizeSelections: ({normalizeEndPosition}={}) ->
+  normalizeSelections: ->
     switch @submode
       when 'characterwise'
         null
@@ -165,10 +165,9 @@ class ModeManager
           bs.restoreCharacterwise()
         @vimState.clearBlockwiseSelections()
 
-    if normalizeEndPosition ? true
-      swrap.clearProperties(@editor)
-      for selection in @editor.getSelections() when not selection.isEmpty()
-        swrap(selection).translateSelectionEndAndClip('backward')
+    swrap.clearProperties(@editor)
+    for selection in @editor.getSelections() when not selection.isEmpty()
+      swrap(selection).translateSelectionEndAndClip('backward')
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -133,9 +133,10 @@ class ModeManager
   activateVisualMode: (submode) ->
     if @submode?
       @selectCharacterwise()
-    else if @editor.getLastSelection().isEmpty()
-      for selection in @editor.getSelections()
-        swrap(selection).translateSelectionEndAndClip('forward')
+    else
+      if @editor.getLastSelection().isEmpty()
+        for selection in @editor.getSelections()
+          swrap(selection).translateSelectionEndAndClip('forward')
 
     swrap.updateSelectionProperties(@editor, unknownOnly: true)
 
@@ -164,10 +165,8 @@ class ModeManager
   normalizeSelections: ->
     @selectCharacterwise()
     swrap.clearProperties(@editor)
-
-    # We selectRight()ed in visual-mode, so reset this effect here.
     for selection in @editor.getSelections() when swrap(selection).isForwarding()
-      swrap(selection).translateSelectionEndAndClip('backward')
+      swrap(selection).translateSelectionEndAndClip('backward', hello: 'normalize!')
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -132,7 +132,7 @@ class ModeManager
   # At this point @submode is not yet updated to final submode.
   activateVisualMode: (submode) ->
     if @submode?
-      @selectCharacterwise()
+      @normalizeSelections(normalizeEndPosition: false)
     else
       if @editor.getLastSelection().isEmpty()
         for selection in @editor.getSelections()
@@ -151,8 +151,10 @@ class ModeManager
       selection.clear(autoscroll: false) for selection in @editor.getSelections()
       @updateNarrowedState(false)
 
-  selectCharacterwise: ->
+  normalizeSelections: ({normalizeEndPosition}={})->
     switch @submode
+      when 'characterwise'
+        null
       when 'linewise'
         for selection in @editor.getSelections() when not selection.isEmpty()
           swrap(selection).normalize()
@@ -162,11 +164,10 @@ class ModeManager
           bs.restoreCharacterwise()
         @vimState.clearBlockwiseSelections()
 
-  normalizeSelections: ->
-    @selectCharacterwise()
-    swrap.clearProperties(@editor)
-    for selection in @editor.getSelections() when swrap(selection).isForwarding()
-      swrap(selection).translateSelectionEndAndClip('backward', hello: 'normalize!')
+    if normalizeEndPosition ? true
+      swrap.clearProperties(@editor)
+      for selection in @editor.getSelections() when swrap(selection).isForwarding()
+        swrap(selection).translateSelectionEndAndClip('backward', hello: 'normalize!')
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -158,8 +158,11 @@ class ModeManager
         null
       when 'linewise'
         for selection in @editor.getSelections() when not selection.isEmpty()
+          # console.log 'before restore column', selection.getBufferRange().toString()
           swrap(selection).restoreColumnFromProperties()
+          # console.log 'restored column', selection.getBufferRange().toString()
           swrap(selection).translateSelectionEndAndClip('forward')
+          # console.log 'clip forwarded', selection.getBufferRange().toString()
       when 'blockwise'
         for bs in @vimState.getBlockwiseSelections()
           bs.restoreCharacterwise()
@@ -167,7 +170,9 @@ class ModeManager
 
     swrap.clearProperties(@editor)
     for selection in @editor.getSelections() when not selection.isEmpty()
+
       swrap(selection).translateSelectionEndAndClip('backward')
+      # console.log 'clip backwarded', selection.getBufferRange().toString()
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -151,7 +151,7 @@ class ModeManager
       selection.clear(autoscroll: false) for selection in @editor.getSelections()
       @updateNarrowedState(false)
 
-  normalizeSelections: ({normalizeEndPosition}={})->
+  normalizeSelections: ({normalizeEndPosition}={}) ->
     switch @submode
       when 'characterwise'
         null
@@ -166,8 +166,9 @@ class ModeManager
 
     if normalizeEndPosition ? true
       swrap.clearProperties(@editor)
-      for selection in @editor.getSelections() when swrap(selection).isForwarding()
-        swrap(selection).translateSelectionEndAndClip('backward', hello: 'normalize!')
+      # for selection in @editor.getSelections() when swrap(selection).isForwarding()
+      for selection in @editor.getSelections() when not selection.isEmpty()
+        swrap(selection).translateSelectionEndAndClip('backward')
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -158,7 +158,7 @@ class ModeManager
         null
       when 'linewise'
         for selection in @editor.getSelections() when not selection.isEmpty()
-          swrap(selection).normalize()
+          swrap(selection).restoreColumnFromProperties()
           swrap(selection).translateSelectionEndAndClip('forward')
       when 'blockwise'
         for bs in @vimState.getBlockwiseSelections()

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -169,7 +169,7 @@ class ModeManager
     for selection in selections when swrap(selection).isForwarding()
       selection.modifySelection ->
         # [FIXME] SCATTERED_CURSOR_ADJUSTMENT
-        moveCursorLeft(selection.cursor, {allowWrap: true, preserveGoalColumn: true})
+        moveCursorLeft(selection.cursor, allowWrap: true, preserveGoalColumn: true)
 
   # Narrow to selection
   # -------------------------

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -90,13 +90,15 @@ class Motion extends Base
 
     selection.modifySelection =>
       @moveCursor(cursor)
-      
+
+    return if not @isMode('visual') and selection.isEmpty() # Failed to move.
     return unless @isInclusive() or @isLinewise()
-    return if not @isMode('visual') and selection.isEmpty()
 
     if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
+      # Avoid puting cursor on EOL in visual-mode as long as cursor's row was non-empty.
       swrap(selection).translateSelectionHeadAndClip('backward')
-    swrap(selection).translateSelectionEndAndClip('forward')
+
+    swrap(selection).translateSelectionEndAndClip('forward') # @inclusive effect
 
 # Used as operator's target in visual-mode.
 class CurrentSelection extends Motion

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -77,11 +77,10 @@ class Motion extends Base
 
   modifySelections: (fn) ->
     wasVisual = @isMode('visual')
-    console.log 'b', @editor.getCursorBufferPosition()
+    # console.log 'b', @editor.getCursorBufferPosition()
     @vimState.modeManager.normalizeSelections() if wasVisual
-    console.log 'a', @editor.getCursorBufferPosition()
-    # console.log 'before', @editor.getLastSelection().getText(), getLengthForRange(@editor.getSelectedBufferRange())
-    console.log @editor.getLastSelection().isEmpty()
+    # console.log 'a', @editor.getCursorBufferPosition()
+    # console.log @editor.getLastSelection().isEmpty()
 
     fn()
 
@@ -120,24 +119,23 @@ class Motion extends Base
   selectInclusively: (selection) ->
     {cursor} = selection
     originalPoint = cursor.getBufferPosition()
-    # save tailRange(range under cursor) before we start to modify selection
     tailRange = swrap(selection).getTailBufferRange()
 
     selection.modifySelection =>
       @moveCursor(cursor)
 
     cursorMoved = not cursor.getBufferPosition().isEqual(originalPoint)
+    return unless cursorMoved or @isMode('visual')
 
     if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
       swrap(selection).translateSelectionEndAndClip('backward')
 
-    if @isMode('visual') or cursorMoved
-      unless selection.isReversed()
-        # When cursor is at empty row, we allow to wrap to next line
-        # since when we `v`, we have to select line.
-        swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
+    unless selection.isReversed()
+      # When cursor is at empty row, we allow to wrap to next line
+      # since when we `v`, we have to select line.
+      swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
 
-      swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
+    swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
 
 
 # Used as operator's target in visual-mode.

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -86,9 +86,6 @@ class Motion extends Base
 
     # Update characterwise properties on each movement.
     if @isMode('visual')
-      Select ?= Base.getClass('Select')
-      unless @getOperator() instanceof Select
-        debug "= updating: #{@getOperator()?.toString()}"
       @updateSelectionProperties()
 
     switch

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -33,6 +33,7 @@ Select = null
   debug
 } = require './utils'
 
+swrap = require './selection-wrapper'
 {MatchList} = require './match'
 settings = require './settings'
 Base = require './base'

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -1277,19 +1277,3 @@ class MoveToPair extends Motion
         enclosingRange.containsRange(range)
 
     forwardingRanges[0]?.end.translate([0, -1]) or enclosingRange?.start
-
-class MoveThreeColumnRight extends Motion
-  @extend()
-  inclusive: true
-  moveCursor: (cursor) ->
-    point = cursor.getBufferPosition()
-    newPoint = point.translate([0, 3])
-    cursor.setBufferPosition(newPoint)
-
-class MoveThreeColumnLeft extends Motion
-  @extend()
-  inclusive: true
-  moveCursor: (cursor) ->
-    point = cursor.getBufferPosition()
-    newPoint = point.translate([0, -3])
-    cursor.setBufferPosition(newPoint)

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -33,10 +33,6 @@ Select = null
   debug
 } = require './utils'
 
-getLengthForRange = (range) ->
-  Range.fromObject(range).getExtent().toString()
-
-swrap = require './selection-wrapper'
 {MatchList} = require './match'
 settings = require './settings'
 Base = require './base'

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -94,8 +94,8 @@ class Motion extends Base
     if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
       # Avoid puting cursor on EOL in visual-mode as long as cursor's row was non-empty.
       swrap(selection).translateSelectionHeadAndClip('backward')
-
-    swrap(selection).translateSelectionEndAndClip('forward') # @inclusive effect
+    # to select @inclusive-ly
+    swrap(selection).translateSelectionEndAndClip('forward')
 
 # Used as operator's target in visual-mode.
 class CurrentSelection extends Motion

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -124,20 +124,18 @@ class Motion extends Base
     tailRange = swrap(selection).getTailBufferRange()
     selection.modifySelection =>
       @moveCursor(cursor)
+      cursorMoved = not cursor.getBufferPosition().isEqual(originalPoint)
 
-      if @isMode('visual')
-        if cursorIsAtEndOfLineAtNonEmptyRow(cursor)
-          swrap(selection).translateSelectionEndAndClip('backward')
-      else
-        # Return here because no movement was happend, nothing to do.
-        return if cursor.getBufferPosition().isEqual(originalPoint)
+      if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
+        swrap(selection).translateSelectionEndAndClip('backward')
 
-      unless selection.isReversed()
-        # When cursor is at empty row, we allow to wrap to next line
-        # since when we `v`, we have to select line.
-        swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
+      if @isMode('visual') or cursorMoved
+        unless selection.isReversed()
+          # When cursor is at empty row, we allow to wrap to next line
+          # since when we `v`, we have to select line.
+          swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
 
-      swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
+        swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
 
 
 # Used as operator's target in visual-mode.

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -122,20 +122,22 @@ class Motion extends Base
     originalPoint = cursor.getBufferPosition()
     # save tailRange(range under cursor) before we start to modify selection
     tailRange = swrap(selection).getTailBufferRange()
+
     selection.modifySelection =>
       @moveCursor(cursor)
-      cursorMoved = not cursor.getBufferPosition().isEqual(originalPoint)
 
-      if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
-        swrap(selection).translateSelectionEndAndClip('backward')
+    cursorMoved = not cursor.getBufferPosition().isEqual(originalPoint)
 
-      if @isMode('visual') or cursorMoved
-        unless selection.isReversed()
-          # When cursor is at empty row, we allow to wrap to next line
-          # since when we `v`, we have to select line.
-          swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
+    if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
+      swrap(selection).translateSelectionEndAndClip('backward')
 
-        swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
+    if @isMode('visual') or cursorMoved
+      unless selection.isReversed()
+        # When cursor is at empty row, we allow to wrap to next line
+        # since when we `v`, we have to select line.
+        swrap(selection).translateSelectionEndAndClip('forward', hello: 'in select inclusive')
+
+      swrap(selection).mergeBufferRange(tailRange, {preserveFolds: true})
 
 
 # Used as operator's target in visual-mode.

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -894,7 +894,7 @@ class SearchBase extends Motion
 
   getFromPoint: (cursor) ->
     if @isMode('visual', 'linewise') and @isIncrementalSearch?()
-      swrap(cursor.selection).getCharacterwiseHeadPosition()
+      swrap(cursor.selection).getBufferPositionFor('head', fromProperty: true)
     else
       cursor.getBufferPosition()
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -433,8 +433,7 @@ class MoveToNextParagraph extends Motion
 
   getPoint: (fromPoint) ->
     wasAtNonBlankRow = not @editor.isBufferRowBlank(fromPoint.row)
-    options = {startRow: fromPoint.row, @direction, includeStartRow: false}
-    for row in getBufferRows(@editor, options)
+    for row in getBufferRows(@editor, {startRow: fromPoint.row, @direction})
       if @editor.isBufferRowBlank(row)
         return new Point(row, 0) if wasAtNonBlankRow
       else

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -78,7 +78,7 @@ class Motion extends Base
     @editor.mergeCursors()
     @editor.mergeIntersectingSelections()
 
-    swrap.updateSelectionProperties(@editor) if @isMode('visual')
+    @updateSelectionProperties() if @isMode('visual')
 
     # Modify selection to submode-wisely
     switch

--- a/lib/mutation-tracker.coffee
+++ b/lib/mutation-tracker.coffee
@@ -67,6 +67,10 @@ class MutationTracker
         ranges.push(range)
     ranges
 
+  restoreInitialPositions: ->
+    for selection in @editor.getSelections() when point = @getInitialPointForSelection(selection)
+      selection.setBufferPosition(point)
+
   restoreCursorPositions: (options) ->
     {stay, strict, clipToMutationEnd, isBlockwise, mutationEnd} = options
     if isBlockwise

--- a/lib/occurrence-manager.coffee
+++ b/lib/occurrence-manager.coffee
@@ -45,15 +45,9 @@ class OccurrenceManager
     @disposables.dispose()
     @markerLayer.destroy()
 
-  # return true if success
-  selectInRanges: (ranges, exclusive=false) ->
-    markers = @getMarkersIntersectsWithRanges(ranges, exclusive)
-    if markers.length
-      ranges = markers.map (marker) -> marker.getBufferRange()
-      @editor.setSelectedBufferRanges(ranges)
-      true
-    else
-      false
+  getMarkerRangesIntersectsWithRanges: (ranges, exclusive=false) ->
+    @getMarkersIntersectsWithRanges(ranges, exclusive).map (marker) ->
+      marker.getBufferRange()
 
   # Patterns
   hasPatterns: ->

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -87,13 +87,12 @@ class OperationStack
       else
         klass = Base.getClass(klass) if type is 'string'
         # Replace operator when identical one repeated, e.g. `dd`, `cc`, `gUgU`
-        klass = MoveToRelativeLine if (@peekTop()?.constructor is klass)
-
+        klass = MoveToRelativeLine if @peekTop()?.constructor is klass
         operation = new klass(@vimState, properties)
 
-        # Compliment implicit Select operator
-        if operation.isTextObject() and @mode isnt 'operator-pending' or operation.isMotion() and @mode is 'visual'
-          operation = new Select(@vimState).setTarget(operation)
+      # Compliment implicit Select operator
+      if operation.isTextObject() and @mode isnt 'operator-pending' or operation.isMotion() and @mode is 'visual'
+        operation = new Select(@vimState).setTarget(operation)
 
       if @isEmpty() or (@peekTop().isOperator() and operation.isTarget())
         @push(operation)

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -164,16 +164,6 @@ class InsertAtEndOfTarget extends InsertByTarget
   @extend()
   which: 'end'
 
-class InsertAtStartOfInnerCurrentLine extends InsertByTarget
-  @extend()
-  which: 'start'
-  target: "InnerCurrentLine"
-
-class InsertAtEndOfInnerCurrentLine extends InsertByTarget
-  @extend()
-  which: 'end'
-  target: "InnerCurrentLine"
-
 class InsertAtStartOfInnerSmartWord extends InsertByTarget
   @extend()
   which: 'start'

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -164,6 +164,16 @@ class InsertAtEndOfTarget extends InsertByTarget
   @extend()
   which: 'end'
 
+class InsertAtStartOfInnerCurrentLine extends InsertByTarget
+  @extend()
+  which: 'start'
+  target: "InnerCurrentLine"
+
+class InsertAtEndOfInnerCurrentLine extends InsertByTarget
+  @extend()
+  which: 'end'
+  target: "InnerCurrentLine"
+
 class InsertAtHeadOfTarget extends InsertByTarget
   @extend()
   which: 'head'

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -174,6 +174,16 @@ class InsertAtEndOfInnerCurrentLine extends InsertByTarget
   which: 'end'
   target: "InnerCurrentLine"
 
+class InsertAtStartOfInnerSmartWord extends InsertByTarget
+  @extend()
+  which: 'start'
+  target: "InnerSmartWord"
+
+class InsertAtEndOfInnerSmartWord extends InsertByTarget
+  @extend()
+  which: 'end'
+  target: "InnerSmartWord"
+
 class InsertAtHeadOfTarget extends InsertByTarget
   @extend()
   which: 'head'

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -203,7 +203,7 @@ class Operator extends Base
     @addOccurrencePattern() unless @occurrenceManager.hasMarkers()
 
     # To repoeat(`.`) operation where multiple occurrence patterns was set.
-    # Here we save patterns which resresent UNIONED regex which @occurrenceManager knows.
+    # Here we save patterns which resresent unioned regex which @occurrenceManager knows.
     @patternForOccurrence ?= @occurrenceManager.buildPattern()
 
     selectedRanges = @editor.getSelectedBufferRanges()
@@ -211,7 +211,7 @@ class Operator extends Base
       @vimState.modeManager.deactivate() if @isMode('visual')
       @editor.setSelectedBufferRanges(ranges)
     else
-      @mutationTracker.estoreInitialPositions() # Restoreing position also clear selection.
+      @mutationTracker.restoreInitialPositions() # Restoreing position also clear selection.
     @occurrenceManager.resetPatterns()
 
   # Return true unless all selection is empty.

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -568,6 +568,7 @@ class PutBefore extends Operator
       adjustCursor = (range) ->
         cursor.setBufferPosition(range.end.translate([0, -1]))
 
+    @setMarkForChange(newRange)
     if selectPastedText
       selection.setBufferRange(newRange)
     else

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -199,32 +199,19 @@ class Operator extends Base
     # we have to return to normal-mode from operator-pending or visual
     @activateMode('normal')
 
-  reselectOccurrence: (fn) ->
-    cursorPositionManager = new CursorPositionManager(@editor)
-    cursorPositionManager.save('head', fromProperty: true, allowFallback: true)
-
-    # This has to be BEFORE @target.select, to use CURRENT cursor position.
-    # to find occurrence-word.
+  selectOccurrence: ->
     @addOccurrencePattern() unless @occurrenceManager.hasMarkers()
 
-    fn()
-
-    @addOccurrencePattern() unless @occurrenceManager.hasMarkers()
-    scanRanges = @editor.getSelectedBufferRanges()
-    isVisual = @isMode('visual')
-    @vimState.modeManager.deactivate() if isVisual
-
-    if @occurrenceManager.selectInRanges(scanRanges, isVisual)
-      cursorPositionManager.destroy()
-    else
-      # Restoring cursor position also clear selection. Require to avoid unwanted mutation.
-      cursorPositionManager.restore()
-
-    # There is possibility that multiple markers are pre-setted manually.
-    # To repeat this multi pre-set occurrences by `.`, we consult manager to cache
-    # bundled(unioned) regex pattern to @patternForOccurrence.
+    # To repoeat(`.`) operation where multiple occurrence patterns was set.
+    # Here we save patterns which resresent UNIONED regex which @occurrenceManager knows.
     @patternForOccurrence ?= @occurrenceManager.buildPattern()
-    # We got ranges to select, so good-by @occurrenceManager by reset()
+
+    selectedRanges = @editor.getSelectedBufferRanges()
+    if ranges = @occurrenceManager.getMarkerRangesIntersectsWithRanges(selectedRanges, @isMode('visual'))
+      @vimState.modeManager.deactivate() if @isMode('visual')
+      @editor.setSelectedBufferRanges(ranges)
+    else
+      @mutationTracker.estoreInitialPositions() # Restoreing position also clear selection.
     @occurrenceManager.resetPatterns()
 
   # Return true unless all selection is empty.
@@ -236,11 +223,13 @@ class Operator extends Base
     @forceTargetWise() if @wise
     @emitWillSelectTarget()
 
+    # To use CURRENT cursor position, this has to be BEFORE @target.select() which move cursors.
+    if @isOccurrence() and not @occurrenceManager.hasMarkers()
+      @addOccurrencePattern()
+
+    @target.select()
     if @isOccurrence()
-      @reselectOccurrence =>
-        @target.select()
-    else
-      @target.select()
+      @selectOccurrence()
 
     isExplicitEmptyTarget = @target.getName() is "Empty"
     if haveSomeSelection(@editor) or isExplicitEmptyTarget

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -159,10 +159,9 @@ class SelectionWrapper
   getStartRow: -> @getRowFor('start')
   getEndRow: -> @getRowFor('end')
 
-  saveProperties: ({normalized}={}) ->
-    normalized ?= false
+  saveProperties: ->
     properties = @captureProperties()
-    unless @selection.isEmpty() or normalized
+    unless @selection.isEmpty()
       # We select righted in visual-mode, this translation de-effect select-right-effect
       # so that after restoring preserved poperty we can do activate-visual mode without
       # special care
@@ -173,7 +172,6 @@ class SelectionWrapper
       else
         properties.head = endPoint
 
-    properties.normalized = normalized
     @setProperties(properties)
 
   captureProperties: ->
@@ -193,7 +191,7 @@ class SelectionWrapper
     head.isGreaterThan(tail)
 
   normalize: ->
-    {head, tail, normalized} = @getProperties()
+    {head, tail} = @getProperties()
     return unless head? and tail?
     return if @selection.isEmpty()
 
@@ -204,8 +202,7 @@ class SelectionWrapper
     [start.row, end.row] = @selection.getBufferRowRange()
 
     {goalColumn} = @selection.cursor
-    unless normalized
-      end = translatePointAndClip(@selection.editor, end, 'backward', translate: false)
+    end = translatePointAndClip(@selection.editor, end, 'backward', translate: false)
     @setBufferRange([start, end], {preserveFolds: true})
     @selection.cursor.goalColumn = goalColumn if goalColumn?
 
@@ -300,10 +297,9 @@ swrap.detectVisualModeSubmode = (editor) ->
   else
     null
 
-swrap.updateSelectionProperties = (editor, options={}) ->
-  {unknownOnly, normalized} = options
+swrap.updateSelectionProperties = (editor, {unknownOnly}={}) ->
   for selection in editor.getSelections()
     continue if unknownOnly and swrap(selection).hasProperties()
-    swrap(selection).saveProperties({normalized})
+    swrap(selection).saveProperties()
 
 module.exports = swrap

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -159,8 +159,11 @@ class SelectionWrapper
   getStartRow: -> @getRowFor('start')
   getEndRow: -> @getRowFor('end')
 
+
   saveProperties: ->
+    # {inspect} = require 'util'
     properties = @captureProperties()
+    # console.log 'saving properties original', inspect(properties)
     unless @selection.isEmpty()
       # We select righted in visual-mode, this translation de-effect select-right-effect
       # so that after restoring preserved poperty we can do activate-visual mode without
@@ -172,6 +175,7 @@ class SelectionWrapper
       else
         properties.head = endPoint
 
+    # console.log 'saving properties end translated -1 column', inspect(properties)
     @setProperties(properties)
 
   captureProperties: ->
@@ -192,6 +196,7 @@ class SelectionWrapper
 
   restoreColumnFromProperties: ->
     {head, tail} = @getProperties()
+    # console.log [tail?.toString(), head?.toString()]
     return unless head? and tail?
     return if @selection.isEmpty()
 
@@ -199,9 +204,9 @@ class SelectionWrapper
       [start, end] = [head, tail]
     else
       [start, end] = [tail, head]
-
     [start.row, end.row] = @selection.getBufferRowRange()
     @withKeepingGoalColumn =>
+      # console.log 'restoring in restoreColumnFromProperties', new Point(start, end).toString()
       @setBufferRange([start, end], preserveFolds: true)
       @translateSelectionEndAndClip('backward', translate: false)
 

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -11,7 +11,7 @@ translatePointAndClip = (editor, point, direction, {translate, hello}={}) ->
     when 'forward'
       point = point.translate([0, +1]) if translate
       eol = editor.bufferRangeForBufferRow(point.row).end
-      console.log 'point, eol, hello', [point.toString(), eol.toString(), hello]
+      # console.log 'point, eol, hello', [point.toString(), eol.toString(), hello]
 
       if point.isEqual(eol)
         return Point.min(point, editor.getEofBufferPosition())
@@ -22,7 +22,7 @@ translatePointAndClip = (editor, point, direction, {translate, hello}={}) ->
       point = Point.min(point, editor.getEofBufferPosition())
     when 'backward'
       point = point.translate([0, -1]) if translate
-      console.log 'point, hello', [point.toString(), hello]
+      # console.log 'point, hello', [point.toString(), hello]
 
       if point.column < 0
         newRow = point.row - 1

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -40,6 +40,8 @@ translatePointAndClip = (editor, point, direction, {translate}={}) ->
 
 class SelectionWrapper
   constructor: (@selection) ->
+    @selection.onDidDestroy =>
+      @clearProperties()
 
   hasProperties: -> propertyStore.has(@selection)
   getProperties: -> propertyStore.get(@selection) ? {}

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -99,8 +99,7 @@ class SelectionWrapper
     @setBufferRange(range, preserveFolds: true)
 
   # Native selection.expandOverLine is not aware of actual rowRange of selection.
-  expandOverLine: (options={}) ->
-    {preserveGoalColumn} = options
+  expandOverLine: ({preserveGoalColumn}={}) ->
     if preserveGoalColumn
       {goalColumn} = @selection.cursor
 
@@ -162,14 +161,13 @@ class SelectionWrapper
     @setReversedState(head.isLessThan(tail))
 
   # Equivalent to
-  # "not (selection.isReversed() or selection.isEmpty())"
+  # "not selection.isReversed() and not selection.isEmpty()"
   isForwarding: ->
     head = @selection.getHeadBufferPosition()
     tail = @selection.getTailBufferPosition()
     head.isGreaterThan(tail)
 
-  restoreCharacterwise: (options={}) ->
-    {preserveGoalColumn} = options
+  restoreCharacterwise: ({preserveGoalColumn}={}) ->
     {goalColumn} = @selection.cursor if preserveGoalColumn
 
     {head, tail} = @getProperties()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -27,20 +27,6 @@ translatePointAndClip = (editor, point, direction) ->
 
   point
 
-translateBufferRangeEndToRightForSelection = (selection) ->
-  editor = selection.editor
-  {start, end} = selection.getBufferRange()
-  screenPoint = editor.screenPositionForBufferPosition(end).translate([0, +1])
-  end = editor.bufferPositionForScreenPosition(screenPoint, clipDirection: 'forward')
-  new Range(start, end)
-
-translateBufferRangeEndToLeftForSelection = (selection) ->
-  editor = selection.editor
-  {start, end} = selection.getBufferRange()
-  screenPoint = editor.screenPositionForBufferPosition(end).translate([0, +1])
-  end = editor.bufferPositionForScreenPosition(screenPoint, clipDirection: 'backward')
-  new Range(start, end)
-
 class SelectionWrapper
   constructor: (@selection) ->
 
@@ -162,18 +148,30 @@ class SelectionWrapper
   getStartRow: -> @getRowFor('start')
   getEndRow: -> @getRowFor('end')
 
-  getTailBufferRange: ->
-    if (@isSingleRow() and @isLinewise())
-      @selection.editor.bufferRangeForBufferRow(@getTailRow(), includeNewline: true)
-    else
-      {editor} = @selection
-      start = @selection.getTailScreenPosition()
-      end = if @selection.isReversed()
-        editor.clipScreenPosition(start.translate([0, -1]), clipDirection: 'backward')
-      else
-        editor.clipScreenPosition(start.translate([0, +1]), clipDirection: 'forward')
 
-      editor.bufferRangeForScreenRange([start, end])
+  getTailBufferRange: ->
+    {editor} = @selection
+    if (@isSingleRow() and @isLinewise())
+      console.log "singleRow"
+      editor.bufferRangeForBufferRow(@getTailRow(), includeNewline: true)
+    else
+      console.log "normal tail"
+      tailStart = @selection.getTailScreenPosition()
+      # tailStart = @selection.getTailBufferPosition()
+      if @selection.isReversed()
+        # tailEnd = translatePointAndClip(editor, tailStart, 'backward')
+        tailEnd = editor.clipScreenPosition(tailStart.translate([0, -1]), clipDirection: 'backward')
+      else
+        # tailEnd = translatePointAndClip(editor, tailStart, 'forward')
+        tailEnd = editor.clipScreenPosition(tailStart.translate([0, +1]), clipDirection: 'forward')
+
+      # tailStart = @selection.getTailScreenPosition()
+      # if @selection.isReversed()
+      #   tailEnd = translatePointAndClip(editor, tailStart, 'backward')
+      # else
+      #   tailEnd = translatePointAndClip(editor, tailStart, 'forward')
+
+      editor.bufferRangeForScreenRange([tailStart, tailEnd])
 
   preserveCharacterwise: ->
     properties = @detectCharacterwiseProperties()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -191,8 +191,8 @@ class SelectionWrapper
     @setBufferRange([tail, head])
     @setReversedState(head.isLessThan(tail))
 
-  # Equivalent to
-  # "not selection.isReversed() and not selection.isEmpty()"
+  # Return true if selection was non-empty and non-reversed selection.
+  # Equivalent to not selection.isEmpty() and not selection.isReversed()"
   isForwarding: ->
     head = @selection.getHeadBufferPosition()
     tail = @selection.getTailBufferPosition()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -190,7 +190,7 @@ class SelectionWrapper
     tail = @selection.getTailBufferPosition()
     head.isGreaterThan(tail)
 
-  normalize: ->
+  restoreColumnFromProperties: ->
     {head, tail} = @getProperties()
     return unless head? and tail?
     return if @selection.isEmpty()
@@ -199,12 +199,11 @@ class SelectionWrapper
       [start, end] = [head, tail]
     else
       [start, end] = [tail, head]
-    [start.row, end.row] = @selection.getBufferRowRange()
 
-    {goalColumn} = @selection.cursor
-    end = translatePointAndClip(@selection.editor, end, 'backward', translate: false)
-    @setBufferRange([start, end], {preserveFolds: true})
-    @selection.cursor.goalColumn = goalColumn if goalColumn?
+    [start.row, end.row] = @selection.getBufferRowRange()
+    @withKeepingGoalColumn =>
+      @setBufferRange([start, end], preserveFolds: true)
+      @translateSelectionEndAndClip('backward', translate: false)
 
   # Only for setting autoscroll option to false by default
   setBufferRange: (range, options={}) ->
@@ -254,7 +253,7 @@ class SelectionWrapper
     {start, end} = @getBufferRange()
     @withKeepingGoalColumn =>
       end = translatePointAndClip(@selection.editor, end, direction, options)
-      @setBufferRange([start, end], {preserveFolds: true})
+      @setBufferRange([start, end], preserveFolds: true)
 
   translateSelectionHeadAndClip: (direction, options) ->
     {start, end} = @getBufferRange()
@@ -265,7 +264,7 @@ class SelectionWrapper
         [tail, head] = [start, end]
 
       head = translatePointAndClip(@selection.editor, head, direction, options)
-      @setBufferRange([head, tail], {preserveFolds: true})
+      @setBufferRange([head, tail], preserveFolds: true)
 
 swrap = (selection) ->
   new SelectionWrapper(selection)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -55,7 +55,7 @@ class TextObject extends Base
       for selection in @editor.getSelections() when canSelect
         @selectTextObject(selection, stopSelection)
     @editor.mergeIntersectingSelections()
-    swrap.updateSelectionProperties(@editor) if @isMode('visual')
+    @updateSelectionProperties() if @isMode('visual')
 
   selectTextObject: (selection, stopSelection) ->
     range = @getRange(selection, stopSelection)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -25,6 +25,7 @@ swrap = require './selection-wrapper'
 class TextObject extends Base
   @extend(false)
   allowSubmodeChange: true
+  normalize: false
 
   constructor: ->
     @constructor::inner = @getName().startsWith('Inner')
@@ -52,6 +53,9 @@ class TextObject extends Base
       canSelect = false
 
     @countTimes =>
+      if @normalize and @isMode('visual')
+        @vimState.modeManager.normalizeSelections()
+
       for selection in @editor.getSelections() when canSelect
         @selectTextObject(selection, stopSelection)
     @editor.mergeIntersectingSelections()
@@ -68,10 +72,7 @@ class TextObject extends Base
 # -------------------------
 class Word extends TextObject
   @extend(false)
-
-  select: ->
-    @vimState.modeManager.normalizeSelections()
-    super
+  normalize: true
 
   getRange: (selection) ->
     {range, kind} = @getWordBufferRangeAndKindAtBufferPosition(selection.cursor.getBufferPosition(), {@wordRegex})
@@ -127,6 +128,7 @@ class Pair extends TextObject
   allowSubmodeChange: false
   adjustInnerRange: true
   pair: null
+  
   getPattern: ->
     [open, close] = @pair
     if open is close

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -51,12 +51,6 @@ class TextObject extends Base
   stopSelection: ->
     @canSelect = false
 
-  getUnionedRangeUnlessSelectionWasEmpty: (selection, range) ->
-    if selection.isEmpty()
-      range
-    else
-      selection.getBufferRange().union(range)
-
   getNormalizedHeadBufferPosition: (selection) ->
     head = selection.getHeadBufferPosition()
     if @isMode('visual') and not selection.isReversed()
@@ -264,7 +258,7 @@ class Pair extends TextObject
 
   getPointToSearchFrom: (selection, searchFrom) ->
     switch searchFrom
-      when 'head' then swrap(selection).getNormalizedBufferPosition()
+      when 'head' then @getNormalizedHeadBufferPosition(selection)
       when 'start' then swrap(selection).getBufferPositionFor('start')
 
   # Allow override @allowForwarding by 2nd argument.
@@ -781,8 +775,8 @@ class SearchMatchForward extends TextObject
     {range: found, whichIsHead: 'end'}
 
   getRange: (selection) ->
-    unless pattern = @globalState.get('lastSearchPattern')
-      return null
+    pattern = @globalState.get('lastSearchPattern')
+    return unless pattern?
 
     fromPoint = selection.getHeadBufferPosition()
     {range, whichIsHead} = @findMatch(fromPoint, pattern)
@@ -884,7 +878,6 @@ class UnionTextObject extends TextObject
 class AFunctionOrInnerParagraph extends UnionTextObject
   @extend()
   member: ['AFunction', 'InnerParagraph']
-
 
 # FIXME: make Motion.CurrentSelection to TextObject then use concatTextObject
 class ACurrentSelectionAndAPersistentSelection extends TextObject

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -55,7 +55,7 @@ class TextObject extends Base
       for selection in @editor.getSelections() when canSelect
         @selectTextObject(selection, stopSelection)
     @editor.mergeIntersectingSelections()
-    @updateSelectionProperties() if @isMode('visual')
+    swrap.updateSelectionProperties(@editor) if @isMode('visual')
 
   selectTextObject: (selection, stopSelection) ->
     range = @getRange(selection, stopSelection)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -212,17 +212,19 @@ moveCursorToNextNonWhitespace = (cursor) ->
     cursor.moveRight()
   not originalPoint.isEqual(cursor.getBufferPosition())
 
-getBufferRows = (editor, {startRow, direction, includeStartRow}) ->
+getBufferRows = (editor, {startRow, direction}) ->
   switch direction
     when 'previous'
-      if not includeStartRow and startRow <= 0
-        return []
-      [(startRow - 1)..0]
+      if startRow <= 0
+        []
+      else
+        [(startRow - 1)..0]
     when 'next'
       vimLastBufferRow = getVimLastBufferRow(editor)
-      if not includeStartRow and startRow >= vimLastBufferRow
-        return []
-      [(startRow + 1)..vimLastBufferRow]
+      if startRow >= vimLastBufferRow
+        []
+      else
+        [(startRow + 1)..vimLastBufferRow]
 
 # Return Vim's EOF position rather than Atom's EOF position.
 # This function change meaning of EOF from native TextEditor::getEofBufferPosition()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -252,6 +252,9 @@ isEmptyRow = (editor, row) ->
 cursorIsAtEmptyRow = (cursor) ->
   isEmptyRow(cursor.editor, cursor.getBufferRow())
 
+cursorIsAtEndOfLineAtNonEmptyRow = (cursor) ->
+  cursor.isAtEndOfLine() and not cursorIsAtEmptyRow(cursor)
+
 getVimLastBufferRow = (editor) ->
   getVimEofBufferPosition(editor).row
 
@@ -878,6 +881,7 @@ module.exports = {
   moveCursorToNextNonWhitespace
   isEmptyRow
   cursorIsAtEmptyRow
+  cursorIsAtEndOfLineAtNonEmptyRow
   getCodeFoldRowRanges
   getCodeFoldRowRangesContainesForRow
   getBufferRangeForRowRange

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -253,7 +253,7 @@ cursorIsAtEmptyRow = (cursor) ->
   isEmptyRow(cursor.editor, cursor.getBufferRow())
 
 cursorIsAtEndOfLineAtNonEmptyRow = (cursor) ->
-  cursor.isAtEndOfLine() and not cursorIsAtEmptyRow(cursor)
+  cursor.isAtEndOfLine() and not cursor.isAtBeginningOfLine()
 
 getVimLastBufferRow = (editor) ->
   getVimEofBufferPosition(editor).row

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -757,6 +757,49 @@ getLargestFoldRangeContainsBufferRow = (editor, row) ->
   if startPoint? and endPoint?
     new Range(startPoint, endPoint)
 
+translatePointAndClip = (editor, point, direction, {translate}={}) ->
+  translate ?= true
+  point = Point.fromObject(point)
+
+  dontClip = false
+  switch direction
+    when 'forward'
+      point = point.translate([0, +1]) if translate
+      eol = editor.bufferRangeForBufferRow(point.row).end
+
+      if point.isEqual(eol)
+        dontClip = true
+
+      if point.isGreaterThan(eol)
+        point = new Point(point.row + 1, 0)
+        dontClip = true
+
+      point = Point.min(point, editor.getEofBufferPosition())
+
+    when 'backward'
+      point = point.translate([0, -1]) if translate
+
+      if point.column < 0
+        newRow = point.row - 1
+        eol = editor.bufferRangeForBufferRow(newRow).end
+        point = new Point(newRow, eol.column)
+
+      point = Point.max(point, Point.ZERO)
+
+  if dontClip
+    point
+  else
+    screenPoint = editor.screenPositionForBufferPosition(point, clipDirection: direction)
+    editor.bufferPositionForScreenPosition(screenPoint)
+
+getRangeByTranslatePointAndClip = (editor, range, which, direction, options) ->
+  newPoint = translatePointAndClip(editor, range[which], direction, options)
+  switch which
+    when 'start'
+      new Range(newPoint, range.end)
+    when 'end'
+      new Range(range.start, newPoint)
+
 # Debugging purpose
 # -------------------------
 logGoalColumnForSelection = (subject, selection) ->
@@ -923,6 +966,8 @@ module.exports = {
   isRangeContainsSomePoint
   destroyNonLastSelection
   getLargestFoldRangeContainsBufferRow
+  translatePointAndClip
+  getRangeByTranslatePointAndClip
 
   # Debugging
   reportSelection,

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -344,12 +344,12 @@ moveCursorRight = (cursor, options={}) ->
     motion = (cursor) -> cursor.moveRight()
     moveCursor(cursor, options, motion)
 
-moveCursorUp = (cursor, options={}) ->
+moveCursorUpScreen = (cursor, options={}) ->
   unless cursor.getScreenRow() is 0
     motion = (cursor) -> cursor.moveUp()
     moveCursor(cursor, options, motion)
 
-moveCursorDown = (cursor, options={}) ->
+moveCursorDownScreen = (cursor, options={}) ->
   unless getVimLastScreenRow(cursor.editor) is cursor.getScreenRow()
     motion = (cursor) -> cursor.moveDown()
     moveCursor(cursor, options, motion)
@@ -734,6 +734,26 @@ destroyNonLastSelection = (editor) ->
   for selection in editor.getSelections() when not selection.isLastSelection()
     selection.destroy()
 
+getLargestFoldRangeContainsBufferRow = (editor, row) ->
+  markers = editor.displayLayer.findFoldMarkers(intersectsRow: row)
+
+  startPoint = null
+  endPoint = null
+
+  for marker in markers ? []
+    {start, end} = marker.getRange()
+    unless startPoint
+      startPoint = start
+      endPoint = end
+      continue
+
+    if start.isLessThan(startPoint)
+      startPoint = start
+      endPoint = end
+
+  if startPoint? and endPoint?
+    new Range(startPoint, endPoint)
+
 # Debugging purpose
 # -------------------------
 logGoalColumnForSelection = (subject, selection) ->
@@ -838,8 +858,8 @@ module.exports = {
   getVimLastScreenRow
   moveCursorLeft
   moveCursorRight
-  moveCursorUp
-  moveCursorDown
+  moveCursorUpScreen
+  moveCursorDownScreen
   getEolForBufferRow
   getFirstVisibleScreenRow
   getLastVisibleScreenRow
@@ -898,6 +918,7 @@ module.exports = {
   scanEditor
   isRangeContainsSomePoint
   destroyNonLastSelection
+  getLargestFoldRangeContainsBufferRow
 
   # Debugging
   reportSelection,

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -90,7 +90,7 @@ class VimState
   selectBlockwise: ->
     for selection in @editor.getSelections()
       @blockwiseSelections.push(new BlockwiseSelection(selection))
-    @updateSelectionProperties()
+    swrap.updateSelectionProperties(@editor)
 
   # Other
   # -------------------------
@@ -284,14 +284,6 @@ class VimState
   updateCursorsVisibility: ->
     @cursorStyleManager.refresh()
 
-  updateSelectionProperties: ({force}={}) ->
-    selections = @editor.getSelections()
-    unless (force ? true)
-      selections = selections.filter (selection) ->
-        not swrap(selection).getCharacterwiseHeadPosition()?
-
-    for selection in selections
-      swrap(selection).preserveCharacterwise()
 
   updatePreviousSelection: ->
     if @isMode('visual', 'blockwise')

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -90,12 +90,15 @@ class VimState
   selectBlockwise: ->
     for selection in @editor.getSelections()
       @blockwiseSelections.push(new BlockwiseSelection(selection))
-    swrap.updateSelectionProperties(@editor)
+    @updateSelectionProperties()
 
   # Other
   # -------------------------
   selectLinewise: ->
     swrap.expandOverLine(@editor, preserveGoalColumn: true)
+
+  updateSelectionProperties: (options) ->
+    swrap.updateSelectionProperties(@editor, options)
 
   # Mark
   # -------------------------
@@ -237,12 +240,12 @@ class VimState
       else
         @activate('normal') if @isMode('visual')
 
-    _preserveCharacterwise = =>
+    _saveProperties = =>
       for selection in @editor.getSelections()
-        swrap(selection).preserveCharacterwise()
+        swrap(selection).saveProperties()
 
     checkSelection = onInterestingEvent(_checkSelection)
-    preserveCharacterwise = onInterestingEvent(_preserveCharacterwise)
+    saveProperties = onInterestingEvent(_saveProperties)
 
     @editorElement.addEventListener('mouseup', checkSelection)
     @subscriptions.add new Disposable =>
@@ -251,7 +254,7 @@ class VimState
     # [FIXME]
     # Hover position get wired when focus-change between more than two pane.
     # commenting out is far better than introducing Buggy behavior.
-    # @subscriptions.add atom.commands.onWillDispatch(preserveCharacterwise)
+    # @subscriptions.add atom.commands.onWillDispatch(saveProperties)
 
     @subscriptions.add atom.commands.onDidDispatch(checkSelection)
 
@@ -289,7 +292,7 @@ class VimState
     if @isMode('visual', 'blockwise')
       properties = @getLastBlockwiseSelection()?.getCharacterwiseProperties()
     else
-      properties = swrap(@editor.getLastSelection()).detectCharacterwiseProperties()
+      properties = swrap(@editor.getLastSelection()).captureProperties()
 
     return unless properties?
 

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -22,6 +22,12 @@ describe "Motion Find", ->
     it 'moves to the first specified character it finds', ->
       ensure ['f', input: 'c'], cursor: [0, 2]
 
+    it 'extends visual selection in visual-mode and repetable', ->
+      ensure 'v', mode: ['visual', 'characterwise']
+      ensure ['f', input: 'c'], selectedText: 'abc', cursor: [0, 3]
+      ensure ';', selectedText: 'abcabc', cursor: [0, 6]
+      ensure ',', selectedText: 'abc', cursor: [0, 3]
+
     it 'moves backwards to the first specified character it finds', ->
       set cursor: [0, 2]
       ensure ['F', input: 'a'], cursor: [0, 0]

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -126,7 +126,7 @@ describe "Motion general", ->
           ensure 'v', cursor: [2, 4], selectedText: 'd'
           ensure 'k k', cursor: [0, 3], selectedText: "defg\n\nabcd"
 
-    describe "jk in softwrap", ->
+    describe "gj gk in softwrap", ->
       [text] = []
 
       beforeEach ->
@@ -144,10 +144,10 @@ describe "Motion general", ->
 
       describe "selection is not reversed", ->
         it "screen position and buffer position is different", ->
-          ensure 'j', cursor: [1, 0], cursorBuffer: [0, 9]
-          ensure 'j', cursor: [2, 0], cursorBuffer: [1, 0]
-          ensure 'j', cursor: [3, 0], cursorBuffer: [1, 9]
-          ensure 'j', cursor: [4, 0], cursorBuffer: [1, 12]
+          ensure 'g j', cursor: [1, 0], cursorBuffer: [0, 9]
+          ensure 'g j', cursor: [2, 0], cursorBuffer: [1, 0]
+          ensure 'g j', cursor: [3, 0], cursorBuffer: [1, 9]
+          ensure 'g j', cursor: [4, 0], cursorBuffer: [1, 12]
 
         it "jk move selection buffer-line wise", ->
           ensure 'V', selectedText: text.getLines([0..0])
@@ -163,10 +163,10 @@ describe "Motion general", ->
 
       describe "selection is reversed", ->
         it "screen position and buffer position is different", ->
-          ensure 'j', cursor: [1, 0], cursorBuffer: [0, 9]
-          ensure 'j', cursor: [2, 0], cursorBuffer: [1, 0]
-          ensure 'j', cursor: [3, 0], cursorBuffer: [1, 9]
-          ensure 'j', cursor: [4, 0], cursorBuffer: [1, 12]
+          ensure 'g j', cursor: [1, 0], cursorBuffer: [0, 9]
+          ensure 'g j', cursor: [2, 0], cursorBuffer: [1, 0]
+          ensure 'g j', cursor: [3, 0], cursorBuffer: [1, 9]
+          ensure 'g j', cursor: [4, 0], cursorBuffer: [1, 12]
 
         it "jk move selection buffer-line wise", ->
           set cursorBuffer: [4, 0]

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -351,7 +351,7 @@ describe "Operator general", ->
           cursorBuffer: [[0, 1], [1, 2], [2, 3]]
 
         ensure 'd e',
-          text: "a\n12\nABC\n"
+          text: "a\n12\nABC"
           cursorBuffer: [[0, 0], [1, 1], [2, 2]]
 
       it "doesn't delete empty selections", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -34,6 +34,9 @@ withMockPlatform = (target, platform, fn) ->
 buildKeydownEvent = (key, options) ->
   KeymapManager.buildKeydownEvent(key, options)
 
+headFromProperty = (selection) ->
+  swrap(selection).getBufferPositionFor('head', fromProperty: true)
+
 buildKeydownEventFromKeystroke = (keystroke, target) ->
   modifier = ['ctrl', 'alt', 'shift', 'cmd']
   parts = if keystroke is '-'
@@ -324,7 +327,7 @@ class VimEditor
     expect(actual).toEqual(toArray(text))
 
   ensureCharacterwiseHead: (points) ->
-    actual = (swrap(s).getCharacterwiseHeadPosition() for s in @editor.getSelections())
+    actual = (headFromProperty(s) for s in @editor.getSelections())
     expect(actual).toEqual(toArrayOfPoint(points))
 
   ensureScrollTop: (scrollTop) ->


### PR DESCRIPTION
For #421

## Inclusive, exclusive

- All motion in visual-mode is work as inclusive

- When inclusive: true
  - forward: include selection-end point(head of selection)
  - backward: include selection-end point(tail of selection)

- When inclusive: false(exclusive) e.g. T
  - forward: exclude selection-end point(head of selection)
  - backward: exclude selection-end point(tail of selection)

# ~~TailRange and inclusive~~ become unnecessary after cleanup.
- ~~In visual-mode selection have tailRange~~
- ~~tailRange is selection-tail to one-char-right range.~~
- ~~tailRange is always selected even if selection-head traversed selection-tail as a result of movement.~~
- ~~When tailRange is maintained, it called inclusive~~

# Saving selection properties

- In Atom cursor position is at head of selection.
- In visual-linewise, cursor position is at column 0 of next-line.
- But we have to show at arbitrary position in **within** whole linewise selection range.
- That's why we maintain cursor positon independently from selection as selection property.

# Selection property update

- We save selection property as characterwise orientation.
- We can restore characterwise selection range from property.
- When we start visual-mode, we save it.
- When we have to normalize restored selection range, we translateAndClip end position of selection to de-effect characterwise select-right effect
- When we shift submode in visual-mode, we save it

# Normalized selection orientation

- Head and tail position, we can determine reversed or not by comparing head and tail
- if head was greater than tail, selection is NOT reversed
- if head was less than tail, selection is reversed
- if head and tail was equal, selection is empty
- ~~We clip-left to end position of selection(head or tail depending on reversed state) to de-effect select-right-effect~~

# When we move cursor in visual-mode

- In visual-mode, reardless of submode, all motion start in selection-normalized-state.
- We normalize selection so that each motion don't have to do special care about visual-mode
- Then after movement finished, we adjust update selection range to appropriate submode range.
- We need to update selection property before restoring original submode(linewise, characterwise, blockwise).
- Also need to update cursor visibility using saved selection property.
- Motion in visual-linewise, normalize first then move then selectLinewise()
- Motion in visual-blockwise, normalize first then move then selectBlockwise()
- Motion in visual-characterwise, normalize first then move then selectCharacterwise()

# Select operator

- In visual-mode, Select operator comes in play
- Select operator is responsible to update selection by Target(Motion, TextObject).
- For Motion, first normalize selection, move cursor by `Motion::moveCursor()` then update selection property, update selection inclusively then resore submode's orientation.
- For TextObject, first normalize selection, getRange by `TextObject::getRange()` then update selection, update submode-wise(change submode in TextObject).
