### PR TITLE
Implement ability to equalize panes, i.e. vim's `ctrl-w =`

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -177,6 +177,8 @@
   'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
 
+  'ctrl-w =': 'vim-mode-plus:equalize-panes'
+
   'ctrl-w ctrl-c': 'pane:close'
   'ctrl-w c': 'pane:close'
   'ctrl-w ctrl-q': 'core:close'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -105,6 +105,7 @@ module.exports =
 
     @subscribe atom.commands.add 'atom-workspace',
       'vim-mode-plus:maximize-pane': => @maximizePane()
+      'vim-mode-plus:equalize-panes': => @equalizePanes()
 
   maximizePane: ->
     selector = 'vim-mode-plus-pane-maximized'
@@ -114,6 +115,14 @@ module.exports =
       classList.add('hide-tab-bar') if settings.get('hideTabBarOnMaximizePane')
     else
       classList.remove('hide-tab-bar')
+
+  equalizePanes: ->
+    for pane in atom.workspace.getPanes()
+      pane.setFlexScale 1
+      # I couldn't figure out a way to get all the PaneAxis in the workspace, this might result in some
+      # redundant sets
+      pane.parent.setFlexScale 1
+
 
   registerVimStateCommands: ->
     # all commands here is executed with context where 'this' binded to 'vimState'


### PR DESCRIPTION
`ctrl-w =` in vim attempts to equalize the size of all the visible panes.

![out](https://cloud.githubusercontent.com/assets/13682706/20471460/3316adc0-af6f-11e6-9766-1f59a7b402c8.gif)

