### PR TITLE
Cleanup cursor placement

### DIFF
--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -21,13 +21,14 @@ vimStateMethods = [
   "onDidCancelSearch"
   "onDidCommandSearch"
 
+  "onWillMutateTarget"
+  "onDidMutateTarget"
   "onDidSetTarget"
   "onWillSelectTarget"
   "onDidSelectTarget"
   "preemptWillSelectTarget"
   "preemptDidSelectTarget"
   "onDidRestoreCursorPositions"
-  "onDidGroupChangesSinceBufferCheckpoint"
   "onDidSetOperatorModifier"
   "onDidResetOperationStack"
 
@@ -270,8 +271,11 @@ class Base
   emitDidRestoreCursorPositions: ->
     @vimState.emitter.emit('did-restore-cursor-positions')
 
-  emitDidGroupChangesSinceBufferCheckpoint: (purpose) ->
-    @vimState.emitter.emit('did-group-changes-since-buffer-checkpoint', {purpose})
+  emitWillMutateTarget: ->
+    @vimState.emitter.emit('on-will-mutate-target')
+
+  emitDidMutateTarget: ->
+    @vimState.emitter.emit('on-did-mutate-target')
 
   # Class methods
   # -------------------------

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -21,24 +21,30 @@ vimStateMethods = [
   "onDidCancelSearch"
   "onDidCommandSearch"
 
-  "onWillMutateTarget"
-  "onDidMutateTarget"
+  # Life cycle
   "onDidSetTarget"
-  "onWillSelectTarget"
-  "onDidSelectTarget"
-  "preemptWillSelectTarget"
-  "preemptDidSelectTarget"
-  "onDidRestoreCursorPositions"
-  "onDidSetOperatorModifier"
+  "emitDidSetTarget"
+    "onWillMutateTarget"
+    "emitWillMutateTarget"
+      "onWillSelectTarget"
+      "emitWillSelectTarget"
+      "onDidSelectTarget"
+      "emitDidSelectTarget"
+
+      "onDidRestoreCursorPositions"
+      "emitDidRestoreCursorPositions"
+    "onDidMutateTarget"
+    "emitDidMutateTarget"
+  "onDidFinishOperation"
   "onDidResetOperationStack"
+
+  "onDidSetOperatorModifier"
 
   "onWillActivateMode"
   "onDidActivateMode"
-  "onWillDeactivateMode"
   "preemptWillDeactivateMode"
+  "onWillDeactivateMode"
   "onDidDeactivateMode"
-
-  "onDidFinishOperation"
 
   "onDidCancelSelectList"
   "subscribe"
@@ -258,24 +264,6 @@ class Base
     str = @getName()
     str += ", target=#{@getTarget().toString()}" if @hasTarget()
     str
-
-  emitWillSelectTarget: ->
-    @vimState.emitter.emit('will-select-target')
-
-  emitDidSelectTarget: ->
-    @vimState.emitter.emit('did-select-target')
-
-  emitDidSetTarget: (operator) ->
-    @vimState.emitter.emit('did-set-target', operator)
-
-  emitDidRestoreCursorPositions: ->
-    @vimState.emitter.emit('did-restore-cursor-positions')
-
-  emitWillMutateTarget: ->
-    @vimState.emitter.emit('on-will-mutate-target')
-
-  emitDidMutateTarget: ->
-    @vimState.emitter.emit('on-did-mutate-target')
 
   # Class methods
   # -------------------------

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -41,8 +41,14 @@ class Undo extends MiscCommand
     newRanges = []
     oldRanges = []
 
+    # {inspect} = require 'util'
+    # p = (args...) -> console.log inspect(args...)
+
     # Collect changed range while mutating text-state by fn callback.
-    disposable = @editor.getBuffer().onDidChange ({newRange, oldRange}) ->
+    disposable = @editor.getBuffer().onDidChange (event) ->
+      {newRange, newText, oldRange, oldText} = event
+      # p {newRange, newText, oldRange, oldText}
+
       if newRange.isEmpty()
         oldRanges.push(oldRange) # Remove only
       else
@@ -55,6 +61,7 @@ class Undo extends MiscCommand
 
     allRanges = sortRanges(newRanges.concat(oldRanges))
     restoredCursorPosition = @editor.getCursorBufferPosition()
+    # if cursorContainedRange = findRangeContainsPoint(newRanges, restoredCursorPosition)
     if cursorContainedRange = findRangeContainsPoint(allRanges, restoredCursorPosition)
       @vimState.mark.setRange('[', ']', cursorContainedRange)
       if settings.get('setCursorToStartOfChangeOnUndoRedo')

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -8,6 +8,7 @@ _ = require 'underscore-plus'
 {
   pointIsAtEndOfLine
   sortRanges
+  findRangeContainsPoint
 } = require './utils'
 
 class MiscCommand extends Base
@@ -36,11 +37,6 @@ class BlockwiseOtherEnd extends ReverseSelections
 class Undo extends MiscCommand
   @extend()
 
-  findRangeContainsPoint: (ranges, point) ->
-    for range in ranges when range.containsPoint(point)
-      return range
-    null
-
   withTrackingChanges: (fn) ->
     newRanges = []
     oldRanges = []
@@ -59,7 +55,7 @@ class Undo extends MiscCommand
 
     allRanges = sortRanges(newRanges.concat(oldRanges))
     restoredCursorPosition = @editor.getCursorBufferPosition()
-    if cursorContainedRange = @findRangeContainsPoint(allRanges, restoredCursorPosition)
+    if cursorContainedRange = findRangeContainsPoint(allRanges, restoredCursorPosition)
       @vimState.mark.setRange('[', ']', cursorContainedRange)
       if settings.get('setCursorToStartOfChangeOnUndoRedo')
         if isLinewiseRange(cursorContainedRange)

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -59,16 +59,17 @@ class Undo extends MiscCommand
     disposable.dispose()
     selection.clear() for selection in @editor.getSelections()
 
-    allRanges = sortRanges(newRanges.concat(oldRanges))
     restoredCursorPosition = @editor.getCursorBufferPosition()
-    # if cursorContainedRange = findRangeContainsPoint(newRanges, restoredCursorPosition)
-    if cursorContainedRange = findRangeContainsPoint(allRanges, restoredCursorPosition)
+    if cursorContainedRange = findRangeContainsPoint(newRanges, restoredCursorPosition)
       @vimState.mark.setRange('[', ']', cursorContainedRange)
       if settings.get('setCursorToStartOfChangeOnUndoRedo')
         if isLinewiseRange(cursorContainedRange)
           setBufferRow(@editor.getLastCursor(), cursorContainedRange.start.row)
         else
-          @editor.setCursorBufferPosition(cursorContainedRange.start)
+          @editor.getLastCursor().setBufferPosition(cursorContainedRange.start)
+
+    if settings.get('setCursorToStartOfChangeOnUndoRedo')
+      @vimState.clearSelections()
 
     if settings.get('flashOnUndoRedo')
       if newRanges.length > 0

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -2,7 +2,9 @@ _ = require 'underscore-plus'
 {Range} = require 'atom'
 
 {
-  moveCursorLeft, moveCursorRight, limitNumber
+  moveCursorLeft
+  moveCursorRight
+  limitNumber
 } = require './utils'
 swrap = require './selection-wrapper'
 settings = require './settings'
@@ -65,7 +67,11 @@ class ActivateInsertMode extends Operator # FIXME
 
       # grouping changes for undo checkpoint need to come last
       if settings.get('groupChangesWhenLeavingInsertMode')
+        lastCursor = @editor.getLastCursor()
+        currentCursorPosition = lastCursor.getBufferPosition()
+        lastCursor.setBufferPosition(@vimState.getOriginalCursorPositionByMarker())
         @groupChangesSinceBufferCheckpoint('undo')
+        lastCursor.setBufferPosition(currentCursorPosition)
 
   # When each mutaion's extent is not intersecting, muitiple changes are recorded
   # e.g
@@ -291,7 +297,6 @@ class Change extends ActivateInsertMode
         selection.cursor.moveLeft()
       else
         selection.insertText('', autoIndent: true)
-
 
 class ChangeOccurrence extends Change
   @extend()

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -67,11 +67,7 @@ class ActivateInsertMode extends Operator # FIXME
 
       # grouping changes for undo checkpoint need to come last
       if settings.get('groupChangesWhenLeavingInsertMode')
-        lastCursor = @editor.getLastCursor()
-        currentCursorPosition = lastCursor.getBufferPosition()
-        lastCursor.setBufferPosition(@vimState.getOriginalCursorPositionByMarker())
         @groupChangesSinceBufferCheckpoint('undo')
-        lastCursor.setBufferPosition(currentCursorPosition)
 
   # When each mutaion's extent is not intersecting, muitiple changes are recorded
   # e.g
@@ -192,6 +188,18 @@ class InsertAtLastInsert extends ActivateInsertMode
 
 class InsertAboveWithNewline extends ActivateInsertMode
   @extend()
+
+  # This is for `o` and `O` operator.
+  # On undo/redo put cursor at original point where user type `o` or `O`.
+  groupChangesSinceBufferCheckpoint: ->
+    lastCursor = @editor.getLastCursor()
+    cursorPosition = lastCursor.getBufferPosition()
+    lastCursor.setBufferPosition(@vimState.getOriginalCursorPositionByMarker())
+
+    super
+
+    lastCursor.setBufferPosition(cursorPosition)
+
   mutateText: ->
     @editor.insertNewlineAbove()
 

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -237,6 +237,7 @@ class TransformStringByExternalCommand extends TransformString
   stdoutBySelection: null
 
   execute: ->
+    @normalizeSelectionsIfNecessary()
     if @selectTarget()
       new Promise (resolve) =>
         @collect(resolve)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -375,17 +375,15 @@ class Delete extends Operator
 
   execute: ->
     @onDidSelectTarget =>
-      @requestAdjustCursorPositions() if @target.isLinewise() and not @occurrenceSelected
+      return if @occurrenceSelected
+      if @target.isLinewise()
+        @onDidRestoreCursorPositions =>
+          @adjustCursor(cursor) for cursor in @editor.getCursors()
     super
 
   mutateSelection: (selection) =>
     @setTextToRegisterForSelection(selection)
     selection.deleteSelectedText()
-
-  requestAdjustCursorPositions: ->
-    @onDidRestoreCursorPositions =>
-      for cursor in @editor.getCursors()
-        @adjustCursor(cursor)
 
   adjustCursor: (cursor) ->
     row = getValidVimBufferRow(@editor, cursor.getBufferRow())

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -218,6 +218,10 @@ class Operator extends Base
 
   # Return true unless all selection is empty.
   selectTarget: ->
+    if @target.isMotion() and @isMode('visual')
+      @vimState.modeManager.normalizeSelections()
+      @createBufferCheckpoint('undo')
+
     @occurrenceSelected = false
     @mutationManager.init(
       isSelect: @instanceof('Select')
@@ -237,11 +241,6 @@ class Operator extends Base
     #  occurrence-marker, occurrence-marker has to be created BEFORE `@target.execute()`
     if @isRepeated() and @isOccurrence() and not @occurrenceManager.hasMarkers()
       @addOccurrencePattern()
-
-    if @target.isMotion() and @isMode('visual')
-      @vimState.modeManager.normalizeSelections()
-      # Overwrite checkpoint since I want restore cursor position at undo/redo.
-      @createBufferCheckpoint('undo')
 
     @target.execute()
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -798,6 +798,7 @@ limitNumber = (number, {max, min}={}) ->
 findRangeContainsPoint = (ranges, point) ->
   for range in ranges when range.containsPoint(point)
     return range
+  null
 
 isNotEmpty = (target) ->
   not target.isEmpty()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -301,7 +301,6 @@ class VimState
     @saveOriginalCursorPosition()
 
   reset: ->
-    @resetOriginalCursorPosition()
     @register.reset()
     @searchHistory.reset()
     @hover.reset()
@@ -353,14 +352,19 @@ class VimState
   # Other
   # -------------------------
   saveOriginalCursorPosition: ->
+    @originalCursorPosition = null
+    @originalCursorPositionByMarker?.destroy()
+
     if @mode is 'visual'
       options = {fromProperty: true, allowFallback: true}
-      @originalCursorPosition = swrap(@editor.getLastSelection()).getBufferPositionFor('head', options)
+      point = swrap(@editor.getLastSelection()).getBufferPositionFor('head', options)
     else
-      @originalCursorPosition = @editor.getCursorBufferPosition()
+      point = @editor.getCursorBufferPosition()
+    @originalCursorPosition = point
+    @originalCursorPositionByMarker = @editor.markBufferPosition(point, invalidate: 'never')
 
   getOriginalCursorPosition: ->
     @originalCursorPosition
 
-  resetOriginalCursorPosition: ->
-    @originalCursorPosition = null
+  getOriginalCursorPositionByMarker: ->
+    @originalCursorPositionByMarker.getStartBufferPosition()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -144,13 +144,22 @@ class VimState
 
   # Select and text mutation(Change)
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
+  emitDidSetTarget: (operator) -> @emitter.emit('did-set-target', operator)
+
   onWillSelectTarget: (fn) -> @subscribe @emitter.on('will-select-target', fn)
+  emitWillSelectTarget: -> @emitter.emit('will-select-target')
+
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
+  emitDidSelectTarget: -> @emitter.emit('did-select-target')
+
   onWillMutateTarget: (fn) -> @subscribe @emitter.on('on-will-mutate-target', fn)
+  emitWillMutateTarget: -> @emitter.emit('on-will-mutate-target')
+
   onDidMutateTarget: (fn) -> @subscribe @emitter.on('on-did-mutate-target', fn)
-  preemptWillSelectTarget: (fn) -> @subscribe @emitter.preempt('will-select-target', fn)
-  preemptDidSelectTarget: (fn) -> @subscribe @emitter.preempt('did-select-target', fn)
+  emitDidMutateTarget: -> @emitter.emit('on-did-mutate-target')
+
   onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
+  emitDidRestoreCursorPositions: -> @emitter.emit('did-restore-cursor-positions')
 
   onDidSetOperatorModifier: (fn) -> @subscribe @emitter.on('did-set-operator-modifier', fn)
   emitDidSetOperatorModifier: (options) -> @emitter.emit('did-set-operator-modifier', options)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -146,10 +146,11 @@ class VimState
   onDidSetTarget: (fn) -> @subscribe @emitter.on('did-set-target', fn)
   onWillSelectTarget: (fn) -> @subscribe @emitter.on('will-select-target', fn)
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
+  onWillMutateTarget: (fn) -> @subscribe @emitter.on('on-will-mutate-target', fn)
+  onDidMutateTarget: (fn) -> @subscribe @emitter.on('on-did-mutate-target', fn)
   preemptWillSelectTarget: (fn) -> @subscribe @emitter.preempt('will-select-target', fn)
   preemptDidSelectTarget: (fn) -> @subscribe @emitter.preempt('did-select-target', fn)
   onDidRestoreCursorPositions: (fn) -> @subscribe @emitter.on('did-restore-cursor-positions', fn)
-  onDidGroupChangesSinceBufferCheckpoint: (fn) -> @subscribe @emitter.on('did-group-changes-since-buffer-checkpoint', fn)
 
   onDidSetOperatorModifier: (fn) -> @subscribe @emitter.on('did-set-operator-modifier', fn)
   emitDidSetOperatorModifier: (options) -> @emitter.emit('did-set-operator-modifier', options)

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -351,6 +351,22 @@ describe "Operator ActivateInsertMode family", ->
       ensure 'escape', text: "abc\n  012\n  def\n"
       ensure 'u', text: "abc\n  012\n"
 
+  describe "undo/redo for `o` and `O`", ->
+    beforeEach ->
+      set textC: "----|=="
+    it "undo and redo by keeping cursor at o started position", ->
+      ensure 'o', mode: 'insert'
+      editor.insertText('@@')
+      ensure "escape", textC: "----==\n@|@"
+      ensure "u", textC: "----|=="
+      ensure "ctrl-r", textC: "----|==\n@@"
+    it "undo and redo by keeping cursor at O started position", ->
+      ensure 'O', mode: 'insert'
+      editor.insertText('@@')
+      ensure "escape", textC: "@|@\n----=="
+      ensure "u", textC: "----|=="
+      ensure "ctrl-r", textC: "@@\n----|=="
+
   describe "the a keybinding", ->
     beforeEach ->
       set text: "012\n"

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -610,34 +610,52 @@ describe "Operator TransformString", ->
         jasmine.attachToDOM(editorElement)
 
         set
-          text: """
+          textC: """
 
-            apple
+            |apple
             pairs tomato
             orange
             milk
 
             """
-          cursorBuffer: [1, 0]
 
         atom.keymaps.add "ms",
           'atom-text-editor.vim-mode-plus:not(.insert-mode)':
             'm s': 'vim-mode-plus:map-surround'
           'atom-text-editor.vim-mode-plus.visual-mode':
             'm s':  'vim-mode-plus:map-surround'
+
       it "surround text for each word in target case-1", ->
-        ensure ['m s i p', input: '('],
-          text: "\n(apple)\n(pairs) (tomato)\n(orange)\n(milk)\n"
-          cursor: [1, 0]
+        ensure 'm s i p (',
+          textC: """
+
+          |(apple)
+          (pairs) (tomato)
+          (orange)
+          (milk)
+
+          """
       it "surround text for each word in target case-2", ->
         set cursor: [2, 1]
-        ensure ['m s i l', input: '<'],
-          text: '\napple\n<pairs> <tomato>\norange\nmilk\n'
-          cursor: [2, 1]
+        ensure 'm s i l <',
+          textC: """
+
+          apple
+          <|pairs> <tomato>
+          orange
+          milk
+
+          """
       it "surround text for each word in visual selection", ->
-        ensure ['v i p m s', input: '"'],
-          text: '\n"apple"\n"pairs" "tomato"\n"orange"\n"milk"\n'
-          cursor: [4, 0]
+        ensure 'v i p m s "',
+          textC: """
+
+          "apple"
+          "pairs" "tomato"
+          "orange"
+          |"milk"
+
+          """
 
     describe 'delete surround', ->
       beforeEach ->

--- a/spec/persistent-selectionr-spec.coffee
+++ b/spec/persistent-selectionr-spec.coffee
@@ -58,7 +58,7 @@ describe "Persistent Selection", ->
 
     describe "basic behavior", ->
       describe "create-persistent-selection", ->
-        it "create-persistent-selection create range marker", ->
+        it "create-persistent-selection", ->
           ensurePersistentSelection 'g m i w',
             length: 1
             text: ['ooo']


### PR DESCRIPTION
- Improved cursor placement for undo/redo of  `o` and `O`.
- Improve flash for undo/redo, especially "\n" starting change.
- Reduce use of `green` color of flash, it was `> 1` before, but now it has to be `>1` and all range is single line range
  - Essentially this color is used on `occurrence` mutation or multi-cursor mutation(`cmd-d`)
- Remove manual checkpoint management from operator except insertion operator(e.g. `i`, `a`).
  - Since I noticed `editor.transaction` is used for this after cleaning up code(and done).