### PR TITLE
operator works on normal-target even in has-occurrence

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -230,6 +230,8 @@
   '[': 'vim-mode-plus:move-up-to-edge'
   ']': 'vim-mode-plus:move-down-to-edge'
 
+  'tab': 'vim-mode-plus:search-occurrence'
+  'shift-tab': 'vim-mode-plus:search-occurrence-backwards'
   # '[ [': 'vim-mode-plus:move-to-previous-fold-start'
   # '] [': 'vim-mode-plus:move-to-next-fold-start'
   # '[ ]': 'vim-mode-plus:move-to-previous-fold-end'
@@ -439,8 +441,6 @@
 'atom-text-editor.vim-mode-plus.has-occurrence:not(.insert-mode)':
   'I': 'vim-mode-plus:insert-at-start-of-target'
   'A': 'vim-mode-plus:insert-at-end-of-target'
-  'tab': 'vim-mode-plus:search-occurrence'
-  'shift-tab': 'vim-mode-plus:search-occurrence-backwards'
 
 # operator-pending, visual
 # -------------------------

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -187,8 +187,7 @@ class Operator extends Base
     # Here we save patterns which resresent unioned regex which @occurrenceManager knows.
     @patternForOccurrence ?= @occurrenceManager.buildPattern()
 
-    unless @occurrenceManager.select()
-      @mutationManager.restoreInitialPositions() # Restoreing position also clear selection.
+    @occurrenceManager.select()
 
   # Return true unless all selection is empty.
   selectTarget: ->


### PR DESCRIPTION
And `tab`, `shift-tab` mapped globally.
This might conflict user’s custom keymap `tab` in normal-mode.
But I here go opinionated decision to make occurrence more accessible.

#578 