### PR TITLE
Improve undo redo further

### DIFF
--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -105,7 +105,7 @@ class ModeManager
       replaceModeDeactivator = null
 
       if settings.get('clearMultipleCursorsOnEscapeInsertMode')
-        @editor.clearSelections()
+        @vimState.clearSelections()
 
       # When escape from insert-mode, cursor move Left.
       needSpecialCareToPreventWrapLine = atom.config.get('editor.atomicSoftTabs') ? true

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -111,9 +111,9 @@ class Motion extends Base
     if @hasOperator()
       if @isMode('visual')
         if @isMode('visual', 'linewise') and @editor.getLastSelection().isReversed()
-          @vimState.mutationManager.setCheckPoint('did-move')
+          @vimState.mutationManager.setCheckpoint('did-move')
       else
-        @vimState.mutationManager.setCheckPoint('did-move')
+        @vimState.mutationManager.setCheckpoint('did-move')
 
     # Modify selection to submode-wisely
     switch @wise

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -97,7 +97,7 @@ class MutationManager
             selection.destroy()
             continue
 
-          if isOccurrence
+          if isOccurrence and stay
             point = @vimState.getOriginalCursorPosition()
             selection.cursor.setBufferPosition(point)
           else if point = mutation.getRestorePoint({stay})

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -71,7 +71,6 @@ class MutationManager
       selection.cursor.setBufferPosition(point)
 
   restoreCursorPositions: (options) ->
-    console.log options
     {stay, isOccurrence, isBlockwise} = options
     if isBlockwise
       # [FIXME] why I need this direct manupilation?

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -71,7 +71,8 @@ class MutationManager
       selection.cursor.setBufferPosition(point)
 
   restoreCursorPositions: (options) ->
-    {stay, strict, isBlockwise} = options
+    console.log options
+    {stay, isOccurrence, isBlockwise} = options
     if isBlockwise
       # [FIXME] why I need this direct manupilation?
       # Because there's bug that blockwise selecction is not addes to each
@@ -93,14 +94,17 @@ class MutationManager
     else
       for selection, i in @editor.getSelections()
         if mutation = @mutationsBySelection.get(selection)
-          if strict and mutation.createdAt isnt 'will-select'
+          if isOccurrence and mutation.createdAt isnt 'will-select'
             selection.destroy()
             continue
 
-          if point = mutation.getRestorePoint({stay})
+          if isOccurrence
+            point = @vimState.getOriginalCursorPosition()
+            selection.cursor.setBufferPosition(point)
+          else if point = mutation.getRestorePoint({stay})
             selection.cursor.setBufferPosition(point)
         else
-          if strict
+          if isOccurrence
             selection.destroy()
 
 # mutation information is created even if selection.isEmpty()

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -4,10 +4,10 @@ swrap = require './selection-wrapper'
 # keep mutation snapshot necessary for Operator processing.
 # mutation stored by each Selection have following field
 #  marker:
-#    marker to track mutation. marker is created when `setCheckPoint`
+#    marker to track mutation. marker is created when `setCheckpoint`
 #  createdAt:
 #    'string' representing when marker was created.
-#  checkPoint: {}
+#  checkpoint: {}
 #    key is ['will-select', 'did-select', 'will-mutate', 'did-mutate']
 #    key is checkpoint, value is bufferRange for marker at that checkpoint
 #  selection:
@@ -31,30 +31,32 @@ class MutationManager
     @reset()
 
   reset: ->
-    marker.destroy() for marker in @markerLayer.getMarkers()
+    @clearMarkers()
     @mutationsBySelection.clear()
 
-  saveInitialPointForSelection: (selection) ->
-    if @vimState.isMode('visual')
-      point = swrap(selection).getBufferPositionFor('head', fromProperty: true, allowFallback: true)
-    else
-      point = swrap(selection).getBufferPositionFor('head') unless @options.isSelect
-    if @options.useMarker
-      point = @markerLayer.markBufferPosition(point, invalidate: 'never')
-    point
+  clearMarkers: (pattern) ->
+    for marker in @markerLayer.getMarkers()
+      marker.destroy()
 
-  getInitialPointForSelection: (selection) ->
-    @mutationsBySelection.get(selection)?.initialPoint
+  getInitialPointForSelection: (selection, options) ->
+    @getMutationForSelection(selection)?.getInitialPoint(options)
 
-  setCheckPoint: (checkPoint) ->
+  setCheckpoint: (checkpoint) ->
     for selection in @editor.getSelections()
-      unless @mutationsBySelection.has(selection)
-        createdAt = checkPoint
-        initialPoint = @saveInitialPointForSelection(selection)
-        options = {selection, initialPoint, createdAt, @markerLayer}
+      if @mutationsBySelection.has(selection)
+        @mutationsBySelection.get(selection).update(checkpoint)
+
+      else
+        initialPoint =
+          if @vimState.isMode('visual')
+            swrap(selection).getBufferPositionFor('head', fromProperty: true, allowFallback: true)
+          else
+            # [FIXME] investigate WHY I did: initialPoint can be null when isSelect was true
+            swrap(selection).getBufferPositionFor('head') unless @options.isSelect
+
+        {useMarker} = @options
+        options = {selection, initialPoint, checkpoint, @markerLayer, useMarker}
         @mutationsBySelection.set(selection, new Mutation(options))
-      mutation = @mutationsBySelection.get(selection)
-      mutation.update(checkPoint)
 
   getMutationForSelection: (selection) ->
     @mutationsBySelection.get(selection)
@@ -78,7 +80,7 @@ class MutationManager
       # bsInstance.selection. Need investigation.
       points = []
       @mutationsBySelection.forEach (mutation, selection) ->
-        points.push(mutation.checkPoint['will-select']?.start)
+        points.push(mutation.bufferRangeByCheckpoint['will-select']?.start)
       points = points.sort (a, b) -> a.compare(b)
       points = points.filter (point) -> point?
       if @vimState.isMode('visual', 'blockwise')
@@ -106,42 +108,47 @@ class MutationManager
           if isOccurrence
             selection.destroy()
 
-# mutation information is created even if selection.isEmpty()
+# Mutation information is created even if selection.isEmpty()
 # So that we can filter selection by when it was created.
-# e.g. some selection is created at 'will-select' checkpoint, others at 'did-select'
-# This is important since when occurrence modifier is used, selection is created at target.select()
-# In that case some selection have createdAt = `did-select`, and others is createdAt = `will-select`
+#  e.g. Some selection is created at 'will-select' checkpoint, others at 'did-select' or 'did-select-occurrence'
 class Mutation
   constructor: (options) ->
-    {@selection, @initialPoint, @createdAt, @markerLayer} = options
-    @checkPoint = {}
-    @marker = null
+    {@selection, @initialPoint, checkpoint, @markerLayer, @useMarker} = options
 
-  update: (checkPoint) ->
-    # Current non-empty selection is prioritized over marker's range.
-    # We ivalidate old marker to re-track from current selection.
+    @createdAt = checkpoint
+    if @useMarker
+      @initialPointMarker = @markerLayer.markBufferPosition(@initialPoint, invalidate: 'never')
+    @bufferRangeByCheckpoint = {}
+    @marker = null
+    @update(checkpoint)
+
+  update: (checkpoint) ->
+    # Current non-empty selection is prioritized over existing marker's range.
+    # We invalidate old marker to re-track from current selection.
     unless @selection.getBufferRange().isEmpty()
       @marker?.destroy()
       @marker = null
 
     @marker ?= @markerLayer.markBufferRange(@selection.getBufferRange(), invalidate: 'never')
-    @checkPoint[checkPoint] = @marker.getBufferRange()
+    @bufferRangeByCheckpoint[checkpoint] = @marker.getBufferRange()
 
-  getMutationEnd: ->
-    range = @marker.getBufferRange()
-    if range.isEmpty()
-      range.end
+  getStartBufferPosition: ->
+    @marker.getBufferRange().start
+
+  getEndBufferPosition: ->
+    {start, end} = @marker.getBufferRange()
+    point = Point.max(start, end.translate([0, -1]))
+    @selection.editor.clipBufferPosition(point)
+
+  getInitialPoint: ({clip}={})->
+    point = @initialPointMarker?.getHeadBufferPosition() ? @initialPoint
+    if clip
+      Point.min(@getEndBufferPosition(), point)
     else
-      point = range.end.translate([0, -1])
-      @selection.editor.clipBufferPosition(point)
+      point
 
-  getRestorePoint: (options={}) ->
-    if options.stay
-      if @initialPoint instanceof Point
-        point = @initialPoint
-      else
-        point = @initialPoint.getHeadBufferPosition()
-
-      Point.min(@getMutationEnd(), point)
+  getRestorePoint: ({stay}={}) ->
+    if stay
+      @getInitialPoint(clip: true)
     else
-      @checkPoint['did-move']?.start ? @checkPoint['did-select']?.start
+      @bufferRangeByCheckpoint['did-move']?.start ? @bufferRangeByCheckpoint['did-select']?.start

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -140,7 +140,7 @@ class Mutation
     point = Point.max(start, end.translate([0, -1]))
     @selection.editor.clipBufferPosition(point)
 
-  getInitialPoint: ({clip}={})->
+  getInitialPoint: ({clip}={}) ->
     point = @initialPointMarker?.getHeadBufferPosition() ? @initialPoint
     if clip
       Point.min(@getEndBufferPosition(), point)

--- a/lib/occurrence-manager.coffee
+++ b/lib/occurrence-manager.coffee
@@ -98,9 +98,11 @@ class OccurrenceManager
   # Select occurrence marker bufferRange intersecting current selections.
   # - Return: true/false to indicate success or fail
   #
-  # When startInsertMode was true, do special handling for which occurrence range
-  #  become lastSelection so that autocomplete+popup shows at original cursor position or near.
-  select: ({startInsertMode}={}) ->
+  # Do special handling for which occurrence range become lastSelection
+  # e.g.
+  #  - c(change): So that autocomplete+popup shows at original cursor position or near.
+  #  - g U(upper-case): So that undo/redo can respect last cursor position.
+  select: ->
     isVisualMode = @vimState.mode is 'visual'
     markers = @getMarkersIntersectsWithRanges(@editor.getSelectedBufferRanges(), isVisualMode)
     ranges = markers.map (marker) -> marker.getBufferRange()
@@ -112,10 +114,9 @@ class OccurrenceManager
         # So that SelectOccurrence can acivivate visual-mode with correct range, we have to unset submode here.
         @vimState.submode = null
 
-      if startInsertMode
-        range = @getRangeForLastSelection(ranges)
-        _.remove(ranges, range)
-        ranges.push(range)
+      range = @getRangeForLastSelection(ranges)
+      _.remove(ranges, range)
+      ranges.push(range)
 
       @editor.setSelectedBufferRanges(ranges)
 

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -177,7 +177,7 @@ class OperationStack
       if settings.get('throwErrorOnNonEmptySelectionInNormalMode')
         throw new Error("Selection is not empty in normal-mode: #{operation.toString()}")
       else
-        @editor.clearSelections()
+        @vimState.clearSelections()
 
   ensureAllCursorsAreNotAtEndOfLine: ->
     for cursor in @editor.getCursors() when cursor.isAtEndOfLine()

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -95,9 +95,7 @@ class OperationStack
         operation.count = count
         operation.target?.count = count # Some opeartor have no target like ctrl-a(increase).
 
-      # [FIXME] Degradation, this `transact` should not be necessary
-      @editor.transact =>
-        @run(operation)
+      @run(operation)
 
   runRecordedMotion: (key, {reverse}={}) ->
     return unless operation = @vimState.globalState.get(key)

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -104,7 +104,7 @@ class ActivateInsertMode extends Operator
           moveCursorLeft(selection.cursor)
 
       if settings.get('clearMultipleCursorsOnEscapeInsertMode')
-        @editor.clearSelections()
+        @vimState.clearSelections()
 
     else
       if @getInsertionCount() > 0

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -171,8 +171,7 @@ class Operator extends Base
     # Here we save patterns which resresent unioned regex which @occurrenceManager knows.
     @patternForOccurrence ?= @occurrenceManager.buildPattern()
 
-    startInsertMode = @instanceof('ActivateInsertMode') and not @isRepeated()
-    unless @occurrenceManager.select({startInsertMode})
+    unless @occurrenceManager.select()
       @mutationManager.restoreInitialPositions() # Restoreing position also clear selection.
 
   # Return true unless all selection is empty.

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -188,6 +188,7 @@ class Operator extends Base
     @target.select()
     @mutationManager.setCheckPoint('did-select')
     @selectOccurrence() if @isOccurrence()
+    @mutationManager.setCheckPoint('did-select-occurrence')
 
     if haveSomeNonEmptySelection(@editor) or @target.getName() is "Empty"
       @emitDidSelectTarget()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -203,7 +203,7 @@ class Operator extends Base
 
     options =
       stay: @needStay()
-      strict: @isOccurrence()
+      isOccurrence: @isOccurrence()
       isBlockwise: @target?.isBlockwise?()
 
     @mutationManager.restoreCursorPositions(options)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -176,19 +176,20 @@ class Operator extends Base
 
   # Return true unless all selection is empty.
   selectTarget: ->
-    @mutationManager.init
+    @mutationManager.init(
       isSelect: @instanceof('Select')
       useMarker: @needStay() and @stayByMarker
-    @mutationManager.setCheckPoint('will-select')
+    )
+    @mutationManager.setCheckpoint('will-select')
 
     # Currently only motion have forceWise methods
     @target.forceWise?(@wise) if @wise?
     @emitWillSelectTarget()
 
     @target.select()
-    @mutationManager.setCheckPoint('did-select')
+    @mutationManager.setCheckpoint('did-select')
     @selectOccurrence() if @isOccurrence()
-    @mutationManager.setCheckPoint('did-select-occurrence')
+    @mutationManager.setCheckpoint('did-select-occurrence')
 
     if haveSomeNonEmptySelection(@editor) or @target.getName() is "Empty"
       @emitDidSelectTarget()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -186,10 +186,10 @@ class Operator extends Base
     @emitWillSelectTarget()
 
     @target.select()
+    @mutationManager.setCheckPoint('did-select')
     @selectOccurrence() if @isOccurrence()
 
     if haveSomeNonEmptySelection(@editor) or @target.getName() is "Empty"
-      @mutationManager.setCheckPoint('did-select')
       @emitDidSelectTarget()
       @flashChangeIfNecessary()
       @trackChangeIfNecessary()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -264,17 +264,16 @@ class VimState
     # @subscriptions.add atom.commands.onWillDispatch(saveProperties)
     @subscriptions.add atom.commands.onDidDispatch(checkSelection)
 
+  # What's this?
+  # editor.clearSelections() doesn't respect lastCursor positoin.
+  # This method works in same way as editor.clearSelections() but respect last cursor position.
+  clearSelections: ->
+    @editor.setCursorBufferPosition(@editor.getCursorBufferPosition())
+
   resetNormalMode: ({userInvocation}={}) ->
     if userInvocation ? false
       if @editor.hasMultipleCursors()
-        # Don't @editor.clearSelections() doesn't respect lastCursor
-        # So here I destroy() except lastSelection
-        # Important when clearing multi-cursor after bulk-edit using occurrence
-        for selection in @editor.getSelections()
-          if selection.isLastSelection()
-            selection.clear()
-          else
-            selection.destroy()
+        @clearSelections()
 
       else if @hasPersistentSelections() and settings.get('clearPersistentSelectionOnResetNormalMode')
         @clearPersistentSelections()
@@ -284,7 +283,7 @@ class VimState
       if settings.get('clearHighlightSearchOnResetNormalMode')
         @globalState.set('highlightSearchPattern', null)
     else
-      @editor.clearSelections()
+      @clearSelections()
     @activate('normal')
 
   init: ->

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -287,7 +287,7 @@ describe "Occurrence", ->
         withMockPlatform searchEditorElement, 'platform-darwin' , ->
           rawKeystroke 'cmd-d', document.activeElement
           ensure 'i e',
-            selectedText: ['0000', '3333', '444']
+            selectedText: ['3333', '444', '0000'] # Why '0000' comes last is '0000' become last selection.
             mode: ['visual', 'characterwise']
 
       it "change occurrence by pattern match", ->

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -251,31 +251,73 @@ describe "Operator ActivateInsertMode family", ->
       spyOn(editor, 'autoIndentBufferRow').andCallFake (line) ->
         editor.indent()
 
-      set text: "  abc\n  012\n", cursor: [1, 1]
+      set
+        textC_: """
+        __abc
+        _|_012\n
+        """
 
     it "switches to insert and adds a newline above the current one", ->
       keystroke 'O'
       ensure
-        text: "  abc\n  \n  012\n"
-        cursor: [1, 2]
+        textC_: """
+        __abc
+        __|
+        __012\n
+        """
         mode: 'insert'
 
     it "is repeatable", ->
       set
-        text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
+        textC_: """
+          __abc
+          __|012
+          ____4spaces\n
+          """
+      # set
+      #   text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
       keystroke 'O'
       editor.insertText "def"
-      ensure 'escape', text: "  abc\n  def\n  012\n    4spaces\n"
-      set cursor: [1, 1]
-      ensure '.', text: "  abc\n  def\n  def\n  012\n    4spaces\n"
-      set cursor: [4, 1]
-      ensure '.', text: "  abc\n  def\n  def\n  012\n    def\n    4spaces\n"
+      ensure 'escape',
+        textC_: """
+          __abc
+          __de|f
+          __012
+          ____4spaces\n
+          """
+      ensure '.',
+        textC_: """
+        __abc
+        __de|f
+        __def
+        __012
+        ____4spaces\n
+        """
+      set cursor: [4, 0]
+      ensure '.',
+        textC_: """
+        __abc
+        __def
+        __def
+        __012
+        ____de|f
+        ____4spaces\n
+        """
 
     it "is undoable", ->
       keystroke 'O'
       editor.insertText "def"
-      ensure 'escape', text: "  abc\n  def\n  012\n"
-      ensure 'u', text: "  abc\n  012\n"
+      ensure 'escape',
+        textC_: """
+        __abc
+        __def
+        __012\n
+        """
+      ensure 'u',
+        textC_: """
+        __abc
+        __012\n
+        """
 
   describe "the o keybinding", ->
     beforeEach ->

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -192,24 +192,52 @@ describe "Operator general", ->
           selectedText: ""
 
       describe "with multiple cursors", ->
-        beforeEach ->
-          set
-            textC: """
-            |12345
-            a|bcde
-            ABCDE
-            QWERT
-            """
-          ensure 'd l',
-            textC: """
-            |2345
-            a|cde
-            ABCDE
-            QWERT
-            """
-
         describe "setCursorToStartOfChangeOnUndoRedo is true(default)", ->
-          it "clear multiple cursors and set cursor to start of changes", ->
+          it "clear multiple cursors and set cursor to start of changes of last cursor", ->
+            set
+              text: originalText
+              cursor: [[0, 0], [1, 1]]
+
+            ensure 'd l',
+              textC: """
+              |2345
+              a|cde
+              ABCDE
+              QWERT
+              """
+
+            ensure 'u',
+              textC: """
+              12345
+              a|bcde
+              ABCDE
+              QWERT
+              """
+              selectedText: ''
+
+            ensure 'ctrl-r',
+              textC: """
+              2345
+              a|cde
+              ABCDE
+              QWERT
+              """
+              selectedText: ''
+
+          it "clear multiple cursors and set cursor to start of changes of last cursor", ->
+            set
+              text: originalText
+              cursor: [[1, 1], [0, 0]]
+
+            ensure 'd l',
+              text: """
+              2345
+              acde
+              ABCDE
+              QWERT
+              """
+              cursor: [[1, 1], [0, 0]]
+
             ensure 'u',
               textC: """
               |12345
@@ -219,9 +247,32 @@ describe "Operator general", ->
               """
               selectedText: ''
 
+            ensure 'ctrl-r',
+              textC: """
+              |2345
+              acde
+              ABCDE
+              QWERT
+              """
+              selectedText: ''
+
         describe "setCursorToStartOfChangeOnUndoRedo is false", ->
           beforeEach ->
             settings.set('setCursorToStartOfChangeOnUndoRedo', false)
+            set
+              textC: """
+              |12345
+              a|bcde
+              ABCDE
+              QWERT
+              """
+            ensure 'd l',
+              textC: """
+              |2345
+              a|cde
+              ABCDE
+              QWERT
+              """
 
           it "put cursor to end of change (works in same way of atom's core:undo)", ->
             ensure 'u',

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -221,19 +221,23 @@ describe "VimState", ->
       beforeEach ->
         set
           text: 'abc'
-          cursor: [[0, 0], [0, 1]]
+          cursor: [[0, 1], [0, 2]]
 
-      describe "when enabled", ->
+      describe "when enabled, clear multiple cursors on escaping insert-mode", ->
         beforeEach ->
           settings.set('clearMultipleCursorsOnEscapeInsertMode', true)
-        it "clear multiple cursor on escape", ->
-          ensure 'escape', mode: 'normal', numCursors: 1
+        it "clear multiple cursors by respecting last cursor's position", ->
+          ensure 'escape', mode: 'normal', numCursors: 1, cursor: [0, 1]
+
+        it "clear multiple cursors by respecting last cursor's position", ->
+          set cursor: [[0, 2], [0, 1]]
+          ensure 'escape', mode: 'normal', numCursors: 1, cursor: [0, 0]
 
       describe "when disabled", ->
         beforeEach ->
           settings.set('clearMultipleCursorsOnEscapeInsertMode', false)
-        it "clear multiple cursor on escape", ->
-          ensure 'escape', mode: 'normal', numCursors: 2
+        it "keep multiple cursors", ->
+          ensure 'escape', mode: 'normal', numCursors: 2, cursor: [[0, 0], [0, 1]]
 
     describe "automaticallyEscapeInsertModeOnActivePaneItemChange setting", ->
       [otherVim, otherEditor, pane] = []
@@ -259,7 +263,7 @@ describe "VimState", ->
 
           pane.activateItem(otherEditor)
           expect(pane.getActiveItem()).toBe(otherEditor)
-          
+
           ensure mode: 'insert'
           otherVim.ensure mode: 'insert'
 


### PR DESCRIPTION
I noticed, I can keep original cursor position for bulk-change done by multiple-cursors(including `ocurrence` operation).
But to fully support that, I need overhaul `opeartor-insert.coffee` especially `Change` Operator

I'll try and evaluate in this processing

What I have to do is

- Currently at the timing of creating `undo` checkpoint, multiple cursor is not yet necessarily created.
- The reason is `@selectTarget()` is called **after** `@setCheckpoint('undo')`.
- Atom editor's  `@editor.undo()`, `@editor.redo()` correctly restore multiple-cursors as long as multiple-cursors was exists at that checkpoint.
- By consulting multiple-cursors position information, we can restore original cursor position even in undo/redo.
- So what I have to do is to introduce new requirement for all operators.
- That requirement is do `@selectTarget()` before starting ANY text mutation so that checkpoint is created with multiple-cursor information.
- Operators which is not conforming this new requirement is very few, the children of `ActivateInsertMode` operator including `Change`.

Another example, by trying to make new minor improvement reveal inconsistency and hidden design bug of existing code.
Let's overhaul!
