### PR TITLE
Revert "Fix focus keymaps for empty panes"

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -6,26 +6,6 @@
   # 'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
 
-# pane
-# -------------------------
-'atom-pane':
-  'ctrl-w ctrl-h': 'window:focus-pane-on-left'
-  'ctrl-w h': 'window:focus-pane-on-left'
-  'ctrl-w left': 'window:focus-pane-on-left'
-  'ctrl-w ctrl-l': 'window:focus-pane-on-right'
-  'ctrl-w l': 'window:focus-pane-on-right'
-  'ctrl-w right': 'window:focus-pane-on-right'
-  'ctrl-w ctrl-k': 'window:focus-pane-above'
-  'ctrl-w k': 'window:focus-pane-above'
-  'ctrl-w up': 'window:focus-pane-above'
-  'ctrl-w ctrl-j': 'window:focus-pane-below'
-  'ctrl-w j': 'window:focus-pane-below'
-  'ctrl-w down': 'window:focus-pane-below'
-  'ctrl-w ctrl-w': 'window:focus-next-pane'
-  'ctrl-w w': 'window:focus-next-pane'
-  'ctrl-w ctrl-p': 'window:focus-previous-pane'
-  'ctrl-w p': 'window:focus-previous-pane'
-
 # all
 # -------------------------
 'atom-text-editor.vim-mode-plus':
@@ -168,6 +148,23 @@
   'ctrl-x': 'vim-mode-plus:decrease'
   'g ctrl-a': 'vim-mode-plus:increment-number' # experimental
   'g ctrl-x': 'vim-mode-plus:decrement-number' # experimental
+
+  'ctrl-w ctrl-h': 'window:focus-pane-on-left'
+  'ctrl-w h': 'window:focus-pane-on-left'
+  'ctrl-w left': 'window:focus-pane-on-left'
+  'ctrl-w ctrl-l': 'window:focus-pane-on-right'
+  'ctrl-w l': 'window:focus-pane-on-right'
+  'ctrl-w right': 'window:focus-pane-on-right'
+  'ctrl-w ctrl-k': 'window:focus-pane-above'
+  'ctrl-w k': 'window:focus-pane-above'
+  'ctrl-w up': 'window:focus-pane-above'
+  'ctrl-w ctrl-j': 'window:focus-pane-below'
+  'ctrl-w j': 'window:focus-pane-below'
+  'ctrl-w down': 'window:focus-pane-below'
+  'ctrl-w ctrl-w': 'window:focus-next-pane'
+  'ctrl-w w': 'window:focus-next-pane'
+  'ctrl-w ctrl-p': 'window:focus-previous-pane'
+  'ctrl-w p': 'window:focus-previous-pane'
 
   # From v1.6.0
   'ctrl-w ctrl-v': 'pane:split-right-and-copy-active-item'


### PR DESCRIPTION
It conflict `ctrl-w` in mini-editor within pane(e.g. mini editor in setting-view pane)
Reverts t9md/atom-vim-mode-plus#470