### PR TITLE
new option automaticallyEscapeInesrtModeOnActivePaneItemChange…

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,6 +47,11 @@ module.exports =
     @subscribe atom.workspace.onDidChangeActivePane ->
       workspaceClassList.remove('vim-mode-plus-pane-maximized', 'hide-tab-bar')
 
+    @subscribe atom.workspace.onDidChangeActivePaneItem =>
+      if settings.get('automaticallyEscapeInesrtModeOnActivePaneItemChange')
+        @vimStatesByEditor.forEach (vimState) ->
+          vimState.activate('normal') if vimState.mode is 'insert'
+
     @subscribe atom.workspace.onDidStopChangingActivePaneItem (item) =>
       if atom.workspace.isTextEditor(item)
         # Still there is possibility editor is destroyed and don't have corresponding

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -46,6 +46,9 @@ module.exports = new Settings 'vim-mode-plus',
     description: 'Start in insert-mode whan editorElement matches scope'
   clearMultipleCursorsOnEscapeInsertMode: false
   autoSelectPersistentSelectionOnOperate: true
+  automaticallyEscapeInesrtModeOnActivePaneItemChange:
+    default: false
+    description: '[Experimental]'
   wrapLeftRightMotion: false
   numberRegex:
     default: '-?[0-9]+'

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -48,7 +48,7 @@ module.exports = new Settings 'vim-mode-plus',
   autoSelectPersistentSelectionOnOperate: true
   automaticallyEscapeInesrtModeOnActivePaneItemChange:
     default: false
-    description: '[Experimental]'
+    description: 'Escape insert-mode on tab switch, pane switch'
   wrapLeftRightMotion: false
   numberRegex:
     default: '-?[0-9]+'

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -235,7 +235,7 @@ describe "VimState", ->
         it "clear multiple cursor on escape", ->
           ensure 'escape', mode: 'normal', numCursors: 2
 
-    fdescribe "automaticallyEscapeInesrtModeOnActivePaneItemChange setting", ->
+    describe "automaticallyEscapeInesrtModeOnActivePaneItemChange setting", ->
       [otherVim, otherEditor, pane] = []
 
       beforeEach ->

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -235,6 +235,44 @@ describe "VimState", ->
         it "clear multiple cursor on escape", ->
           ensure 'escape', mode: 'normal', numCursors: 2
 
+    fdescribe "automaticallyEscapeInesrtModeOnActivePaneItemChange setting", ->
+      [otherVim, otherEditor, pane] = []
+
+      beforeEach ->
+        getVimState (otherVimState, _other) ->
+          otherVim = _other
+          otherEditor = otherVimState.editor
+
+        runs ->
+          pane = atom.workspace.getActivePane()
+          pane.activateItem(editor)
+
+          set textC: "|editor-1"
+          otherVim.set textC: "|editor-2"
+
+          ensure 'i', mode: 'insert'
+          otherVim.ensure 'i', mode: 'insert'
+          expect(pane.getActiveItem()).toBe(editor)
+
+      describe "default behavior", ->
+        it "remain in insert-mode on paneItem change by default", ->
+
+          pane.activateItem(otherEditor)
+          expect(pane.getActiveItem()).toBe(otherEditor)
+          
+          ensure mode: 'insert'
+          otherVim.ensure mode: 'insert'
+
+      describe "automaticallyEscapeInesrtModeOnActivePaneItemChange = true", ->
+        beforeEach ->
+          settings.set('automaticallyEscapeInesrtModeOnActivePaneItemChange', true)
+
+        it "return to escape mode for all vimEditors", ->
+          pane.activateItem(otherEditor)
+          expect(pane.getActiveItem()).toBe(otherEditor)
+          ensure mode: 'normal'
+          otherVim.ensure mode: 'normal'
+
   describe "replace-mode", ->
     describe "with content", ->
       beforeEach -> set text: "012345\n\nabcdef"


### PR DESCRIPTION
fix #535

Introduce new config option
- `automaticallyEscapeInesrtModeOnActivePaneItemChange`: default `false`

Automatically return to `normal-mode` for `insert-mode` editors on activePaneItem change.
- activePaneItem change is the event fired at tab-switch(`cmd-{`, `cmd-}`)(pane is same bug active tab was changed), pane-change.
- this options works for only `insert-mode` editor, so other mode state's(`visual-mode`, `operator-pending`) editors are not affect by this option.
