### PR TITLE
:beer: better flash with keyframe animation

### DIFF
--- a/lib/flash-manager.coffee
+++ b/lib/flash-manager.coffee
@@ -1,0 +1,75 @@
+_ = require 'underscore-plus'
+
+flashTypes =
+  operator:
+    allowMultiple: true
+    decorationOptions:
+      type: 'highlight'
+      class: 'vim-mode-plus-flash operator'
+  search:
+    allowMultiple: false
+    decorationOptions:
+      type: 'highlight'
+      class: 'vim-mode-plus-flash search'
+  screen:
+    allowMultiple: true
+    decorationOptions:
+      type: 'highlight'
+      class: 'vim-mode-plus-flash screen'
+  added:
+    allowMultiple: true
+    decorationOptions:
+      type: 'highlight'
+      class: 'vim-mode-plus-flash added'
+  removed:
+    allowMultiple: true
+    decorationOptions:
+      type: 'highlight'
+      class: 'vim-mode-plus-flash removed'
+  scroll:
+    allowMultiple: false
+    decorationOptions:
+      type: 'line'
+      class: 'vim-mode-plus-flash-scroll'
+
+module.exports =
+class FlashManager
+  constructor: (@vimState) ->
+    {@editor} = @vimState
+    @markersByType = new Map
+    @vimState.onDidDestroy(@destroy.bind(this))
+
+  destroy: ->
+    @markersByType.forEach (markers) ->
+      marker.destroy() for marker in markers
+    @markersByType.clear()
+
+  flash: (ranges, options, rangeType='buffer') ->
+    ranges = [ranges] unless _.isArray(ranges)
+    return null unless ranges.length
+
+    {type, timeout} = options
+    timeout ?= 1000
+
+    {allowMultiple, decorationOptions} = flashTypes[type]
+
+    switch rangeType
+      when 'buffer'
+        markers = (@editor.markBufferRange(range) for range in ranges)
+      when 'screen'
+        markers = (@editor.markScreenRange(range) for range in ranges)
+
+    unless allowMultiple
+      if @markersByType.has(type)
+        marker.destroy() for marker in @markersByType.get(type)
+      @markersByType.set(type, markers)
+
+    @editor.decorateMarker(marker, decorationOptions) for marker in markers
+
+    setTimeout ->
+      for marker in markers
+        marker.destroy()
+    , timeout
+
+  flashScreenRange: (args...) ->
+    @flash(args.concat('screen')...)

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -83,14 +83,8 @@ class Undo extends MiscCommand
     fn(range) if range?
     if settings.get('flashOnUndoRedo')
       @onDidFinishOperation =>
-        timeout = settings.get('flashOnUndoRedoDuration')
-        highlightRanges @editor, rangesRemoved,
-          class: "vim-mode-plus-flash removed"
-          timeout: timeout
-
-        highlightRanges @editor, rangesAdded,
-          class: "vim-mode-plus-flash added"
-          timeout: timeout
+        @vimState.flash(rangesRemoved, type: 'removed')
+        @vimState.flash(rangesAdded, type: 'added')
 
   execute: ->
     @mutateWithTrackingChanges (range) =>

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -76,10 +76,7 @@ class Operator extends Base
 
   flashIfNecessary: (ranges) ->
     return unless @needFlash()
-
-    highlightRanges @editor, ranges,
-      class: 'vim-mode-plus-flash'
-      timeout: settings.get('flashOnOperateDuration')
+    @vimState.flash(ranges, type: 'operator')
 
   flashChangeIfNecessary: ->
     return unless @needFlash()

--- a/lib/search-model.coffee
+++ b/lib/search-model.coffee
@@ -27,8 +27,10 @@ class SearchModel
 
       @vimState.hoverSearchCounter.reset()
       unless @currentMatch?
-        @flashScreen() if settings.get('flashScreenOnSearchHasNoMatch')
-        return
+        if settings.get('flashScreenOnSearchHasNoMatch')
+          @vimState.flash(getVisibleBufferRange(@editor), type: 'screen')
+          atom.beep()
+          return
 
       if settings.get('showHoverSearchCounter')
         hoverOptions =
@@ -44,14 +46,7 @@ class SearchModel
       smartScrollToBufferPosition(@editor, @currentMatch.start)
 
       if settings.get('flashOnSearch')
-        @flashRange(@currentMatch)
-
-  flashMarker = null
-  flashRange: (range) ->
-    flashMarker?.destroy()
-    flashMarker = highlightRange @editor, range,
-      class: 'vim-mode-plus-flash'
-      timeout: settings.get('flashOnSearchDuration')
+        @vimState.flash(@currentMatch, type: 'search')
 
   destroy: ->
     @markerLayer.destroy()
@@ -122,8 +117,3 @@ class SearchModel
 
   getRelativeIndex: ->
     @currentMatchIndex - @initialCurrentMatchIndex
-
-  flashScreen: ->
-    options = {class: 'vim-mode-plus-flash', timeout: 100}
-    highlightRange(@editor, getVisibleBufferRange(@editor), options)
-    atom.beep()

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -96,23 +96,14 @@ module.exports = new Settings 'vim-mode-plus',
     description: "Don't move cursor after Delete"
   flashOnUndoRedo:
     default: true
-  flashOnUndoRedoDuration:
-    default: 100
-    description: "Duration(msec) for flash"
   flashOnOperate:
     default: true
-  flashOnOperateDuration:
-    default: 100
-    description: "Duration(msec) for flash"
   flashOnOperateBlacklist:
     default: []
     items: type: 'string'
     description: 'comma separated list of operator class name to disable flash e.g. "Yank, AutoIndent"'
   flashOnSearch:
     default: true
-  flashOnSearchDuration:
-    default: 300
-    description: "Duration(msec) for search flash"
   flashScreenOnSearchHasNoMatch:
     default: true
   showHoverOnOperate:

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -275,6 +275,21 @@ getFirstCharacterColumForBufferRow = (editor, row) ->
   else
     0
 
+getFirstCharacterScreenPositionForScreenRow = (editor, screenRow) ->
+  screenLineStart = editor.clipScreenPosition([screenRow, 0], skipSoftWrapIndentation: true)
+  screenLineEnd = [screenRow, Infinity]
+  screenLineBufferRange = editor.bufferRangeForScreenRange([screenLineStart, screenLineEnd])
+
+  firstCharacterBufferPosition = null
+  editor.scanInBufferRange /\S/, screenLineBufferRange, ({range, stop}) ->
+    firstCharacterBufferPosition = range.start
+    stop()
+
+  if firstCharacterBufferPosition?
+    editor.screenPositionForBufferPosition(firstCharacterBufferPosition)
+  else
+    screenLineStart
+
 trimRange = (editor, scanRange) ->
   pattern = /\S/
   [start, end] = []
@@ -857,6 +872,7 @@ module.exports = {
   getCodeFoldRowRangesContainesForRow
   getBufferRangeForRowRange
   getFirstCharacterColumForBufferRow
+  getFirstCharacterScreenPositionForScreenRow
   trimRange
   getFirstCharacterPositionForBufferRow
   getFirstCharacterBufferPositionForScreenRow

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -30,6 +30,7 @@ OccurrenceManager = require './occurrence-manager'
 HighlightSearchManager = require './highlight-search-manager'
 MutationManager = require './mutation-manager'
 PersistentSelectionManager = require './persistent-selection-manager'
+FlashManager = require './flash-manager'
 
 packageScope = 'vim-mode-plus'
 
@@ -40,6 +41,7 @@ class VimState
 
   @delegatesProperty('mode', 'submode', toProperty: 'modeManager')
   @delegatesMethods('isMode', 'activate', toProperty: 'modeManager')
+  @delegatesMethods('flash', 'flashScreenRange', toProperty: 'flashManager')
   @delegatesMethods('subscribe', 'getCount', 'setCount', 'hasCount', 'addToClassList', toProperty: 'operationStack')
 
   constructor: (@editor, @statusBarManager, @globalState) ->
@@ -56,6 +58,7 @@ class VimState
     @persistentSelection = new PersistentSelectionManager(this)
     @occurrenceManager = new OccurrenceManager(this)
     @mutationManager = new MutationManager(this)
+    @flashManager = new FlashManager(this)
 
     @input = new Input(this)
     @searchInput = new SearchInputElement().initialize(this)

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -71,24 +71,43 @@ atom-text-editor.vim-mode-plus.insert-mode.replace,
   }
 }
 
+@keyframes vim-mode-plus-flash {
+  from { background-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%); }
+  to { background-color: transparent; }
+}
+
+@keyframes vim-mode-plus-flash-add {
+  from { background-color: fadeout(darken(@syntax-color-added, 10%), 50%); }
+  to { background-color: transparent; }
+}
+
+@keyframes vim-mode-plus-flash-remove {
+  from { background-color: fadeout(@syntax-color-removed, 50%);}
+  to { background-color: transparent; }
+}
+
+.flash (){
+  z-index: 1;
+  animation-name: vim-mode-plus-flash;
+  animation-duration: .3s;
+  animation-iteration-count: 1;
+}
 
 // Flash ranges e.g. flashing yanked range.
 // =========================
-atom-text-editor {
-  .vim-mode-plus-flash {
-    .region {
-      z-index: 1;
-      background-color: fadeout(@syntax-selection-flash-color, 50%);
-    }
-    &.added .region {
-      z-index: 1;
-      background-color: fadeout(darken(@syntax-color-added, 10%), 50%);
-    }
-    &.removed .region {
-      z-index: 1;
-      background-color: fadeout(@syntax-color-removed, 50%);
-    }
-  }
+atom-text-editor .vim-mode-plus-flash {
+  &          .region { .flash; }
+  &.operator .region {}
+  &.search   .region { animation-duration: .5s; }
+  &.screen   .region {}
+  &.added    .region { animation-name: vim-mode-plus-flash-add; }
+  &.removed  .region { animation-name: vim-mode-plus-flash-remove; }
+}
+
+// type=line decoration not allow space separated multiple classes. atom/atom#13218
+atom-text-editor.editor .line.vim-mode-plus-flash-scroll {
+  .flash;
+  animation-duration: .5s;
 }
 
 // Hover Counter


### PR DESCRIPTION
#496

- :bomb: Removed flashing duration config params.
- different kind of flashing property now consolidated as flashingManager
- flashingDuration is fixed to 1 sec at maximum(duration until marker would be destroyed)
- User can tweak by css within this duration.
- Fix: Scroll motion failed to put cursor at firstChar of screen line when it’s wrapped.