### PR TITLE
Search next occurrence motion

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -435,6 +435,10 @@
   'I': 'vim-mode-plus:insert-at-start-of-target'
   'A': 'vim-mode-plus:insert-at-end-of-target'
 
+'atom-text-editor.vim-mode-plus.has-occurrence:not(.insert-mode)':
+  'tab': 'vim-mode-plus:search-occurrence'
+  'shift-tab': 'vim-mode-plus:search-occurrence-backwards'
+
 # operator-pending, visual
 # -------------------------
 'atom-text-editor.vim-mode-plus.operator-pending-mode, atom-text-editor.vim-mode-plus.visual-mode':
@@ -583,6 +587,9 @@
   'ctrl-[': 'vim-mode-plus:search-cancel'
   'shift-tab': 'vim-mode-plus:search-visit-prev'
   'tab': 'vim-mode-plus:search-visit-next'
+
+'atom-text-editor.vim-mode-plus-search.search-occurrence':
+  'space': 'vim-mode-plus:toggle-occurrence-from-search'
 
 # If you want to map normal char to special operation.
 # Use `not(.literal-mode)` selector like below.

--- a/lib/motion-search.coffee
+++ b/lib/motion-search.coffee
@@ -221,6 +221,7 @@ class SearchOccurrence extends Search
   initialize: ->
     super
     if @vimState.occurrenceManager.hasPatterns()
+      @vimState.addToClassList('silent')
       regexSource = @vimState.occurrenceManager.buildPattern().source
       @vimState.searchInput.editor.insertText(regexSource)
 

--- a/lib/motion-search.coffee
+++ b/lib/motion-search.coffee
@@ -152,9 +152,11 @@ class Search extends SearchBase
         @vimState.operationStack.run(operation) if operation?
       when 'toggle-occurrence'
         if @vimState.occurrenceManager.hasMarkers()
-          point = @getSearchModel().currentMatch.start
+          searchModel = @getSearchModel()
+          point = searchModel.currentMatch.start
           if marker = @vimState.occurrenceManager.getMarkerAtPoint(point)
             marker.destroy()
+            searchModel.visit()
 
       when 'project-find'
         {input} = commandEvent

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -160,7 +160,7 @@ class OperationStack
 
   finish: (operation=null) ->
     @recordedOperation = operation if operation?.isRecordable()
-    @vimState.emitter.emit('did-finish-operation')
+    @vimState.emitDidFinishOperation()
 
     if @mode is 'normal'
       @ensureAllSelectionsAreEmpty(operation)

--- a/lib/register-manager.coffee
+++ b/lib/register-manager.coffee
@@ -130,10 +130,13 @@ class RegisterManager
       @name = name if @isValidName(name)
     else
       @vimState.hover.add '"'
-      @vimState.onDidConfirmInput (@name) =>
+      disposable = @vimState.onDidConfirmInput (@name) =>
+        disposable.dispose()
         @vimState.toggleClassList('with-register', @hasName())
         @vimState.hover.add(@name)
-      @vimState.onDidCancelInput => @vimState.hover.reset()
+      @vimState.onDidCancelInput =>
+        disposable.disposable()
+        @vimState.hover.reset()
       @vimState.input.focus(1)
 
   getCopyType: (text) ->

--- a/lib/search-input.coffee
+++ b/lib/search-input.coffee
@@ -123,7 +123,7 @@ class SearchInput extends HTMLElement
     @registerCommands()
     this
 
-  emitDidCommand: (name, options={})->
+  emitDidCommand: (name, options={}) ->
     options.name = name
     options.input = @editor.getText()
     @emitter.emit('did-command', options)

--- a/lib/search-input.coffee
+++ b/lib/search-input.coffee
@@ -62,7 +62,7 @@ class SearchInput extends HTMLElement
       @cancel() unless @finished
 
   unfocus: ->
-    @editorElement.classList.remove(@options.classList...) if @options.classList?
+    @editorElement.classList.remove(@options.classList...) if @options?.classList?
     @regexSearchStatus.classList.add 'btn-primary'
     @literalModeDeactivator?.dispose()
 

--- a/lib/search-input.coffee
+++ b/lib/search-input.coffee
@@ -51,7 +51,7 @@ class SearchInput extends HTMLElement
   focus: (@options={}) ->
     @finished = false
 
-    @editorElement.classList.add('backwards') if @options.backwards
+    @editorElement.classList.add(@options.classList...) if @options.classList?
     @panel.show()
     @editorElement.focus()
     @commandSubscriptions = @handleEvents()
@@ -62,7 +62,7 @@ class SearchInput extends HTMLElement
       @cancel() unless @finished
 
   unfocus: ->
-    @editorElement.classList.remove('backwards')
+    @editorElement.classList.remove(@options.classList...) if @options.classList?
     @regexSearchStatus.classList.add 'btn-primary'
     @literalModeDeactivator?.dispose()
 
@@ -123,6 +123,11 @@ class SearchInput extends HTMLElement
     @registerCommands()
     this
 
+  emitDidCommand: (name, options={})->
+    options.name = name
+    options.input = @editor.getText()
+    @emitter.emit('did-command', options)
+
   registerCommands: ->
     atom.commands.add @editorElement, @stopPropagation(
       "search-confirm": => @confirm()
@@ -130,13 +135,14 @@ class SearchInput extends HTMLElement
       "search-land-to-end": => @confirm('end')
       "search-cancel": => @cancel()
 
-      "search-visit-next": => @emitter.emit('did-command', name: 'visit', direction: 'next')
-      "search-visit-prev": => @emitter.emit('did-command', name: 'visit', direction: 'prev')
+      "search-visit-next": => @emitDidCommand('visit', direction: 'next')
+      "search-visit-prev": => @emitDidCommand('visit', direction: 'prev')
 
-      "select-occurrence-from-search": => @emitter.emit('did-command', name: 'occurrence', operation: 'SelectOccurrence')
-      "change-occurrence-from-search": => @emitter.emit('did-command', name: 'occurrence', operation: 'ChangeOccurrence')
-      "add-occurrence-pattern-from-search": => @emitter.emit('did-command', name: 'occurrence')
-      "project-find-from-search": => @emitter.emit('did-command', name: 'project-find')
+      "select-occurrence-from-search": => @emitDidCommand('occurrence', operation: 'SelectOccurrence')
+      "change-occurrence-from-search": => @emitDidCommand('occurrence', operation: 'ChangeOccurrence')
+      "add-occurrence-pattern-from-search": => @emitDidCommand('occurrence')
+      "project-find-from-search": => @emitDidCommand('project-find')
+      "toggle-occurrence-from-search": => @emitDidCommand('toggle-occurrence')
 
       "search-insert-wild-pattern": => @editor.insertText('.*?')
       "search-activate-literal-mode": => @activateLiteralMode()

--- a/lib/search-model.coffee
+++ b/lib/search-model.coffee
@@ -11,6 +11,7 @@ settings = require './settings'
 module.exports =
 class SearchModel
   relativeIndex: 0
+  lastRelativeIndex: null
   onDidChangeCurrentMatch: (fn) -> @emitter.on 'did-change-current-match', fn
 
   constructor: (@vimState, @options) ->
@@ -120,7 +121,12 @@ class SearchModel
     @currentMatch = @matches[@currentMatchIndex]
     @emitter.emit('did-change-current-match')
 
-  visit: (relativeIndex) ->
+  visit: (relativeIndex=null) ->
+    if relativeIndex?
+      @lastRelativeIndex = relativeIndex
+    else
+      relativeIndex = @lastRelativeIndex ? +1
+
     return unless @matches.length
     oldDecoration = @decoationByRange[@currentMatch.toString()]
     @updateCurrentMatch(relativeIndex)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -158,6 +158,7 @@ class VimState
   emitDidSetOperatorModifier: (options) -> @emitter.emit('did-set-operator-modifier', options)
 
   onDidFinishOperation: (fn) -> @subscribe @emitter.on('did-finish-operation', fn)
+  emitDidFinishOperation: -> @emitter.emit('did-finish-operation')
 
   onDidResetOperationStack: (fn) -> @subscribe @emitter.on('did-reset-operation-stack', fn)
   emitDidResetOperationStack: -> @emitter.emit('did-reset-operation-stack')

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -258,7 +258,7 @@ describe "Occurrence", ->
 
     beforeEach ->
       searchEditor = vimState.searchInput.editor
-      searchEditorElement = searchEditor.element
+      searchEditorElement = vimState.searchInput.editorElement
       jasmine.attachToDOM(getView(atom.workspace))
       settings.set('incrementalSearch', true)
       set
@@ -726,6 +726,70 @@ describe "Occurrence", ->
             text: """
             ooo: XXX: ooo xxx: ooo:
             xxx: ooo: XXX: ooo xxx: ooo:
+            """
+
+    describe "search occurrence", ->
+      [searchEditor, searchEditorElement] = []
+      beforeEach ->
+        searchEditor = vimState.searchInput.editor
+        searchEditorElement = vimState.searchInput.editorElement
+        jasmine.attachToDOM(getView(atom.workspace))
+        settings.set('incrementalSearch', true)
+        set
+          text: """
+          ooo: xxx: ooo
+          !!!: ooo: xxx:
+          ooo: xxx: ooo:
+          """
+          cursor: [0, 0]
+
+        runs ->
+          ensure 'g o',
+            occurrenceText: ['ooo', 'ooo', 'ooo', 'ooo', 'ooo']
+        waitsFor ->
+          editorElement.classList.contains('has-occurrence')
+
+      describe "tab, shift-tab", ->
+        it "search next/previous occurrence marker", ->
+          keystroke 'tab'
+          rawKeystroke('tab enter', searchEditorElement)
+          ensure cursor: [1, 5]
+
+          keystroke 'tab'
+          rawKeystroke('tab enter', searchEditorElement)
+          ensure cursor: [2, 10]
+
+          keystroke 'shift-tab'
+          rawKeystroke('shift-tab enter', searchEditorElement)
+          ensure cursor: [1, 5]
+
+          keystroke 'shift-tab'
+          rawKeystroke('shift-tab enter', searchEditorElement)
+          ensure cursor: [0, 0]
+
+      describe "space can clear preset-marker", ->
+        it "clear preset-occurrence and move to next", ->
+          keystroke 'tab'
+          rawKeystroke('tab space tab enter', searchEditorElement)
+          ensure cursor: [2, 10], occurrenceCount: 4
+
+          ensure 'g U i p',
+            text: """
+            OOO: xxx: OOO
+            !!!: ooo: xxx:
+            OOO: xxx: OOO:
+            """
+
+        it "clear preset-occurrence and move to previous", ->
+          keystroke 'shift-tab'
+          rawKeystroke('shift-tab space shift-tab enter', searchEditorElement)
+          ensure cursor: [0, 10], occurrenceCount: 4
+
+          ensure 'g U i p',
+            text: """
+            OOO: xxx: OOO
+            !!!: OOO: xxx:
+            ooo: xxx: OOO:
             """
 
     describe "explict operator-modifier o and preset-marker", ->

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -258,7 +258,7 @@ describe "Occurrence", ->
 
     beforeEach ->
       searchEditor = vimState.searchInput.editor
-      searchEditorElement = vimState.searchInput.editorElement
+      searchEditorElement = searchEditor.element
       jasmine.attachToDOM(getView(atom.workspace))
       settings.set('incrementalSearch', true)
       set

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -49,6 +49,24 @@ describe "Prefixes", ->
         set    register: a: text: 'new content'
         ensure register: a: text: 'new content'
 
+    describe "with yank command", ->
+      beforeEach ->
+        set register: a: text: ''
+        set register: b: text: ''
+        set register: b: text: ''
+        set
+          cursor: [0, 0]
+          text: """
+          aaa bbb ccc
+          """
+      it "save to pre specified register", ->
+        ensure '" a y i w', register: a: text: 'aaa'
+        ensure 'w " b y i w', register: b: text: 'bbb'
+        ensure 'w " c y i w', register: c: text: 'ccc'
+
+      it "work with motion which also require input such as 't'", ->
+        ensure ['" a y t', {input: 'c'}], register: a: text: 'aaa bbb '
+
     describe "the B register", ->
       it "saves a value for future reading", ->
         set    register: B: text: 'new content'

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -195,11 +195,24 @@ atom-text-editor[mini].vim-mode-plus-search {
   }
 }
 
+atom-text-editor:not(.silent) {
+  .vim-mode-plus-search-match {
+    .region {
+      background-color: @syntax-result-marker-color;
+    }
+    &.first .region {
+      background-color: fadeout(@syntax-color-renamed, 60%);
+    }
+    &.last .region {
+      background-color: fadeout(@syntax-color-removed, 60%);
+    }
+  }
+}
+
 atom-text-editor {
   .vim-mode-plus-search-match {
     .region {
       .vim-mode-plus.round-box;
-      background-color: @syntax-result-marker-color;
       border: 2px solid transparent;
       transition: border-color .2s;
     }
@@ -207,14 +220,8 @@ atom-text-editor {
       border-color: @syntax-result-marker-color-selected;
       transition-duration: .1s;
     }
-    &.first .region {
-      background-color: fadeout(@syntax-color-renamed, 60%);
-    }
     &.first.current .region {
       border-color: @syntax-color-renamed;
-    }
-    &.last .region {
-      background-color: fadeout(@syntax-color-removed, 60%);
     }
     &.last.current .region {
       border-color: @syntax-color-removed;


### PR DESCRIPTION
Implement #513

# Spec

- Editor has `has-occurrence` scope when user set `preset-occurrence` or set `occurrence-operator-modifier`(e.g. `o` in `c o f`).
- To say simply `has-occurrence` editor is editor where you see underlined-occurrence-marker.
- In `has-occurrence` editor `shift`, `shfit-tab` invokes `search-occurrence`/`search-occurrence-backwards` motion.(off course except `insert-mode`)
- These two motions are just kind of `incremental-search` with preset search pattern(which search pattern is occurrence pattern).
- Suppress `highlight-search` update(may be further visual-effect-suppression is preferred?)
- These commands allow you to move around to next/previous occurrence marker.
- When `enter`, your cursor is settled.
- This is motion, so you can use this as operator's target.
- `space` is bound to `toggle-occurrence-from-search`, which clear occurrence-marker at current match.

# Use case

Here is the case I come up with this motion's idea.(code is just example, not necessarily meaningful)

- My cursor is at `projects`, I want change it to non-plural `project`.
- But simply doing `c o f` also replace `@projects` which I don't want to change.

With these new motion, flow would be
1. place your cursor at first `projects`.
2. `m`(`g o` by default) to preset `projects` as occurrence.
3. `c tab space tab enter` or `A tab space tab enter`(this is better in this scenario)
    - `c`: `change` or `A`: `insert-at-end-of-target`
    - `tab`: `search-occurrence`
    - `space`: `toggle-occurrence-from-search`: this skips `@projects` under current match.
    - `tab`: `search-occurrence`
    - `enter`: `core:confirm`

- You can decide target area till which occurrences are included **interactively** by seeing UI feedback of `incremental-search` editor.
- As bonus, you can exclude particular instance of `occurrence` by typing `space` while visiting next/prev occurrence via `tab`, `shift-tab`.

```coffeescript

  initialize: ->
    {currentProjectOnly, word} = @options
    if currentProjectOnly
      project = null # initial cursor line
      @projects = atom.project.getPaths() # I don't want this to change
      filePath = @editor.getPath()
      for dir in atom.project.getDirectories() when dir.contains(filePath)
        project = [dir.getPath()]
        break

      unless project? # want to limit operation to this line.
        message = "#{editor.getPath()} not belonging to any project"
        atom.notifications.addInfo message, dismissable: true
        @canceled = true
    else
      @projects = atom.project.getPaths() # I don't want this to change

```

- `m c tab space tab enter`

![search-occurrence](https://cloud.githubusercontent.com/assets/155205/20516859/dca80e34-b0db-11e6-92f0-32f103c19b44.gif)

- `m A tab space tab enter`

![search-occurrence-a](https://cloud.githubusercontent.com/assets/155205/20516853/d792a9fe-b0db-11e6-9b6f-23394d2cb10c.gif)
