### PR TITLE
Possible correction for MoveToLineByPercent issue

### DIFF
--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -681,8 +681,8 @@ class MoveToLastLine extends MoveToFirstLine
 # keymap: N% e.g. 10%
 class MoveToLineByPercent extends MoveToFirstLine
   @extend()
-  getRow: ->
-    percent = Math.min(100, @getCount())
+  getCount: ->
+    percent = Math.min(100, super + 1)
     Math.floor(@getVimLastScreenRow() * (percent / 100))
 
 class MoveToRelativeLine extends Motion


### PR DESCRIPTION
It was overriding getRow, which wasn't actually called in the parent.

Resolves #493 