### PR TITLE
Further compatible cursor positioning after operation

### DIFF
--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -107,6 +107,13 @@ class Motion extends Base
 
     @updateSelectionProperties() if @isMode('visual')
 
+    if @hasOperator()
+      if @isMode('visual')
+        if @isMode('visual', 'linewise') and @editor.getLastSelection().isReversed()
+          @vimState.mutationManager.setCheckPoint('did-move')
+      else
+        @vimState.mutationManager.setCheckPoint('did-move')
+
     # Modify selection to submode-wisely
     switch @wise
       when 'linewise' then @vimState.selectLinewise()
@@ -698,8 +705,8 @@ class MoveToRelativeLine extends Motion
   getCount: ->
     super - 1
 
-  getPoint: ({row}) ->
-    [row + @getCount(), 0]
+  getPoint: ({row, column}) ->
+    [row + @getCount(), column]
 
 class MoveToRelativeLineWithMinimum extends MoveToRelativeLine
   @extend(false)

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -143,5 +143,7 @@ class Mutation
     else
       if mutationEnd
         @getMutationEnd()
+      else if @checkPoint['did-move']?
+        @checkPoint['did-move'].start
       else
         @checkPoint['did-select']?.start

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -17,7 +17,7 @@ transformerRegistry = []
 class TransformString extends Operator
   @extend(false)
   trackChange: true
-  stayOnLinewiseMotion: true
+  stayOptionName: 'stayOnTransformString'
   autoIndent: false
 
   @registerToSelectList: ->
@@ -345,7 +345,6 @@ class SwapWithRegister extends TransformString
 class Indent extends TransformString
   @extend()
   hover: icon: ':indent:', emoji: ':point_right:'
-  stayOnLinewiseMotion: false
   useMarkerForStay: true
   clipToMutationEndOnStay: false
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -31,8 +31,8 @@ class Operator extends Base
   occurrence: false
 
   patternForOccurrence: null
-  stayOnLinewiseMotion: false
   stayAtSamePosition: null
+  stayOptionName: null
   clipToMutationEndOnStay: true
   useMarkerForStay: false
   restorePositions: true
@@ -42,29 +42,11 @@ class Operator extends Base
   acceptPresetOccurrence: true
   acceptPersistentSelection: true
 
-  # [FIXME]
-  # For TextObject, isLinewise result is changed before / after select.
-  # This mean return value may change depending on when you call.
   needStay: ->
-    @stayAtSamePosition ?= do =>
-      param = @getStayParam()
-      if @isMode('visual', 'linewise')
-        @editor.getLastSelection().isReversed() or settings.get(param)
-      else
-        settings.get(param) or (
-          @stayOnLinewiseMotion and @target.isMotion() and @target.isLinewise()
-        )
-
-  getStayParam: ->
-    switch
-      when @instanceof('Increase')
-        'stayOnIncrease'
-      when @instanceof('TransformString')
-        'stayOnTransformString'
-      when @instanceof('Delete')
-        'stayOnDelete'
-      else
-        "stayOn#{@getName()}"
+    if @stayAtSamePosition?
+      @stayAtSamePosition
+    else
+      @stayOptionName? and settings.get(@stayOptionName)
 
   isOccurrence: ->
     @occurrence
@@ -364,6 +346,7 @@ class Delete extends Operator
   hover: icon: ':delete:', emoji: ':scissors:'
   trackChange: true
   flashTarget: false
+  stayOptionName: 'stayOnDelete'
 
   execute: ->
     @onDidSelectTarget =>
@@ -422,8 +405,8 @@ class Yank extends Operator
   @extend()
   hover: icon: ':yank:', emoji: ':clipboard:'
   trackChange: true
-  stayOnLinewiseMotion: true
   clipToMutationEndOnStay: false
+  stayOptionName: 'stayOnYank'
 
   mutateSelection: (selection) ->
     @setTextToRegisterForSelection(selection)
@@ -435,8 +418,6 @@ class YankLine extends Yank
   initialize: ->
     super
     @target = 'MoveToRelativeLine' if @isMode('normal')
-    if @isMode('visual', 'characterwise')
-      @stayOnLinewiseMotion = false
 
 class YankToLastCharacterOfLine extends Yank
   @extend()
@@ -449,6 +430,7 @@ class YankToLastCharacterOfLine extends Yank
 class Increase extends Operator
   @extend()
   requireTarget: false
+  stayOptionName: 'stayOnIncrease'
   step: 1
 
   execute: ->

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -499,23 +499,23 @@ describe "Operator general", ->
         set
           cursor: [0, 4]
           text: """
-          0000
-          1111
-          2222\n
-          """
+            000000
+            111111
+            222222\n
+            """
 
       describe "selection not reversed", ->
         it "saves to register(type=linewise), cursor move to start of target", ->
           ensure "V j y",
             cursor: [0, 0]
-            register: '"': text: "0000\n1111\n", type: 'linewise'
+            register: '"': text: "000000\n111111\n", type: 'linewise'
 
       describe "selection is reversed", ->
         it "saves to register(type=linewise), cursor doesn't move", ->
           set cursor: [2, 2]
           ensure "V k y",
             cursor: [1, 2]
-            register: '"': text: "1111\n2222\n", type: 'linewise'
+            register: '"': text: "111111\n222222\n", type: 'linewise'
 
     describe "y y", ->
       it "saves to register(type=linewise), cursor stay at same position", ->
@@ -679,14 +679,13 @@ describe "Operator general", ->
           text: "no newline!\nno newline!\nno newline!"
 
   describe "the Y keybinding", ->
-    text = """
-    012 345
-    abc\n
-    """
+    text = null
     beforeEach ->
-      set
-        text: text
-        cursor: [0, 4]
+      text = """
+      012 345
+      abc\n
+      """
+      set text: text, cursor: [0, 4]
 
     it "saves the line to the default register", ->
       ensure 'Y', cursor: [0, 4], register: '"': text: "012 345\n"


### PR DESCRIPTION
Fix #507

Now more compatible/accurate cursor position after operator finished.

- In most case cursor land at start of target.
- When `vL` and selection is reversed, cursor land at characterwise head(=start of characterwise-lection).
- When target is linewise motion, then cursor land at start of **characterwised** target lange.
