### PR TITLE
full feature covers for vim-niceblock

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -112,6 +112,7 @@
 
   # '_': 'vim-mode-plus:replace-with-register'
   'I': 'vim-mode-plus:insert-at-first-character-of-line'
+  'A': 'vim-mode-plus:insert-after-end-of-line'
   'g I': 'vim-mode-plus:insert-at-beginning-of-line'
   '>': 'vim-mode-plus:indent'
   '<': 'vim-mode-plus:outdent'
@@ -390,7 +391,6 @@
   'O': 'vim-mode-plus:insert-above-with-newline'
   'o': 'vim-mode-plus:insert-below-with-newline'
   'a': 'vim-mode-plus:insert-after'
-  'A': 'vim-mode-plus:insert-after-end-of-line'
   'x': 'vim-mode-plus:delete-right'
   'X': 'vim-mode-plus:delete-left'
   's': 'vim-mode-plus:substitute'
@@ -552,13 +552,14 @@
   'V': 'vim-mode-plus:activate-linewise-visual-mode'
   'ctrl-v': 'vim-mode-plus:activate-blockwise-visual-mode'
 
-  'I': 'vim-mode-plus:insert-at-start-of-target'
-  'A': 'vim-mode-plus:insert-at-end-of-target'
-
   'enter': 'vim-mode-plus:create-persistent-selection'
 
   # 'p': 'vim-mode-plus:swap-with-register'
   # 'P': 'vim-mode-plus:swap-with-register'
+
+'atom-text-editor.vim-mode-plus.visual-mode:not(.linewise)':
+  'I': 'vim-mode-plus:insert-at-start-of-target'
+  'A': 'vim-mode-plus:insert-at-end-of-target'
 
 # visual-blockwise
 # -------------------------

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -130,21 +130,30 @@ class InsertAfter extends ActivateInsertMode
     moveCursorRight(cursor) for cursor in @editor.getCursors()
     super
 
-class InsertAfterEndOfLine extends ActivateInsertMode
-  @extend()
-  execute: ->
-    @editor.moveToEndOfLine()
-    super
-
+# key: 'g I'
 class InsertAtBeginningOfLine extends ActivateInsertMode
   @extend()
   execute: ->
+    if @isMode('visual', ['characterwise', 'linewise'])
+      @editor.splitSelectionsIntoLines()
     @editor.moveToBeginningOfLine()
     super
 
+# key: 'A', Used in 'normal-mode', 'visual-mode.linewise'
+class InsertAfterEndOfLine extends ActivateInsertMode
+  @extend()
+  execute: ->
+    if @isMode('visual', 'linewise')
+      @editor.splitSelectionsIntoLines()
+    @editor.moveToEndOfLine()
+    super
+
+# key: 'I', Used in 'normal-mode', 'visual-mode.linewise'
 class InsertAtFirstCharacterOfLine extends ActivateInsertMode
   @extend()
   execute: ->
+    if @isMode('visual', 'linewise')
+      @editor.splitSelectionsIntoLines()
     @editor.moveToBeginningOfLine()
     @editor.moveToFirstCharacterOfLine()
     super
@@ -186,11 +195,18 @@ class InsertByTarget extends ActivateInsertMode
       swrap(selection).setBufferPositionTo(@which)
     super
 
+# key: 'I', Used in 'visual-mode.characterwise', visual-mode.blockwise
 class InsertAtStartOfTarget extends InsertByTarget
   @extend()
   which: 'start'
+  execute: ->
+    if @isMode('visual', 'characterwise')
+      # `I(or A)` is short-hand of `ctrl-v I(or A)`
+      @vimState.selectBlockwise()
+    super
 
-class InsertAtEndOfTarget extends InsertByTarget
+# key: 'A', Used in 'visual-mode.characterwise', 'visual-mode.blockwise'
+class InsertAtEndOfTarget extends InsertAtStartOfTarget
   @extend()
   which: 'end'
 


### PR DESCRIPTION
Fix #488

# What's is this?

Straightforward implementation of [vim-niceblock](https://github.com/kana/vim-niceblock).

# Purpose?

In visual-block mode(`vB`), `I` and `A` is already useful.
Why not making `I` and `A` in other visual-mode(`vC`, `vL`) also useful.
So this enhancement change behavior of `g I`, `I`, `A` in mode `vC`, `vL`.

# summary table

## `g I`

Insert at first column in all mode.

| mode | action                              |
|:-----|:------------------------------------|
| `n`  | first column of cursor line         |
| `vC` | first column of each selected lines (cursor multiplied) |
| `vL` | first column of each selected lines (cursor multiplied) |
| `vB` | first column of each selected lines |

## `I`

Insert at first-character-of-line(FCOL) in `n` and `vL`.
Insert at start-of-selection-column in `vC` and `vB`.

| mode | action                                                          |
|:-----|:----------------------------------------------------------------|
| `n`  | insert-at-FCOL of cursor line                                   |
| `vL` | insert-at-FCOL for each selected lines (cursor multiplied)      |
| `vC` | Shorthand of `ctrl-v I`(`vB` in this table) (cursor multiplied) |
| `vB` | insert-at-start-of-selection-column for each selected lines     |

## `A`

Insert at EOL in `n` and `vL`.
Insert at end-of-selection-column in `vC` and `vB`.

| mode | action                                                          |
|:-----|:----------------------------------------------------------------|
| `n`  | insert-at-EOL of cursor line                                    |
| `vL` | insert-at-EOL for each selected lines (cursor multiplied)       |
| `vC` | Shorthand of `ctrl-v A`(`vB` in this table) (cursor multiplied) |
| `vB` | insert-at-end-of-selection-column for each selected lines       |
