### PR TITLE
cleanup and improve accuracy of undo/redo

### DIFF
--- a/lib/highlight-search-manager.coffee
+++ b/lib/highlight-search-manager.coffee
@@ -10,11 +10,10 @@ class HighlightSearchManager
     @disposables = new CompositeDisposable
     @markerLayer = @editor.addMarkerLayer()
 
-    options =
+    decorationOptions =
       type: 'highlight'
-      invalidate: 'inside'
       class: 'vim-mode-plus-highlight-search'
-    @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, options)
+    @decorationLayer = @editor.decorateMarkerLayer(@markerLayer, decorationOptions)
 
     @disposables.add @vimState.onDidDestroy(@destroy.bind(this))
 
@@ -52,4 +51,4 @@ class HighlightSearchManager
     return if matchScopes(@editorElement, settings.get('highlightSearchExcludeScopes'))
 
     for range in scanEditor(@editor, pattern)
-      @markerLayer.markBufferRange(range)
+      @markerLayer.markBufferRange(range, invalidate: 'inside')

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -66,7 +66,8 @@ class Undo extends MiscCommand
       if settings.get('setCursorToStartOfChangeOnUndoRedo')
         @editor.setCursorBufferPosition(range.start)
 
-    @editor.clearSelections()
+    for selection in @editor.getSelections()
+      selection.clear()
     @activateMode('normal')
 
   mutate: ->

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -41,7 +41,7 @@ class Undo extends MiscCommand
     newRanges = []
     oldRanges = []
 
-    disposable = @editor.getBuffer().onDidChange ({oldRange, newRange}) =>
+    disposable = @editor.getBuffer().onDidChange ({oldRange, newRange}) ->
       oldRanges.push(oldRange) unless oldRange.isEmpty()
       newRanges.push(newRange) unless newRange.isEmpty()
 

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -8,6 +8,7 @@ _ = require 'underscore-plus'
 {
   pointIsAtEndOfLine
   mergeIntersectingRanges
+  sortRanges
 } = require './utils'
 
 class MiscCommand extends Base
@@ -36,57 +37,28 @@ class BlockwiseOtherEnd extends ReverseSelections
 class Undo extends MiscCommand
   @extend()
 
-  saveRangeAsMarker: (markers, range) ->
-    if _.all(markers, (m) -> not m.getBufferRange().intersectsWith(range))
-      markers.push @editor.markBufferRange(range)
-
-  trimEndOfLineRange: (range) ->
-    {start} = range
-    if (start.column isnt 0) and pointIsAtEndOfLine(@editor, start)
-      range.traverse([+1, 0], [0, 0])
-    else
-      range
-
-  mapToChangedRanges: (list, fn) ->
-    ranges = list.map (e) -> fn(e)
-    mergeIntersectingRanges(ranges).map (r) =>
-      @trimEndOfLineRange(r)
-
   mutateWithTrackingChanges: (fn) ->
-    markersAdded = []
-    rangesRemoved = []
+    newRanges = []
+    oldRanges = []
 
     disposable = @editor.getBuffer().onDidChange ({oldRange, newRange}) =>
-      # To highlight(decorate) removed range, I don't want marker's auto-tracking-range-change feature.
-      # So here I simply use range for removal
-      rangesRemoved.push(oldRange) unless oldRange.isEmpty()
-      # For added range I want marker's auto-tracking-range-change feature.
-      @saveRangeAsMarker(markersAdded, newRange) unless newRange.isEmpty()
+      oldRanges.push(oldRange) unless oldRange.isEmpty()
+      newRanges.push(newRange) unless newRange.isEmpty()
+
     @mutate()
+
     disposable.dispose()
 
-    # FIXME: this is still not completely accurate and heavy approach.
-    # To accurately track range updated, need to add/remove manually.
-    rangesAdded = @mapToChangedRanges markersAdded, (m) -> m.getBufferRange()
-    markersAdded.forEach (m) -> m.destroy()
-    rangesRemoved = @mapToChangedRanges rangesRemoved, (r) -> r
+    newRanges = mergeIntersectingRanges(newRanges)
+    oldRanges = mergeIntersectingRanges(oldRanges)
 
-    firstAdded = rangesAdded[0]
-    lastRemoved = _.last(rangesRemoved)
-    range =
-      if firstAdded? and lastRemoved?
-        if firstAdded.start.isLessThan(lastRemoved.start)
-          firstAdded
-        else
-          lastRemoved
-      else
-        firstAdded or lastRemoved
+    if range = sortRanges(_.compact([newRanges[0], _.last(oldRanges)]))[0]
+      fn(range)
 
-    fn(range) if range?
     if settings.get('flashOnUndoRedo')
       @onDidFinishOperation =>
-        @vimState.flash(rangesRemoved, type: 'removed', timeout: 500)
-        @vimState.flash(rangesAdded, type: 'added', timeout: 500)
+        @vimState.flash(oldRanges, type: 'removed', timeout: 500)
+        @vimState.flash(newRanges, type: 'added', timeout: 500)
 
   execute: ->
     @mutateWithTrackingChanges (range) =>
@@ -94,8 +66,7 @@ class Undo extends MiscCommand
       if settings.get('setCursorToStartOfChangeOnUndoRedo')
         @editor.setCursorBufferPosition(range.start)
 
-    for selection in @editor.getSelections()
-      selection.clear()
+    @editor.clearSelections()
     @activateMode('normal')
 
   mutate: ->

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -163,35 +163,75 @@ describe "Operator general", ->
           cursor: [0, 2]
 
     describe "undo behavior", ->
-      originalText = "12345\nabcde\nABCDE\nQWERT"
+      originalText = null
+
       beforeEach ->
-        set text: originalText, cursor: [1, 1]
+        set
+          textC: """
+          12345
+          a|bcde
+          ABCDE
+          QWERT
+          """
+
+        originalText = editor.getText()
 
       it "undoes both lines", ->
-        ensure 'd 2 d u', text: originalText, selectedText: ''
+        ensure 'd 2 d',
+          textC: """
+          12345
+          |QWERT
+          """
+        ensure 'u',
+          textC: """
+          12345
+          |abcde
+          ABCDE
+          QWERT
+          """
+          selectedText: ""
 
       describe "with multiple cursors", ->
         beforeEach ->
-          set cursor: [[1, 1], [0, 0]]
+          set
+            textC: """
+            |12345
+            a|bcde
+            ABCDE
+            QWERT
+            """
+          ensure 'd l',
+            textC: """
+            |2345
+            a|cde
+            ABCDE
+            QWERT
+            """
 
         describe "setCursorToStartOfChangeOnUndoRedo is true(default)", ->
-          # [FIXME] Should keep cursor?. so guranularity is not perfect in multi-cursors
-          # And ensure set position to start.
-          it "is undone as one operation and clear cursors", ->
-            ensure 'd l u',
-              text: originalText
-              selectedText: ['']
-              numCursors: 1
+          it "clear multiple cursors and set cursor to start of changes", ->
+            ensure 'u',
+              textC: """
+              |12345
+              abcde
+              ABCDE
+              QWERT
+              """
+              selectedText: ''
 
         describe "setCursorToStartOfChangeOnUndoRedo is false", ->
           beforeEach ->
             settings.set('setCursorToStartOfChangeOnUndoRedo', false)
 
-          it "is undone as one operation", ->
-            ensure 'd l u',
-              text: originalText
+          it "put cursor to end of change (works in same way of atom's core:undo)", ->
+            ensure 'u',
+              textC: """
+              1|2345
+              ab|cde
+              ABCDE
+              QWERT
+              """
               selectedText: ['', '']
-              numCursors: 2
 
     describe "when followed by a w", ->
       it "deletes the next word until the end of the line and exits operator-pending mode", ->


### PR DESCRIPTION
Putting cursor on start of changed on undo/redo was implemented in #14.
It is very old code,  Atom-core and vmp is now very different.

So will evaluate, cleanup again.

### I can’t remember why I need to use marker for newRanges, so removed.

Currently using marker for only newRange(addition).
Comment says "want marker's auto-tracking feature".
But I can't remember and can't understand why.

### I can’t remember why I need to `trimEndOfRange`(bad naming), so removed.

What actually `trimEndOfRange` is doing is "If start-of-change is at EOL of non-empty-line, then translate start-of-change to beginning-of-next-line".
But I can't remember why I need this.( I image I wanted to exclude EOL from flashing range but it should not affect cursor position placement )
And in following situation, this behavior is doing bad than helpful.

##### Expected:

1. initialText(cursor is at `|`)
```
|1st
2nd
```

2. keystoroke `A enter a b c escape`

3. finalText(cursor is at `|`)
```
1st
ab|c
2nd
```

4. undo `u`
cursor should be on `t`
```
1s|t
2nd
```

5. redo `ctrl-r`
cursor should be on `t`
```
1s|t
abc
2nd
```

##### Actual:

4. undo `u`
cursor is at **beginning-of-next-line**
```
1st
|2nd
```

5. redo `ctrl-r`
cursor is at **beginning-of-next-line**
```
1st
|abc
2nd
```
