### PR TITLE
Don't freeze Atom editor with big-count-motion

### DIFF
--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -148,10 +148,10 @@ class Motion extends Base
 
   moveCursorCountTimes: (cursor, fn) ->
     oldPosition = cursor.getBufferPosition()
-    @countTimes ({stop}) ->
-      fn()
+    @countTimes (state) =>
+      fn(state)
       if (newPosition = cursor.getBufferPosition()).isEqual(oldPosition)
-        stop()
+        state.stop()
       oldPosition = newPosition
 
 # Used as operator's target in visual-mode.
@@ -286,13 +286,8 @@ class MoveUpToEdge extends Motion
   @description: "Move cursor up to **edge** char at same-column"
 
   moveCursor: (cursor) ->
-    point = cursor.getScreenPosition()
-    @countTimes ({stop}) =>
-      if (newPoint = @getPoint(point))
-        point = newPoint
-      else
-        stop()
-    @setScreenPositionSafely(cursor, point)
+    @moveCursorCountTimes cursor, =>
+      @setScreenPositionSafely(cursor, @getPoint(cursor.getScreenPosition()))
 
   getPoint: (fromPoint) ->
     column = fromPoint.column
@@ -370,7 +365,7 @@ class MoveToNextWord extends Motion
   moveCursor: (cursor) ->
     return if cursorIsAtVimEndOfFile(cursor)
     wasOnWhiteSpace = cursorIsOnWhiteSpace(cursor)
-    @countTimes ({isFinal}) =>
+    @moveCursorCountTimes cursor, ({isFinal}) =>
       cursorRow = cursor.getBufferRow()
       if cursorIsAtEmptyRow(cursor) and @isAsOperatorTarget()
         point = [cursorRow + 1, 0]
@@ -390,7 +385,7 @@ class MoveToPreviousWord extends Motion
   wordRegex: null
 
   moveCursor: (cursor) ->
-    @countTimes =>
+    @moveCursorCountTimes cursor, =>
       point = cursor.getBeginningOfCurrentWordBufferPosition({@wordRegex})
       cursor.setBufferPosition(point)
 
@@ -406,7 +401,7 @@ class MoveToEndOfWord extends Motion
     cursor.setBufferPosition(point)
 
   moveCursor: (cursor) ->
-    @countTimes =>
+    @moveCursorCountTimes cursor, =>
       originalPoint = cursor.getBufferPosition()
       @moveToNextEndOfWord(cursor)
       if originalPoint.isEqual(cursor.getBufferPosition())
@@ -509,10 +504,8 @@ class MoveToNextSentence extends Motion
   direction: 'next'
 
   moveCursor: (cursor) ->
-    point = cursor.getBufferPosition()
-    @countTimes =>
-      point = @getPoint(point)
-    cursor.setBufferPosition(point)
+    @moveCursorCountTimes cursor, =>
+      @setBufferPositionSafely(cursor, @getPoint(cursor.getBufferPosition()))
 
   getPoint: (fromPoint) ->
     if @direction is 'next'
@@ -576,10 +569,8 @@ class MoveToNextParagraph extends Motion
   direction: 'next'
 
   moveCursor: (cursor) ->
-    point = cursor.getBufferPosition()
-    @countTimes =>
-      point = @getPoint(point)
-    cursor.setBufferPosition(point)
+    @moveCursorCountTimes cursor, =>
+      @setBufferPositionSafely(cursor, @getPoint(cursor.getBufferPosition()))
 
   getPoint: (fromPoint) ->
     startRow = fromPoint.row
@@ -646,7 +637,7 @@ class MoveToFirstCharacterOfLineUp extends MoveToFirstCharacterOfLine
   @extend()
   wise: 'linewise'
   moveCursor: (cursor) ->
-    @countTimes ->
+    @moveCursorCountTimes cursor, =>
       moveCursorUpBuffer(cursor)
     super
 
@@ -654,7 +645,7 @@ class MoveToFirstCharacterOfLineDown extends MoveToFirstCharacterOfLine
   @extend()
   wise: 'linewise'
   moveCursor: (cursor) ->
-    @countTimes ->
+    @moveCursorCountTimes cursor, =>
       moveCursorDownBuffer(cursor)
     super
 
@@ -967,7 +958,7 @@ class MoveToPreviousFoldStart extends Motion
     @getScanRows(cursor)[0]
 
   moveCursor: (cursor) ->
-    @countTimes =>
+    @moveCursorCountTimes cursor, =>
       if (row = @detectRow(cursor))?
         moveCursorToFirstCharacterAtRow(cursor, row)
 
@@ -1026,13 +1017,8 @@ class MoveToPositionByScope extends Motion
     detectScopeStartPositionForScope(@editor, fromPoint, @direction, @scope)
 
   moveCursor: (cursor) ->
-    point = cursor.getBufferPosition()
-    @countTimes ({stop}) =>
-      if (newPoint = @getPoint(point))
-        point = newPoint
-      else
-        stop()
-    @setBufferPositionSafely(cursor, point)
+    @moveCursorCountTimes cursor, =>
+      @setBufferPositionSafely(cursor, @getPoint(cursor.getBufferPosition()))
 
 class MoveToPreviousString extends MoveToPositionByScope
   @extend()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -198,8 +198,11 @@ class MoveLeft extends Motion
   @extend()
   moveCursor: (cursor) ->
     allowWrap = settings.get('wrapLeftRightMotion')
-    @countTimes ->
+    point = cursor.getBufferPosition()
+    @countTimes ({stop})->
       moveCursorLeft(cursor, {allowWrap})
+      stop() if point.isEqual(cursor.getBufferPosition())
+      point = cursor.getBufferPosition()
 
 class MoveRight extends Motion
   @extend()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -146,6 +146,14 @@ class Motion extends Base
     else
       setBufferRow(cursor, row, options)
 
+  moveCursorCountTimes: (cursor, fn) ->
+    oldPosition = cursor.getBufferPosition()
+    @countTimes ({stop}) ->
+      fn()
+      if (newPosition = cursor.getBufferPosition()).isEqual(oldPosition)
+        stop()
+      oldPosition = newPosition
+
 # Used as operator's target in visual-mode.
 class CurrentSelection extends Motion
   @extend(false)
@@ -198,11 +206,8 @@ class MoveLeft extends Motion
   @extend()
   moveCursor: (cursor) ->
     allowWrap = settings.get('wrapLeftRightMotion')
-    point = cursor.getBufferPosition()
-    @countTimes ({stop})->
+    @moveCursorCountTimes cursor, ->
       moveCursorLeft(cursor, {allowWrap})
-      stop() if point.isEqual(cursor.getBufferPosition())
-      point = cursor.getBufferPosition()
 
 class MoveRight extends Motion
   @extend()
@@ -213,7 +218,7 @@ class MoveRight extends Motion
       settings.get('wrapLeftRightMotion')
 
   moveCursor: (cursor) ->
-    @countTimes =>
+    @moveCursorCountTimes cursor, =>
       @editor.unfoldBufferRow(cursor.getBufferRow())
       allowWrap = @canWrapToNextLine(cursor)
       moveCursorRight(cursor)
@@ -238,7 +243,7 @@ class MoveUp extends Motion
       row
 
   moveCursor: (cursor) ->
-    @countTimes =>
+    @moveCursorCountTimes cursor, =>
       setBufferRow(cursor, @getBufferRow(cursor.getBufferRow()))
 
 class MoveDown extends MoveUp
@@ -256,7 +261,7 @@ class MoveUpScreen extends Motion
   direction: 'up'
 
   moveCursor: (cursor) ->
-    @countTimes ->
+    @moveCursorCountTimes cursor, =>
       moveCursorUpScreen(cursor)
 
 class MoveDownScreen extends MoveUpScreen
@@ -265,7 +270,7 @@ class MoveDownScreen extends MoveUpScreen
   direction: 'down'
 
   moveCursor: (cursor) ->
-    @countTimes ->
+    @moveCursorCountTimes cursor, =>
       moveCursorDownScreen(cursor)
 
 # Move down/up to Edge

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -146,6 +146,11 @@ class Motion extends Base
     else
       setBufferRow(cursor, row, options)
 
+  # [NOTE]
+  # Since this function checks cursor position change, a cursor position MUST be
+  # updated IN callback(=fn)
+  # Updating point only in callback is wrong-use of this funciton,
+  # since it stops immediately because of not cursor position change.
   moveCursorCountTimes: (cursor, fn) ->
     oldPosition = cursor.getBufferPosition()
     @countTimes (state) =>

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore-plus'
 {Range} = require 'atom'
 
 {
-  moveCursorLeft, moveCursorRight
+  moveCursorLeft, moveCursorRight, limitNumber
 } = require './utils'
 swrap = require './selection-wrapper'
 settings = require './settings'
@@ -91,7 +91,8 @@ class ActivateInsertMode extends Operator # FIXME
 
   getInsertionCount: ->
     @insertionCount ?= if @supportInsertionCount then @getCount(-1) else 0
-    @insertionCount
+    # Avoid freezing by acccidental big count(e.g. `5555555555555i`), See #560, #596
+    limitNumber(@insertionCount, max: 100)
 
   execute: ->
     if @isRequireTarget()

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -100,26 +100,54 @@ describe "Motion general", ->
           ensure 'j', selectedText: text.getLines([1])
           ensure 'j', selectedText: text.getLines([1, 2])
 
-    describe "with big count was given", ->
-      BIG_NUMBER = null
-      ensureBigCountMotion = (number, keystroke, options) ->
-        count = String(number).split('').join(' ')
-        ensure("#{count} #{keystroke}", options)
+    # [NOTE] See #560
+    # This spec is intended to be used in local test, not at CI service.
+    # Safe to execute if it passes, but freeze editor when it fail.
+    # So explicitly disabled because I don't want be banned by CI service.
+    # Enable this on demmand when freezing happens again!
+    xdescribe "with big count was given", ->
+      BIG_NUMBER = Number.MAX_SAFE_INTEGER
+      ensureBigCountMotion = (keystrokes, options) ->
+        count = String(BIG_NUMBER).split('').join(' ')
+        keystrokes = keystrokes.split('').join(' ')
+        ensure("#{count} #{keystrokes}", options)
 
       beforeEach ->
-        BIG_NUMBER = Number.MAX_SAFE_INTEGER
+        atom.keymaps.add "test",
+          'atom-text-editor.vim-mode-plus:not(.insert-mode)':
+            'g {': 'vim-mode-plus:move-to-previous-fold-start'
+            'g }': 'vim-mode-plus:move-to-next-fold-start'
+            ', N': 'vim-mode-plus:move-to-previous-number'
+            ', n': 'vim-mode-plus:move-to-next-number'
         set
           text: """
           0000
           1111
-          2222
+          2222\n
           """
           cursor: [1, 2]
 
-      it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
-      it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
-      it "by `h`", -> ensureBigCountMotion BIG_NUMBER, 'h', cursor: [1, 0]
-      it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
+      it "by `j`", -> ensureBigCountMotion 'j', cursor: [2, 2]
+      it "by `k`", -> ensureBigCountMotion 'k', cursor: [0, 2]
+      it "by `h`", -> ensureBigCountMotion 'h', cursor: [1, 0]
+      it "by `l`", -> ensureBigCountMotion 'l', cursor: [1, 3]
+      it "by `[`", -> ensureBigCountMotion '[', cursor: [0, 2]
+      it "by `]`", -> ensureBigCountMotion ']', cursor: [2, 2]
+      it "by `w`", -> ensureBigCountMotion 'w', cursor: [2, 3]
+      it "by `W`", -> ensureBigCountMotion 'W', cursor: [2, 3]
+      it "by `b`", -> ensureBigCountMotion 'b', cursor: [0, 0]
+      it "by `B`", -> ensureBigCountMotion 'B', cursor: [0, 0]
+      it "by `e`", -> ensureBigCountMotion 'e', cursor: [2, 3]
+      it "by `(`", -> ensureBigCountMotion '(', cursor: [0, 0]
+      it "by `)`", -> ensureBigCountMotion ')', cursor: [2, 3]
+      it "by `{`", -> ensureBigCountMotion '{', cursor: [0, 0]
+      it "by `}`", -> ensureBigCountMotion '}', cursor: [2, 3]
+      it "by `-`", -> ensureBigCountMotion '-', cursor: [0, 0]
+      it "by `_`", -> ensureBigCountMotion '_', cursor: [2, 0]
+      it "by `g {`", -> ensureBigCountMotion 'g {', cursor: [1, 2] # No fold no move but won't freeze.
+      it "by `g }`", -> ensureBigCountMotion 'g }', cursor: [1, 2] # No fold no move but won't freeze.
+      it "by `, N`", -> ensureBigCountMotion ', N', cursor: [1, 2] # No grammar, no move but won't freeze.
+      it "by `, n`", -> ensureBigCountMotion ', n', cursor: [1, 2] # No grammar, no move but won't freeze.
 
     describe "the k keybinding", ->
       beforeEach ->

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -108,7 +108,6 @@ describe "Motion general", ->
 
       beforeEach ->
         BIG_NUMBER = Number.MAX_SAFE_INTEGER
-        # BIG_NUMBER = 10
         set
           text: """
           0000
@@ -117,10 +116,10 @@ describe "Motion general", ->
           """
           cursor: [1, 2]
 
-      # it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
-      # it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
+      it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
+      it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
       it "by `h`", -> ensureBigCountMotion BIG_NUMBER, 'h', cursor: [1, 0]
-      # it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
+      it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
 
     describe "the k keybinding", ->
       beforeEach ->

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -108,7 +108,7 @@ describe "Motion general", ->
 
       beforeEach ->
         BIG_NUMBER = Number.MAX_SAFE_INTEGER
-        BIG_NUMBER = 10
+        # BIG_NUMBER = 10
         set
           text: """
           0000
@@ -117,10 +117,10 @@ describe "Motion general", ->
           """
           cursor: [1, 2]
 
-      it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
-      it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
+      # it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
+      # it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
       it "by `h`", -> ensureBigCountMotion BIG_NUMBER, 'h', cursor: [1, 0]
-      it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
+      # it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
 
     describe "the k keybinding", ->
       beforeEach ->

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -100,6 +100,28 @@ describe "Motion general", ->
           ensure 'j', selectedText: text.getLines([1])
           ensure 'j', selectedText: text.getLines([1, 2])
 
+    describe "with big count was given", ->
+      BIG_NUMBER = null
+      ensureBigCountMotion = (number, keystroke, options) ->
+        count = String(number).split('').join(' ')
+        ensure("#{count} #{keystroke}", options)
+
+      beforeEach ->
+        BIG_NUMBER = Number.MAX_SAFE_INTEGER
+        BIG_NUMBER = 10
+        set
+          text: """
+          0000
+          1111
+          2222
+          """
+          cursor: [1, 2]
+
+      it "by `j`", -> ensureBigCountMotion BIG_NUMBER, 'j', cursor: [2, 2]
+      it "by `k`", -> ensureBigCountMotion BIG_NUMBER, 'k', cursor: [0, 2]
+      it "by `h`", -> ensureBigCountMotion BIG_NUMBER, 'h', cursor: [1, 0]
+      it "by `l`", -> ensureBigCountMotion BIG_NUMBER, 'l', cursor: [1, 3]
+
     describe "the k keybinding", ->
       beforeEach ->
         set cursor: [2, 1]

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -852,3 +852,12 @@ describe "Operator ActivateInsertMode family", ->
         it "[case-C]", -> ensureInsertionCount '3 C', insert: '=', text: "=", cursor: [0, 0]
         it "[case-s]", -> ensureInsertionCount '3 s', insert: '=', text: "=", cursor: [0, 0]
         it "[case-S]", -> ensureInsertionCount '3 S', insert: '=', text: "=", cursor: [0, 0]
+
+    describe "throttoling intertion count to 100 at maximum", ->
+      it "insert 100 times at maximum even if big count was given", ->
+        set text: ''
+        expect(editor.getLastBufferRow()).toBe(0)
+        ensure '5 5 5 5 5 5 5 i', mode: 'insert'
+        editor.insertText("a\n")
+        ensure 'escape', mode: 'normal'
+        expect(editor.getLastBufferRow()).toBe(101)


### PR DESCRIPTION
This was long lived bug.
  - Also happens in original vim-mode `1111111111111111111111111j` throw exception in vim-mode.

Fix #560

## Points to consider

- Use of `Base::countTimes` and its' derivatives.
- Big count was given to Motion
- Big count was given to TextObject
  - Count support for textObject is very immature state though(`v999999999ip` freezes).
- Count insertion e.g. `1 0 i` then type `abc` then `escape`.
  - Found pure vim(checked by MacVim(vim8) in GUI) also freeze in this scenario.
  - Giving a big count freezes editor.
  - Applied to all child classes which have `@supportInsertionCount` set `true`.

## [TODO]

- [x] Eliminate use of `@countTimes` from Motion.
- [x] Fix text-object
  - Fixed very imperatively, dirtily
    - Count specified in multi-selections and one of its fail stops other selection expand.
    - But I think it's far better than freezing editor.
  - No spec was added(I don't want to spend my time for this now, since count support of text-object is not well supported/defined yet).
- [x] Fix operator-insert.coffee
  - :bomb: Limit max insertion count to `100` to avoid accidental `5555555555555i` freezes editor.
