### PR TITLE
Fix focus keymaps for empty panes

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -6,6 +6,23 @@
   # 'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
 
+  'ctrl-w ctrl-h': 'window:focus-pane-on-left'
+  'ctrl-w h': 'window:focus-pane-on-left'
+  'ctrl-w left': 'window:focus-pane-on-left'
+  'ctrl-w ctrl-l': 'window:focus-pane-on-right'
+  'ctrl-w l': 'window:focus-pane-on-right'
+  'ctrl-w right': 'window:focus-pane-on-right'
+  'ctrl-w ctrl-k': 'window:focus-pane-above'
+  'ctrl-w k': 'window:focus-pane-above'
+  'ctrl-w up': 'window:focus-pane-above'
+  'ctrl-w ctrl-j': 'window:focus-pane-below'
+  'ctrl-w j': 'window:focus-pane-below'
+  'ctrl-w down': 'window:focus-pane-below'
+  'ctrl-w ctrl-w': 'window:focus-next-pane'
+  'ctrl-w w': 'window:focus-next-pane'
+  'ctrl-w ctrl-p': 'window:focus-previous-pane'
+  'ctrl-w p': 'window:focus-previous-pane'
+
 # all
 # -------------------------
 'atom-text-editor.vim-mode-plus':
@@ -148,23 +165,6 @@
   'ctrl-x': 'vim-mode-plus:decrease'
   'g ctrl-a': 'vim-mode-plus:increment-number' # experimental
   'g ctrl-x': 'vim-mode-plus:decrement-number' # experimental
-
-  'ctrl-w ctrl-h': 'window:focus-pane-on-left'
-  'ctrl-w h': 'window:focus-pane-on-left'
-  'ctrl-w left': 'window:focus-pane-on-left'
-  'ctrl-w ctrl-l': 'window:focus-pane-on-right'
-  'ctrl-w l': 'window:focus-pane-on-right'
-  'ctrl-w right': 'window:focus-pane-on-right'
-  'ctrl-w ctrl-k': 'window:focus-pane-above'
-  'ctrl-w k': 'window:focus-pane-above'
-  'ctrl-w up': 'window:focus-pane-above'
-  'ctrl-w ctrl-j': 'window:focus-pane-below'
-  'ctrl-w j': 'window:focus-pane-below'
-  'ctrl-w down': 'window:focus-pane-below'
-  'ctrl-w ctrl-w': 'window:focus-next-pane'
-  'ctrl-w w': 'window:focus-next-pane'
-  'ctrl-w ctrl-p': 'window:focus-previous-pane'
-  'ctrl-w p': 'window:focus-previous-pane'
 
   # From v1.6.0
   'ctrl-w ctrl-v': 'pane:split-right-and-copy-active-item'

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -6,6 +6,9 @@
   # 'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
 
+# pane
+# -------------------------
+'atom-pane':
   'ctrl-w ctrl-h': 'window:focus-pane-on-left'
   'ctrl-w h': 'window:focus-pane-on-left'
   'ctrl-w left': 'window:focus-pane-on-left'


### PR DESCRIPTION
Previously, focus on an empty pane would break the focus pane keymaps, as the keymaps were scoped to `atom-text-editor.vim-mode-plus:not(.insert-mode)`. Further explanation of the bug can be found atom/vim-mode#1057, as it happened in that package as well.