### PR TITLE
Default keymap for surround

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ vim-mode improved.
     - [In visual-block mode, some motions make the editor slow, freeze.](#in-visual-block-mode-some-motions-make-the-editor-slow-freeze)
     - [ex-mode?](#ex-mode)
     - [Want to suppress autocomplete-plus's auto suggestion except insert-mode.](#want-to-suppress-autocomplete-pluss-auto-suggestion-except-insert-mode)
+    - [How can I insert single white space when surround?](#how-can-i-insert-single-white-space-when-surround)
 - [Wiki](#wiki)
 - [Keymap](#keymap)
 - [Helper packages](#helper-packages)
@@ -111,6 +112,10 @@ If you want to directly edit `config.cson`, here it is.
     "vim-mode-plus.insert-mode.replace"
   ]
 ```
+
+### How can I insert single white space when surround?
+
+Set `Characters To Add Space On Surround`. from vim-mode-plus's setting.
 
 # Wiki
 

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -406,6 +406,11 @@
   'ctrl-t': 'symbols-view:return-from-declaration'
   '"': 'vim-mode-plus:set-register-name'
 
+  'y s': 'vim-mode-plus:surround'
+  'd s': 'vim-mode-plus:delete-surround'
+  'd s s': 'vim-mode-plus:delete-surround-any-pair'
+  'c s': 'vim-mode-plus:change-surround'
+  'c s s': 'vim-mode-plus:change-surround-any-pair'
   # 'enter': 'vim-mode-plus:add-blank-line-below'
   # 'shift-enter': 'vim-mode-plus:add-blank-line-above'
 
@@ -535,6 +540,11 @@
   'i v': 'vim-mode-plus:inner-visible-area'
   'a v': 'vim-mode-plus:a-visible-area'
 
+# operator-pending operator-specific
+# -------------------------
+'atom-text-editor.vim-mode-plus.operator-pending-mode.surround-pending':
+  's': 'vim-mode-plus:inner-current-line'
+
 # visual
 # -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode':
@@ -543,6 +553,7 @@
   'v': 'vim-mode-plus:activate-characterwise-visual-mode'
   'V': 'vim-mode-plus:activate-linewise-visual-mode'
   'ctrl-v': 'vim-mode-plus:activate-blockwise-visual-mode'
+  'S': 'vim-mode-plus:surround'
   'enter': 'vim-mode-plus:create-persistent-selection'
 
 'atom-text-editor.vim-mode-plus.has-persistent-selection.normal-mode,

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -423,6 +423,8 @@
   'v': 'vim-mode-plus:operator-modifier-characterwise'
   'V': 'vim-mode-plus:operator-modifier-linewise'
   'o': 'vim-mode-plus:operator-modifier-occurrence'
+  'I': 'vim-mode-plus:move-to-first-character-of-line'
+  'A': 'vim-mode-plus:move-to-last-character-of-line'
 
 # operator-pending.has-occurrence [Experimental]
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -406,18 +406,6 @@
   'ctrl-t': 'symbols-view:return-from-declaration'
   '"': 'vim-mode-plus:set-register-name'
 
-  # 'y s': 'vim-mode-plus:surround'
-  # 'y s w': 'vim-mode-plus:surround-word'
-
-  # 'd s': 'vim-mode-plus:delete-surround'
-  # 'd s': 'vim-mode-plus:delete-surround-any-pair'
-  # 'd s': 'vim-mode-plus:delete-surround-any-pair-allow-forwarding'
-
-  # 'y s c': 'vim-mode-plus:change-surround'
-  # 'y s c': 'vim-mode-plus:change-surround-any-pair'
-  # 'y s c': 'vim-mode-plus:change-surround-any-pair-allow-forwarding'
-
-  # 'y m s':  'vim-mode-plus:map-surround'
   # 'enter': 'vim-mode-plus:add-blank-line-below'
   # 'shift-enter': 'vim-mode-plus:add-blank-line-above'
 

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -409,8 +409,11 @@
   'y s': 'vim-mode-plus:surround'
   'd s': 'vim-mode-plus:delete-surround'
   'd s s': 'vim-mode-plus:delete-surround-any-pair'
+  'd s S': 'vim-mode-plus:delete-surround-any-pair-allow-forwarding'
   'c s': 'vim-mode-plus:change-surround'
   'c s s': 'vim-mode-plus:change-surround-any-pair'
+  'c s S': 'vim-mode-plus:change-surround-any-pair-allow-forwarding'
+
   # 'enter': 'vim-mode-plus:add-blank-line-below'
   # 'shift-enter': 'vim-mode-plus:add-blank-line-above'
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -43,7 +43,7 @@ module.exports = new Settings 'vim-mode-plus',
   startInInsertModeScopes:
     default: []
     items: type: 'string'
-    description: 'Start in insert-mode whan editorElement matches scope'
+    description: 'Start in insert-mode when editorElement matches scope'
   clearMultipleCursorsOnEscapeInsertMode: false
   autoSelectPersistentSelectionOnOperate: true
   automaticallyEscapeInsertModeOnActivePaneItemChange:
@@ -52,7 +52,10 @@ module.exports = new Settings 'vim-mode-plus',
   wrapLeftRightMotion: false
   numberRegex:
     default: '-?[0-9]+'
-    description: 'Used to find number in ctrl-a/ctrl-x.<br>To ignore "-"(minus) char in string like "identifier-1" use "(?:\\B-)?[0-9]+"'
+    description: """
+      Used to find number in ctrl-a/ctrl-x.<br>
+      To ignore "-"(minus) char in string like "identifier-1" use `(?:\\B-)?[0-9]+`
+      """
   clearHighlightSearchOnResetNormalMode:
     default: false
     description: 'Clear highlightSearch on `escape` in normal-mode'
@@ -62,7 +65,10 @@ module.exports = new Settings 'vim-mode-plus',
   charactersToAddSpaceOnSurround:
     default: []
     items: type: 'string'
-    description: 'Comma separated list of character, which add space around surrounded text.<br>For vim-surround compatible behavior, set `(, {, [, <`.'
+    description: """
+      Comma separated list of character, which add space around surrounded text.<br>
+      For vim-surround compatible behavior, set `(, {, [, <`.
+      """
   showCursorInVisualMode: true
   ignoreCaseForSearch:
     default: false
@@ -85,7 +91,7 @@ module.exports = new Settings 'vim-mode-plus',
   incrementalSearchVisitDirection:
     default: 'absolute'
     enum: ['absolute', 'relative']
-    description: "Whether 'visit-next'(tab) and 'visit-prev'(shift-tab) depends on search direction('/' or '?')"
+    description: "When `relative`, `tab`, and `shift-tab` respect search direction('/' or '?')"
   stayOnTransformString:
     default: false
     description: "Don't move cursor after TransformString e.g upper-case, surround"
@@ -104,17 +110,19 @@ module.exports = new Settings 'vim-mode-plus',
   moveToFirstCharacterOnVerticalMotion:
     default: true
     description: """
-    Almost equivalent to `startofline` pure-Vim option. When true, move cursor to first char.
-    Affects to `ctrl-f, b, d, u`, `G`, `H`, `M`, `L`, `gg`
-    Unlike pure-Vim, `d`, `<<`, `>>` are not affected by this option, use independent `stayOn` options.
-    """
+      Almost equivalent to `startofline` pure-Vim option. When true, move cursor to first char.<br>
+      Affects to `ctrl-f, b, d, u`, `G`, `H`, `M`, `L`, `gg`<br>
+      Unlike pure-Vim, `d`, `<<`, `>>` are not affected by this option, use independent `stayOn` options.
+      """
   flashOnUndoRedo: true
-  flashOnMoveToOccurrence: false
+  flashOnMoveToOccurrence:
+    default: false
+    description: "Affects normal-mode's `tab`, `shift-tab`."
   flashOnOperate: true
   flashOnOperateBlacklist:
     default: []
     items: type: 'string'
-    description: 'comma separated list of operator class name to disable flash e.g. "yank, auto-indent"'
+    description: 'Comma separated list of operator class name to disable flash e.g. "yank, auto-indent"'
   flashOnSearch: true
   flashScreenOnSearchHasNoMatch: true
   showHoverOnOperate: false

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -52,7 +52,7 @@ module.exports = new Settings 'vim-mode-plus',
   wrapLeftRightMotion: false
   numberRegex:
     default: '-?[0-9]+'
-    description: 'Used to find number in ctrl-a/ctrl-x. To ignore "-"(minus) char in string like "identifier-1" use "(?:\\B-)?[0-9]+"'
+    description: 'Used to find number in ctrl-a/ctrl-x.<br>To ignore "-"(minus) char in string like "identifier-1" use "(?:\\B-)?[0-9]+"'
   clearHighlightSearchOnResetNormalMode:
     default: false
     description: 'Clear highlightSearch on `escape` in normal-mode'
@@ -62,7 +62,7 @@ module.exports = new Settings 'vim-mode-plus',
   charactersToAddSpaceOnSurround:
     default: []
     items: type: 'string'
-    description: 'Comma separated list of character, which add additional space inside when surround.'
+    description: 'Comma separated list of character, which add space around surrounded text.<br>For vim-surround compatible behavior, set `(, {, [, <`.'
   showCursorInVisualMode: true
   ignoreCaseForSearch:
     default: false

--- a/spec/mark-manager-spec.coffee
+++ b/spec/mark-manager-spec.coffee
@@ -1,2 +1,1 @@
 # TODO
-# spec for ^

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -927,6 +927,8 @@ describe "Motion general", ->
             partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
             text: 'abcde'
             cursor: [0, 0]
+        it 'selects to the first character of the line', ->
+          ensure 'd I', text: 'abcde', cursor: [0, 0]
 
     describe "from the first character of the line", ->
       beforeEach ->
@@ -957,6 +959,8 @@ describe "Motion general", ->
             partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
             text: '  cde'
             cursor: [0, 2]
+        it 'selects to the first character of the line', ->
+          ensure 'd I', text: '  cde', cursor: [0, 2],
 
   describe "the 0 keybinding", ->
     beforeEach ->

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -914,19 +914,19 @@ describe "Motion general", ->
 
   describe "the ^ keybinding", ->
     beforeEach ->
-      set text: "  abcde"
+      set textC: "|  abcde"
 
     describe "from the beginning of the line", ->
-      beforeEach ->
-        set cursor: [0, 0]
-
       describe "as a motion", ->
         it "moves the cursor to the first character of the line", ->
           ensure '^', cursor: [0, 2]
 
       describe "as a selection", ->
         it 'selects to the first character of the line', ->
-          ensure 'd ^', text: 'abcde', cursor: [0, 0]
+          ensure 'd ^',
+            partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
+            text: 'abcde'
+            cursor: [0, 0]
 
     describe "from the first character of the line", ->
       beforeEach ->
@@ -938,7 +938,10 @@ describe "Motion general", ->
 
       describe "as a selection", ->
         it "does nothing", ->
-          ensure 'd ^', text: '  abcde', cursor: [0, 2]
+          ensure 'd ^',
+            partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
+            text: '  abcde'
+            cursor: [0, 2]
 
     describe "from the middle of a word", ->
       beforeEach ->
@@ -950,7 +953,10 @@ describe "Motion general", ->
 
       describe "as a selection", ->
         it 'selects to the first character of the line', ->
-          ensure 'd ^', text: '  cde', cursor: [0, 2],
+          ensure 'd ^',
+            partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
+            text: '  cde'
+            cursor: [0, 2]
 
   describe "the 0 keybinding", ->
     beforeEach ->

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -127,7 +127,9 @@ describe "Operator general", ->
         cursor: [1, 1]
 
     it "enters operator-pending mode", ->
-      ensure 'd', mode: 'operator-pending'
+      ensure 'd',
+        partialMatchTimeout: true
+        mode: 'operator-pending'
 
     describe "when followed by a d", ->
       it "deletes the current line and exits operator-pending mode", ->
@@ -303,6 +305,7 @@ describe "Operator general", ->
         set text: "12345 abcde ABCDE", cursor: [0, 9]
 
         ensure 'd',
+          partialMatchTimeout: true
           mode: 'operator-pending'
 
         ensure 'i w',
@@ -713,6 +716,7 @@ describe "Operator general", ->
           text: "  abcd\n  1234"
           cursorBuffer: [[0, 0], [1, 5]]
         ensure 'y ^',
+          partialMatchTimeout: true # FIXME!!! remove after atom/atom-keymap#195
           register: '"': text: '123'
           cursorBuffer: [[0, 0], [1, 2]]
 

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -465,41 +465,32 @@ describe "Operator TransformString", ->
   describe 'surround', ->
     beforeEach ->
       set
-        text: """
-          apple
+        textC: """
+          |apple
           pairs: [brackets]
           pairs: [brackets]
           ( multi
             line )
           """
-        cursorBuffer: [0, 0]
 
     describe 'surround', ->
-      beforeEach ->
-        atom.keymaps.add "surround-test",
-          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-            'y s': 'vim-mode-plus:surround'
-          , 100
-
       it "surround text object with ( and repeatable", ->
         ensure ['y s i w', input: '('],
-          text: "(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-          cursor: [0, 0]
+          textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
         ensure 'j .',
           text: "(apple)\n(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
       it "surround text object with { and repeatable", ->
         ensure ['y s i w', input: '{'],
-          text: "{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-          cursor: [0, 0]
+          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
         ensure 'j .',
-          text: "{apple}\n{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
-      it "surround linewise", ->
-        ensure ['y s y s', input: '{'],
-          text: "{\napple\n}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-          cursor: [0, 0]
-        ensure '3 j .',
-          text: "{\napple\n}\n{\npairs: [brackets]\n}\npairs: [brackets]\n( multi\n  line )"
-      describe 'with motion which aloso taking user-iinput', ->
+          textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+      it "surround current-line", ->
+        ensure ['y s s', input: '{'],
+          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensure 'j .',
+          textC: "{apple}\n|{pairs: [brackets]}\npairs: [brackets]\n( multi\n  line )"
+
+      describe 'with motion which takes user-input', ->
         beforeEach ->
           set text: "s _____ e", cursor: [0, 0]
         describe "with 'f' motion", ->
@@ -519,8 +510,7 @@ describe "Operator TransformString", ->
         beforeEach ->
           settings.set('charactersToAddSpaceOnSurround', ['(', '{', '['])
           set
-            text: "apple\norange\nlemmon"
-            cursorBuffer: [0, 0]
+            textC: "|apple\norange\nlemmon"
 
         describe "char is in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
@@ -724,42 +714,35 @@ describe "Operator TransformString", ->
 
       it "surround a word with ( and repeatable", ->
         ensure ['y s w', input: '('],
-          text: "(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-          cursor: [0, 0]
+          textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
         ensure 'j .',
-          text: "(apple)\n(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
+          textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
       it "surround a word with { and repeatable", ->
         ensure ['y s w', input: '{'],
-          text: "{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-          cursor: [0, 0]
+          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
         ensure 'j .',
-          text: "{apple}\n{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+          textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
 
     describe 'delete-surround-any-pair', ->
       beforeEach ->
         set
-          text: """
+          textC: """
             apple
-            (pairs: [brackets])
+            (pairs: [|brackets])
             {pairs "s" [brackets]}
             ( multi
               line )
             """
-          cursor: [1, 9]
-
-        atom.keymaps.add "test",
-          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-            'd s': 'vim-mode-plus:delete-surround-any-pair'
 
       it "delete surrounded any pair found and repeatable", ->
-        ensure 'd s',
+        ensure 'd s s',
           text: 'apple\n(pairs: brackets)\n{pairs "s" [brackets]}\n( multi\n  line )'
         ensure '.',
           text: 'apple\npairs: brackets\n{pairs "s" [brackets]}\n( multi\n  line )'
 
       it "delete surrounded any pair found with skip pair out of cursor and repeatable", ->
         set cursor: [2, 14]
-        ensure 'd s',
+        ensure 'd s s',
           text: 'apple\n(pairs: [brackets])\n{pairs "s" brackets}\n( multi\n  line )'
         ensure '.',
           text: 'apple\n(pairs: [brackets])\npairs "s" brackets\n( multi\n  line )'
@@ -768,80 +751,64 @@ describe "Operator TransformString", ->
 
       it "delete surrounded chars expanded to multi-line", ->
         set cursor: [3, 1]
-        ensure 'd s',
+        ensure 'd s s',
           text: 'apple\n(pairs: [brackets])\n{pairs "s" [brackets]}\n multi\n  line '
 
     describe 'delete-surround-any-pair-allow-forwarding', ->
       beforeEach ->
         settings.set('stayOnTransformString', true)
-        atom.keymaps.add "test",
-          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-            'd s': 'vim-mode-plus:delete-surround-any-pair-allow-forwarding'
+
       it "[1] single line", ->
         set
-          cursor: [0, 0]
-          text: """
-          ___(inner)
-          ___(inner)
-          """
-        ensure 'd s',
-          text: """
-          ___inner
+          textC: """
+          |___(inner)
           ___(inner)
           """
-          cursor: [0, 0]
+        ensure 'd s S',
+          textC: """
+          |___inner
+          ___(inner)
+          """
         ensure 'j .',
-          text: """
+          textC: """
           ___inner
-          ___inner
+          |___inner
           """
-          cursor: [1, 0]
 
     describe 'change-surround-any-pair', ->
       beforeEach ->
         set
-          text: """
-            (apple)
+          textC: """
+            (|apple)
             (grape)
             <lemmon>
             {orange}
             """
-          cursor: [0, 1]
-
-        atom.keymaps.add "test",
-          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-            'c s': 'vim-mode-plus:change-surround-any-pair'
 
       it "change any surrounded pair found and repeatable", ->
-        ensure ['c s', input: '<'], text: "<apple>\n(grape)\n<lemmon>\n{orange}"
-        ensure 'j .', text: "<apple>\n<grape>\n<lemmon>\n{orange}"
-        ensure 'j j .', text: "<apple>\n<grape>\n<lemmon>\n<orange>"
+        ensure ['c s s', input: '<'], textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
+        ensure 'j .', textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
+        ensure 'j j .', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
 
     describe 'change-surround-any-pair-allow-forwarding', ->
       beforeEach ->
         settings.set('stayOnTransformString', true)
-        atom.keymaps.add "test",
-          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-            'c s': 'vim-mode-plus:change-surround-any-pair-allow-forwarding'
       it "[1] single line", ->
         set
-          cursor: [0, 0]
-          text: """
-          ___(inner)
-          ___(inner)
-          """
-        ensure ['c s', input: '<'],
-          text: """
-          ___<inner>
+          textC: """
+          |___(inner)
           ___(inner)
           """
-          cursor: [0, 0]
+        ensure ['c s S', input: '<'],
+          textC: """
+          |___<inner>
+          ___(inner)
+          """
         ensure 'j .',
-          text: """
+          textC: """
           ___<inner>
-          ___<inner>
+          |___<inner>
           """
-          cursor: [1, 0]
 
   describe 'ReplaceWithRegister', ->
     originalText = null

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -263,17 +263,25 @@ class VimEditor
     textC: ['cursor', 'cursorBuffer']
     textC_: ['cursor', 'cursorBuffer']
 
+  getAndDeleteKeystrokeOptions: (options) ->
+    {partialMatchTimeout} = options
+    delete options.partialMatchTimeout
+    {partialMatchTimeout}
+
   # Public
   ensure: (args...) =>
     switch args.length
       when 1 then [options] = args
       when 2 then [keystroke, options] = args
+
+    keystrokeOptions = @getAndDeleteKeystrokeOptions(options)
+
     @validateOptions(options, ensureOptionsOrdered, 'Invalid ensure option')
     @validateExclusiveOptions(options, ensureExclusiveRules)
 
     # Input
     unless _.isEmpty(keystroke)
-      @keystroke(keystroke)
+      @keystroke(keystroke, keystrokeOptions)
 
     for name in ensureOptionsOrdered when options[name]?
       method = 'ensure' + _.capitalize(_.camelize(name))
@@ -429,5 +437,8 @@ class VimEditor
             atom.commands.dispatch(@vimState.searchInput.editorElement, 'core:confirm')
           else
             rawKeystroke(k, target)
+
+    if options.partialMatchTimeout
+      advanceClock(atom.keymaps.getPartialMatchTimeout())
 
 module.exports = {getVimState, getView, dispatch, TextData, withMockPlatform, rawKeystroke}

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -163,12 +163,16 @@ describe "VimState", ->
 
       it 'properly clears the operations', ->
 
-        ensure 'd', mode: 'operator-pending'
+        ensure 'd',
+          partialMatchTimeout: true
+          mode: 'operator-pending'
         expect(vimState.operationStack.isEmpty()).toBe(false)
         ensure 'r', mode: 'normal'
         expect(vimState.operationStack.isEmpty()).toBe(true)
 
-        ensure 'd', mode: 'operator-pending'
+        ensure 'd',
+          partialMatchTimeout: true
+          mode: 'operator-pending'
         expect(vimState.operationStack.isEmpty()).toBe(false)
         ensure 'escape', mode: 'normal', text: '012345\nabcdef'
         expect(vimState.operationStack.isEmpty()).toBe(true)


### PR DESCRIPTION
Fix #583, #565
Related #584

Way tougher than I thought.

## Good or Bad

- Good
  - User don't have to manually set keymap for surround.

- Bad
  - For user's who use different keymap, this addition is just a interference.
  - Especially `d`, `y`, `c` not immediately enter `operator-pending`, this is significant change since these are VERY basic operator.
  - When `persistent-selection` exitis with 'normal-mode', `d`, `c`, `y` no longer execute operation since it's not settled(there is `y s` candidate).

## What will change

- Add surround keymap `y s`, `d s` startings, `c s` stargings...
- I make it compatible with tpop's vim-surround.
- vmp's unique addition is
  - `d s s`: mapped to `delete-surround-any-pair` which detects pair char auto.
  - `d s S`: mapped to `delete-surround-any-pair-allow-forwarding` will find forward pair(= cursor not enclosed one)
  - `c s s`: mapped to `change-surround-any-pair` which detects pair char auto.
  - `c s S`: mapped to `change-surround-any-pair-allow-forwarding` will find forward pair(= cursor not enclosed one)
- Update spec to use these default keymap.
- Because of adding `d`, `y`, `c` starting keymap, these keymap no longe enter `operator-pending` immediately after first char(e.g. `d`).
- So specs to use these operation(=`delete`, `yank`, `change`) need special treatment especially when ensureing `operator-pending`.
- Allow spec helper's `ensure` and `keystroke` accept `partialMatchTimeout`.
- `d ^` become delayed because of atom-keymap bug which is not revealed before `d` is solely mapped to `delete` in previous vmp version.
  - So add `I`, `A` keymap in `operator-pending` as alternate of `^`, `$` in `operator-pending`.
  - `d I` is equivalent to `d ^`
  - `d A` is equivalent to `d $`

## keymaps added as default

```coffeescript
# normal
'atom-text-editor.vim-mode-plus.normal-mode':
  'y s': 'vim-mode-plus:surround'
  'd s': 'vim-mode-plus:delete-surround'
  'd s s': 'vim-mode-plus:delete-surround-any-pair'
  'd s S': 'vim-mode-plus:delete-surround-any-pair-allow-forwarding'
  'c s': 'vim-mode-plus:change-surround'
  'c s s': 'vim-mode-plus:change-surround-any-pair'
  'c s S': 'vim-mode-plus:change-surround-any-pair-allow-forwarding'

# operator-pending
# Not essential, but because of bug of atom-keymap `d ^` delays after `d s` addition.
# So let `d I` as alternate of `d ^`.
'atom-text-editor.vim-mode-plus.operator-pending-mode':
  'I': 'vim-mode-plus:move-to-first-character-of-line'
  'A': 'vim-mode-plus:move-to-last-character-of-line'

# operator-pending operator-specific
# So that `y s s` surround current line as vim-surroun
'atom-text-editor.vim-mode-plus.operator-pending-mode.surround-pending':
  's': 'vim-mode-plus:inner-current-line'

# visual
'atom-text-editor.vim-mode-plus.visual-mode':
  'S': 'vim-mode-plus:surround'
```
