### PR TITLE
Elixir function text-object fix

### DIFF
--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -706,7 +706,7 @@ class Function extends Fold
   @extend(false)
 
   # Some language don't include closing `}` into fold.
-  omittingClosingCharLanguages: ['go']
+  omittingClosingCharLanguages: ['go', 'elixir']
 
   initialize: ->
     super

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -517,7 +517,7 @@ isIncludeFunctionScopeForRow = (editor, row) ->
 isFunctionScope = (editor, scope) ->
   {scopeName} = editor.getGrammar()
   switch scopeName
-    when 'source.go'
+    when 'source.go', 'source.elixir'
       /^entity\.name\.function/.test(scope)
     else
       /^meta\.function\./.test(scope)

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1297,6 +1297,54 @@ describe "TextObject", ->
         it 'select function', ->
           ensure 'v a f', selectedBufferRange: [[2, 0], [7, 0]]
 
+    describe 'elixir', ->
+      pack = 'language-elixir'
+      scope = 'source.elixir'
+      beforeEach ->
+        console.log "ELIXIR"
+        waitsForPromise ->
+          atom.packages.activatePackage(pack)
+        set
+          text: """
+            # Commment
+
+            def hello do
+              a = 1
+              b = 2
+              c = 3
+            end
+
+            def one_liner, do: "return value"
+
+            # Commment
+            """
+          cursor: [3, 0]
+        runs ->
+          grammar = atom.grammars.grammarForScopeName(scope)
+          editor.setGrammar(grammar)
+      afterEach ->
+        atom.packages.deactivatePackage(pack)
+
+      describe 'inner-function for elixir', ->
+        it 'select except start row', ->
+          ensure 'v i f', selectedBufferRange: [[3, 0], [6, 0]]
+      describe 'a-function for elixir', ->
+        it 'select function', ->
+          ensure 'v a f', selectedBufferRange: [[2, 0], [7, 0]]
+      describe 'one-liner for elixir', ->
+        beforeEach ->
+          set
+            text: """
+              # Commment
+
+              def one_liner, do: "return value"
+
+              # Commment
+              """
+            cursor: [3, 0]
+        it 'select function', ->
+          ensure 'v a f', selectedBufferRange: [[3, 0], [4, 0]]
+
     describe 'go', ->
       pack = 'language-go'
       scope = 'source.go'


### PR DESCRIPTION
Function text-objects weren't working with Elixir because they are similar to go (uses `entity.name.function` scope, and omits last line as part of function).

I added a test case for this as well, feel free to remove it if you think it's unnecessary. I'm not sure if the `language-elixir` package needs to be added somewhere for the travis configuration.

Thanks for the awesome work on vmp!