### PR TITLE
move-to-next-occurrence, move-to-previous-occurrence

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -230,8 +230,8 @@
   '[': 'vim-mode-plus:move-up-to-edge'
   ']': 'vim-mode-plus:move-down-to-edge'
 
-  'tab': 'vim-mode-plus:search-occurrence'
-  'shift-tab': 'vim-mode-plus:search-occurrence-backwards'
+  'tab': 'vim-mode-plus:move-to-next-occurrence'
+  'shift-tab': 'vim-mode-plus:move-to-previous-occurrence'
   # '[ [': 'vim-mode-plus:move-to-previous-fold-start'
   # '] [': 'vim-mode-plus:move-to-next-fold-start'
   # '[ ]': 'vim-mode-plus:move-to-previous-fold-end'

--- a/lib/motion-search.coffee
+++ b/lib/motion-search.coffee
@@ -206,19 +206,6 @@ class SearchBackwards extends Search
   @extend()
   backwards: true
 
-class SearchOccurrence extends Search
-  @extend()
-  updatelastSearchPattern: false
-
-  initialize: ->
-    if @vimState.occurrenceManager.hasPatterns()
-      @input = @vimState.occurrenceManager.buildPattern().source
-      super
-
-class SearchOccurrenceBackwards extends SearchOccurrence
-  @extend()
-  backwards: true
-
 # *, #
 # -------------------------
 class SearchCurrentWord extends SearchBase

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -30,7 +30,6 @@ Select = null
   setBufferColumn
   limitNumber
   getIndex
-  smartScrollToBufferPosition
 } = require './utils'
 
 swrap = require './selection-wrapper'
@@ -1070,10 +1069,11 @@ class MoveToNextOccurrence extends Motion
         when 'next' then @getCount(-1)
         when 'previous' then -@getCount(-1)
       range = @ranges[getIndex(index + offset, @ranges)]
-      point = range.start
-      @editor.unfoldBufferRow(point.row) if cursor.isLastCursor()
-      smartScrollToBufferPosition(@editor, point)
-      cursor.setBufferPosition(point, autoscroll: false)
+
+      cursor.setBufferPosition(range.start, autoscroll: false)
+      if cursor.isLastCursor()
+        @editor.unfoldBufferRow(range.start.row)
+        cursor.autoscroll(center: true)
       @vimState.flash(range, type: 'search')
 
   getIndex: (fromPoint) ->

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -782,13 +782,9 @@ describe "Occurrence", ->
             xxx: ooo: XXX: ooo xxx: ooo:
             """
 
-    describe "search occurrence", ->
-      [searchEditor, searchEditorElement] = []
+    describe "MoveToNextOccurrence, MoveToPreviousOccurrence", ->
       beforeEach ->
-        searchEditor = vimState.searchInput.editor
-        searchEditorElement = vimState.searchInput.editorElement
         jasmine.attachToDOM(getView(atom.workspace))
-        settings.set('incrementalSearch', true)
         set
           textC: """
           |ooo: xxx: ooo


### PR DESCRIPTION
Fix #580

### Breaking: Command name renamed

- Old: `SearchOccurrence`, `SearchOccurrenceBackwards`
- New: `MoveToNextOccurrence`, `MoveToPreviousOccurrence`


### What's this motion

- No longer child of `Search`, simple Motion
- Move to next or previous `occurrence`(N count supported).
- `tab`, `shift-tab` is mapped in all-mode except `insert-mode`.
  - This might conflicts user's favorite `tab`, `shift-tab` in `normal-mode`.
  - But here I go opinionated, I want embrace `occurrence` in vmp, and make it easy to use, accessible.
  - Also user's custom keymap wins over package's keymap from recent version of Atom.
- When you prepend or append text to `occurrence` on whole big buffer, you can quickly visit `occurrence` to check the result, since `occurrence` marker is not destroyed unless mutating **inside** of marker.
- When you toggle occurrence to un-mark particular instance of `occurrence`. `tab`, `shift-tab` no longer stop that excluded one unlike previous implementation.
  - In other word, visit only under-dotted-marked occurrence only.
