### PR TITLE
Don't share input ui across operations

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -254,6 +254,7 @@
 
 'atom-text-editor.vim-mode-plus-input-char-waiting':
   'enter': 'core:confirm'
+  'escape': 'core:cancel'
 
   'space': 'vim-mode-plus:set-input-char-space'
   '!': 'vim-mode-plus:set-input-char-!'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -9,16 +9,14 @@ Delegato = require 'delegato'
 } = require './utils'
 swrap = require './selection-wrapper'
 
+Input = require './input'
+
 settings = require './settings'
 selectList = null
 getEditorState = null # set by Base.init()
 {OperationAbortedError} = require './errors'
 
 vimStateMethods = [
-  "onDidChangeInput"
-  "onDidConfirmInput"
-  "onDidCancelInput"
-
   "onDidChangeSearch"
   "onDidConfirmSearch"
   "onDidCancelSearch"
@@ -161,6 +159,9 @@ class Base
     klass = Base.getClass(name)
     new klass(@vimState, properties)
 
+  newInputUI: ->
+    new Input(@vimState)
+
   clone: (vimState) ->
     properties = {}
     excludeProperties = ['editor', 'editorElement', 'globalState', 'vimState']
@@ -186,11 +187,8 @@ class Base
   getInput: -> @input
 
   focusInput: (charsMax) ->
-    @onDidConfirmInput (input) =>
-      # [FIXME REALLY] when both operator and motion take user-input,
-      # Currently input UI is inappropreately shared by operator and motion.
-      # So without this guard, @input is overwritten by later input.
-      # console.log "#{@getName()} got input", input
+    inputUI = @newInputUI()
+    inputUI.onDidConfirm (input) =>
       unless @input?
         @input = input
         @processOperation()
@@ -199,14 +197,14 @@ class Base
     # to sync content with input mini editor.
     unless charsMax is 1
       replace = false
-      @onDidChangeInput (input) =>
+      inputUI.onDidChange (input) =>
         @addHover(input, {replace})
         replace = true
 
-    @onDidCancelInput =>
+    inputUI.onDidCancel =>
       @cancelOperation()
 
-    @vimState.input.focus(charsMax)
+    inputUI.focus(charsMax)
 
   getVimEofBufferPosition: ->
     getVimEofBufferPosition(@editor)

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -188,8 +188,9 @@ class Base
   focusInput: (charsMax) ->
     @onDidConfirmInput (input) =>
       # [FIXME REALLY] when both operator and motion take user-input,
-      # Currently input UI is unappropreately shared by operator and motion.
+      # Currently input UI is inappropreately shared by operator and motion.
       # So without this guard, @input is overwritten by later input.
+      # console.log "#{@getName()} got input", input
       unless @input?
         @input = input
         @processOperation()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -401,15 +401,15 @@ class Surround extends TransformString
     return unless @requireInput
     if @requireTarget
       @onDidSetTarget =>
-        @onDidConfirmInput (input) => @onConfirm(input)
-        @onDidChangeInput (input) => @addHover(input)
-        @onDidCancelInput => @cancelOperation()
-        @vimState.input.focus(@charsMax)
+        @focusInput(@charsMax)
     else
-      @onDidConfirmInput (input) => @onConfirm(input)
-      @onDidChangeInput (input) => @addHover(input)
-      @onDidCancelInput => @cancelOperation()
-      @vimState.input.focus(@charsMax)
+      @focusInput(@charsMax)
+
+  focusInput: (charsMax) ->
+    @onDidConfirmInput (input) => @onConfirm(input)
+    @onDidChangeInput (input) => @addHover(input)
+    @onDidCancelInput => @cancelOperation()
+    @vimState.input.focus(charsMax)
 
   onConfirm: (@input) ->
     @processOperation()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -406,10 +406,11 @@ class Surround extends TransformString
       @focusInput(@charsMax)
 
   focusInput: (charsMax) ->
-    @onDidConfirmInput (input) => @onConfirm(input)
-    @onDidChangeInput (input) => @addHover(input)
-    @onDidCancelInput => @cancelOperation()
-    @vimState.input.focus(charsMax)
+    @inputUI = @newInputUI()
+    @inputUI.onDidConfirm(@onConfirm.bind(this))
+    @inputUI.onDidChange(@addHover.bind(this))
+    @inputUI.onDidCancel(@cancelOperation.bind(this))
+    @inputUI.focus(charsMax)
 
   onConfirm: (@input) ->
     @processOperation()
@@ -503,23 +504,21 @@ class ChangeSurroundAnyPair extends ChangeSurround
   charsMax: 1
   target: "AAnyPair"
 
-  highlightTargetRange: (selection) ->
-    if range = @target.getRange(selection)
-      marker = @editor.markBufferRange(range)
-      @editor.decorateMarker(marker, type: 'highlight', class: 'vim-mode-plus-target-range')
-      marker
-    else
-      null
+  highlightRange: (range) ->
+    marker = @editor.markBufferRange(range)
+    @editor.decorateMarker(marker, type: 'highlight', class: 'vim-mode-plus-target-range')
+    marker
 
   initialize: ->
     marker = null
     @onDidSetTarget =>
-      if marker = @highlightTargetRange(@editor.getLastSelection())
+      if range = @target.getRange(@editor.getLastSelection())
+        marker = @highlightRange(range)
         textRange = Range.fromPointWithDelta(marker.getBufferRange().start, 0, 1)
         char = @editor.getTextInBufferRange(textRange)
         @addHover(char, {}, @editor.getCursorBufferPosition())
       else
-        @vimState.input.cancel()
+        @inputUI.cancel()
         @abort()
 
     @onDidResetOperationStack ->

--- a/lib/register-manager.coffee
+++ b/lib/register-manager.coffee
@@ -1,5 +1,6 @@
 settings = require './settings'
 {CompositeDisposable} = require 'atom'
+Input = require './input'
 
 REGISTERS = /// (
   ?: [a-zA-Z*+%_".]
@@ -131,15 +132,14 @@ class RegisterManager
       @name = name if @isValidName(name)
     else
       @vimState.hover.add '"'
-      inputSubscriptions = new CompositeDisposable()
-      inputSubscriptions.add @vimState.onDidConfirmInput (@name) =>
-        inputSubscriptions.dispose()
-        @vimState.toggleClassList('with-register', @hasName())
+
+      inputUI = new Input(@vimState)
+      inputUI.onDidConfirm (@name) =>
+        @vimState.toggleClassList('with-register', true)
         @vimState.hover.add(@name)
-      inputSubscriptions.add @vimState.onDidCancelInput =>
-        inputSubscriptions.disposable()
+      inputUI.onDidCancel =>
         @vimState.hover.reset()
-      @vimState.input.focus(1)
+      inputUI.focus(1)
 
   getCopyType: (text) ->
     if text.lastIndexOf("\n") is text.length - 1

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -7,7 +7,6 @@ _ = require 'underscore-plus'
 
 settings = require './settings'
 {HoverElement} = require './hover'
-Input = require './input'
 SearchInputElement = require './search-input'
 {
   highlightRanges
@@ -59,7 +58,6 @@ class VimState
     @mutationManager = new MutationManager(this)
     @flashManager = new FlashManager(this)
 
-    @input = new Input(this)
     @searchInput = new SearchInputElement().initialize(this)
 
     @operationStack = new OperationStack(this)
@@ -126,10 +124,6 @@ class VimState
 
   # All subscriptions here is celared on each operation finished.
   # -------------------------
-  onDidChangeInput: (fn) -> @subscribe @input.onDidChange(fn)
-  onDidConfirmInput: (fn) -> @subscribe @input.onDidConfirm(fn)
-  onDidCancelInput: (fn) -> @subscribe @input.onDidCancel(fn)
-
   onDidChangeSearch: (fn) -> @subscribe @searchInput.onDidChange(fn)
   onDidConfirmSearch: (fn) -> @subscribe @searchInput.onDidConfirm(fn)
   onDidCancelSearch: (fn) -> @subscribe @searchInput.onDidCancel(fn)
@@ -198,15 +192,13 @@ class VimState
     @hoverSearchCounter?.destroy?()
     @searchHistory?.destroy?()
     @cursorStyleManager?.destroy?()
-    @input?.destroy?()
     @search?.destroy?()
     @register?.destroy?
     {
       @hover, @hoverSearchCounter, @operationStack,
       @searchHistory, @cursorStyleManager
-      @input, @search, @modeManager, @register
+      @search, @modeManager, @register
       @editor, @editorElement, @subscriptions,
-      @inputCharSubscriptions
       @occurrenceManager
       @previousSelection
       @persistentSelection

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -944,16 +944,12 @@ describe "Operator general", ->
       ensure ['r', input: 'x'], text: 'x2\nx4\n\n'
 
     it "does nothing when cancelled", ->
-      keystroke 'r'
-      vimState.input.cancel()
-      ensure
+      ensure 'r escape',
         text: '12\n34\n\n'
         mode: 'normal'
 
     it "remain visual-mode when cancelled", ->
-      keystroke 'v r'
-      vimState.input.cancel()
-      ensure
+      ensure 'v r escape',
         text: '12\n34\n\n'
         mode: ['visual', 'characterwise']
 

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -160,9 +160,7 @@ describe "Prefixes", ->
         ensure ['ctrl-r', input: 'a'], text: '01abc2\n'
 
       it "is cancelled with the escape key", ->
-        keystroke 'ctrl-r'
-        atom.commands.dispatch(vimState.input.editorElement, 'core:cancel')
-        ensure
+        ensure 'ctrl-r escape',
           text: '012\n'
           mode: 'insert'
           cursor: [0, 2]

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -162,13 +162,16 @@ describe "VimState", ->
         set text: '012345\nabcdef'
 
       it 'properly clears the operations', ->
-        ensure 'd r',
-          mode: 'normal'
+
+        ensure 'd', mode: 'operator-pending'
+        expect(vimState.operationStack.isEmpty()).toBe(false)
+        ensure 'r', mode: 'normal'
         expect(vimState.operationStack.isEmpty()).toBe(true)
-        target = vimState.input.editorElement
-        keystroke 'd'
-        atom.commands.dispatch(target, 'core:cancel')
-        ensure text: '012345\nabcdef'
+
+        ensure 'd', mode: 'operator-pending'
+        expect(vimState.operationStack.isEmpty()).toBe(false)
+        ensure 'escape', mode: 'normal', text: '012345\nabcdef'
+        expect(vimState.operationStack.isEmpty()).toBe(true)
 
   describe "activate-normal-mode-once command", ->
     beforeEach ->


### PR DESCRIPTION
Related
#520
#491


input UI now instantiated per Operation(motion, text-object, operator).
