### PR TITLE
Allow backspace on empty search to cancel

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -576,6 +576,8 @@
   'ctrl-v': 'vim-mode-plus:search-activate-literal-mode'
   'ctrl-c': 'vim-mode-plus:search-cancel'
   'ctrl-[': 'vim-mode-plus:search-cancel'
+  'ctrl-h': 'vim-mode-plus:search-backspace'
+  'backspace': 'vim-mode-plus:search-backspace'
   'shift-tab': 'vim-mode-plus:search-visit-prev'
   'tab': 'vim-mode-plus:search-visit-next'
 

--- a/lib/search-input.coffee
+++ b/lib/search-input.coffee
@@ -96,6 +96,12 @@ class SearchInput extends HTMLElement
     @emitter.emit('did-cancel')
     @unfocus()
 
+  backspace: ->
+    if @editor.getText().length is 0
+      @cancel()
+    else
+      atom.commands.dispatch(@editorElement, 'core:backspace')
+
   confirm: (landingPoint=null) ->
     @emitter.emit('did-confirm', {input: @editor.getText(), landingPoint})
     @unfocus()
@@ -129,6 +135,7 @@ class SearchInput extends HTMLElement
       "search-land-to-start": => @confirm()
       "search-land-to-end": => @confirm('end')
       "search-cancel": => @cancel()
+      "search-backspace": => @backspace()
 
       "search-visit-next": => @emitter.emit('did-command', name: 'visit', direction: 'next')
       "search-visit-prev": => @emitter.emit('did-command', name: 'visit', direction: 'prev')


### PR DESCRIPTION
With Vim, using backspace when the search input is empty results in the search being cancelled. This PR implements that feature.