### PR TITLE
separate select and mutate phase in operator lifecycle

### DIFF
--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -29,6 +29,9 @@ vimStateMethods = [
       "onDidSelectTarget"
       "emitDidSelectTarget"
 
+      "onDidFailSelectTarget"
+      "emitDidFailSelectTarget"
+
       "onDidRestoreCursorPositions"
       "emitDidRestoreCursorPositions"
     "onWillFinishMutation"

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -76,7 +76,7 @@ class Base
   # Operation processor execute only when isComplete() return true.
   # If false, operation processor postpone its execution.
   isComplete: ->
-    if (@isRequireInput() and not @hasInput())
+    if @isRequireInput() and not @hasInput()
       false
     else if @isRequireTarget()
       # When this function is called in Base::constructor

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -188,7 +188,7 @@ class Base
   focusInput: (charsMax) ->
     inputUI = @newInputUI()
     inputUI.onDidConfirm (input) =>
-      unless @input?
+      unless @input?  # [FIXME] I think I can delete this guard.
         @input = input
         @processOperation()
 
@@ -200,9 +200,7 @@ class Base
         @addHover(input, {replace})
         replace = true
 
-    inputUI.onDidCancel =>
-      @cancelOperation()
-
+    inputUI.onDidCancel(@cancelOperation.bind(this))
     inputUI.focus(charsMax)
 
   getVimEofBufferPosition: ->

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -13,6 +13,7 @@ _ = require 'underscore-plus'
   findRangeContainsPoint
   mergeIntersectingRanges
   isSingleLineRange
+  isLinewiseRange
   isLeadingWhiteSpaceRange
 } = require './utils'
 
@@ -117,7 +118,7 @@ class Undo extends MiscCommand
   humanizeNewLineForRange: (range) ->
     {start, end} = range
 
-    if isSingleLineRange(range)
+    if isSingleLineRange(range) or isLinewiseRange(range)
       return range
 
     if pointIsAtEndOfLine(@editor, start)

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -116,10 +116,10 @@ class Undo extends MiscCommand
   #
   # So always trim initial "\n" part range because flashing trailing line is counterintuitive.
   humanizeNewLineForRange: (range) ->
-    {start, end} = range
-
     if isSingleLineRange(range) or isLinewiseRange(range)
       return range
+
+    {start, end} = range
 
     if pointIsAtEndOfLine(@editor, start)
       newStart = new Point(start.row + 1, 0)

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -134,6 +134,9 @@ class OperationStack
       @peekTop().setTarget(operation)
 
     top = @peekTop()
+    console.log "in process() complete? ", top.isComplete()
+    console.log "in process() toString() ", top.toString()
+
     if top.isComplete()
       @execute(@stack.pop())
     else

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -158,6 +158,7 @@ class OperationStack
   cancel: ->
     if @mode not in ['visual', 'insert']
       @vimState.resetNormalMode()
+      @vimState.restoreOriginalCursorPosition()
     @finish()
 
   finish: (operation=null) ->

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -128,8 +128,10 @@ class OperationStack
     if @stack.length is 2
       # [FIXME ideally]
       # If target is not complete, we postpone compsing target with operator to keep situation simple.
-      # We can assume, when target is set to operator it's complete.
+      # So that we can assume when target is set to operator it's complete.
+      # e.g. `y s t a'(surround for range from here to till a)
       return unless @peekTop().isComplete()
+
       operation = @stack.pop()
       @peekTop().setTarget(operation)
 

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -134,8 +134,6 @@ class OperationStack
       @peekTop().setTarget(operation)
 
     top = @peekTop()
-    console.log "in process() complete? ", top.isComplete()
-    console.log "in process() toString() ", top.toString()
 
     if top.isComplete()
       @execute(@stack.pop())
@@ -165,6 +163,8 @@ class OperationStack
   finish: (operation=null) ->
     @recordedOperation = operation if operation?.isRecordable()
     @vimState.emitDidFinishOperation()
+    if operation?.isOperator()
+      operation.resetState()
 
     if @mode is 'normal'
       @ensureAllSelectionsAreEmpty(operation)

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -20,26 +20,6 @@ class ActivateInsertMode extends Operator # FIXME
   flashTarget: false
   finalSubmode: null
   supportInsertionCount: true
-  bufferCheckpointByPurpose: null
-
-  # Two checkpoint for different purpose
-  # - one for undo(handled by modeManager)
-  # - one for preserve last inserted text
-  createBufferCheckpoint: (purpose) ->
-    @bufferCheckpointByPurpose ?= {}
-    @bufferCheckpointByPurpose[purpose] = @editor.createCheckpoint()
-
-  getBufferCheckpoint: (purpose) ->
-    @bufferCheckpointByPurpose?[purpose]
-
-  deleteBufferCheckpoint: (purpose) ->
-    if @bufferCheckpointByPurpose?
-      delete @bufferCheckpointByPurpose[purpose]
-
-  groupChangesSinceBufferCheckpoint: (purpose) ->
-    if checkpoint = @getBufferCheckpoint(purpose)
-      @editor.groupChangesSinceCheckpoint(checkpoint)
-      @deleteBufferCheckpoint(purpose)
 
   observeWillDeactivateMode: ->
     disposable = @vimState.modeManager.preemptWillDeactivateMode ({mode}) =>

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -431,12 +431,16 @@ class Surround extends TransformString
   requireInput: true
   autoIndent: false
 
+  supportEarlySelect: true # Experimental
+
   initialize: ->
     super
 
     return unless @requireInput
     if @requireTarget
-      @onDidSetTarget =>
+      # @onDidSetTarget =>
+      @onDidSelectTarget =>
+        console.log "SLECTED! now focusing input"
         @focusInput(@charsMax)
     else
       @focusInput(@charsMax)
@@ -449,6 +453,7 @@ class Surround extends TransformString
     @inputUI.focus(charsMax)
 
   onConfirm: (@input) ->
+    console.log 'confirmed input = ', @input
     @processOperation()
 
   getPair: (char) ->

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -436,10 +436,10 @@ class SurroundBase extends TransformString
     super
 
   focusInput: ->
-    @inputUI = @newInputUI()
-    @inputUI.onDidConfirm(@onConfirm.bind(this))
-    @inputUI.onDidCancel(@cancelOperation.bind(this))
-    @inputUI.focus()
+    inputUI = @newInputUI()
+    inputUI.onDidConfirm(@onConfirm.bind(this))
+    inputUI.onDidCancel(@cancelOperation.bind(this))
+    inputUI.focus()
 
   getPair: (char) ->
     pair = _.detect(@pairs, (pair) -> char in pair)
@@ -454,9 +454,9 @@ class SurroundBase extends TransformString
       close += "\n"
 
     if char in settings.get('charactersToAddSpaceOnSurround') and isSingleLineText(text)
-      open + ' ' + text + ' ' + close
-    else
-      open + text + close
+      text = ' ' + text + ' '
+
+    open + text + close
 
   deleteSurround: (text) ->
     [open, innerText..., close] = text
@@ -574,6 +574,7 @@ class ChangeSurroundAnyPairAllowForwarding extends ChangeSurroundAnyPair
   @description: "Change surround character, from char is auto-detected from enclosed and forwarding area"
   target: "AAnyPairAllowForwarding"
 
+# -------------------------
 # FIXME
 # Currently native editor.joinLines() is better for cursor position setting
 # So I use native methods for a meanwhile.

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -429,19 +429,17 @@ class SurroundBase extends TransformString
 
   requireInput: true
   requireTarget: true
-
   supportEarlySelect: true # Experimental
 
   initialize: ->
     @subscribeForInput()
     super
 
-  focusInput: (charsMax) ->
+  focusInput: ->
     @inputUI = @newInputUI()
     @inputUI.onDidConfirm(@onConfirm.bind(this))
-    @inputUI.onDidChange(@addHover.bind(this))
     @inputUI.onDidCancel(@cancelOperation.bind(this))
-    @inputUI.focus(charsMax)
+    @inputUI.focus()
 
   getPair: (char) ->
     pair = _.detect(@pairs, (pair) -> char in pair)
@@ -468,7 +466,7 @@ class SurroundBase extends TransformString
     else
       innerText
 
-  setTargetFromPairChar: (char) ->
+  setTargetForPairChar: (char) ->
     @setTarget @new 'Pair',
       pair: @getPair(char)
       inner: false
@@ -482,7 +480,6 @@ class SurroundBase extends TransformString
 class Surround extends SurroundBase
   @extend()
   @description: "Surround target by specified character like `(`, `[`, `\"`"
-  displayName: "Surround ()"
   hover: icon: ':surround:', emoji: ':two_women_holding_hands:'
 
   subscribeForInput: ->
@@ -522,7 +519,7 @@ class DeleteSurround extends SurroundBase
       @focusInput()
 
   onConfirm: (@input) ->
-    @setTargetFromPairChar(@input)
+    @setTargetForPairChar(@input)
     @processOperation()
 
   getNewText: (text) ->
@@ -550,15 +547,15 @@ class ChangeSurround extends SurroundBase
       @onDidFailSelectTarget(@abort.bind(this))
     else
       @onDidFailSelectTarget(@cancelOperation.bind(this))
-      @focusInput()
+      @focusInput() # Read pair-char to determine target pair range.
 
     @onDidSelectTarget =>
       @showOldCharOnHover()
-      @focusInput()
+      @focusInput() # Read new pair-char.
 
   onConfirm: (input) ->
     if not @targetSelected
-      @setTargetFromPairChar(input)
+      @setTargetForPairChar(input)
     else
       @input = input
       @processOperation()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -472,8 +472,6 @@ class SurroundBase extends TransformString
     else
       innerText
 
-  setTargetForPairChar: (char) ->
-
   onConfirmSurround: (@input) ->
     @processOperation()
 
@@ -482,7 +480,6 @@ class SurroundBase extends TransformString
       pair: @getPair(char)
       inner: false
       allowNextLine: char in @pairCharsAllowForwarding
-    @setTargetForPairChar(char)
 
 class Surround extends SurroundBase
   @extend()
@@ -523,8 +520,8 @@ class DeleteSurround extends SurroundBase
       @focusInputForDeleteSurround()
 
   onConfirmDeleteSurround: (input) ->
-    @input = input
     super
+    @input = input
     @processOperation()
 
   getNewText: (text) ->

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -438,9 +438,7 @@ class Surround extends TransformString
 
     return unless @requireInput
     if @requireTarget
-      # @onDidSetTarget =>
       @onDidSelectTarget =>
-        console.log "SLECTED! now focusing input"
         @focusInput(@charsMax)
     else
       @focusInput(@charsMax)
@@ -453,7 +451,6 @@ class Surround extends TransformString
     @inputUI.focus(charsMax)
 
   onConfirm: (@input) ->
-    console.log 'confirmed input = ', @input
     @processOperation()
 
   getPair: (char) ->
@@ -545,25 +542,16 @@ class ChangeSurroundAnyPair extends ChangeSurround
   charsMax: 1
   target: "AAnyPair"
 
-  highlightRange: (range) ->
-    marker = @editor.markBufferRange(range)
-    @editor.decorateMarker(marker, type: 'highlight', class: 'vim-mode-plus-target-range')
-    marker
-
   initialize: ->
-    marker = null
-    @onDidSetTarget =>
-      if range = @target.getRange(@editor.getLastSelection())
-        marker = @highlightRange(range)
-        textRange = Range.fromPointWithDelta(marker.getBufferRange().start, 0, 1)
-        char = @editor.getTextInBufferRange(textRange)
-        @addHover(char, {}, @editor.getCursorBufferPosition())
-      else
-        @inputUI.cancel()
-        @abort()
+    @onDidSelectTarget =>
+      char = @editor.getSelectedText()[0]
+      point = @vimState.getOriginalCursorPosition()
+      @addHover(char, {}, point)
 
-    @onDidResetOperationStack ->
-      marker?.destroy()
+    @onDidFailSelectTarget =>
+      @inputUI.cancel()
+      @abort()
+
     super
 
   onConfirm: (@char) ->

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -25,8 +25,8 @@ class TransformString extends Operator
   @registerToSelectList: ->
     @stringTransformers.push(this)
 
-  mutateSelection: (selection, stopMutation) ->
-    if text = @getNewText(selection.getText(), selection, stopMutation)
+  mutateSelection: (selection) ->
+    if text = @getNewText(selection.getText(), selection)
       selection.insertText(text, {@autoIndent})
 
 class ToggleCase extends TransformString

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -193,13 +193,10 @@ class Operator extends Base
 
   # Main
   execute: ->
-    canMutate = true
-    stopMutation = -> canMutate = false
-
     @startMutation =>
       if @selectTarget()
-        for selection in @editor.getSelections() when canMutate
-          @mutateSelection(selection, stopMutation)
+        for selection in @editor.getSelections()
+          @mutateSelection(selection)
         @restoreCursorPositionsIfNecessary()
 
     # Even though we fail to select target and fail to mutate,
@@ -641,7 +638,7 @@ class AddBlankLineBelow extends Operator
   stayByMarker: true
   where: 'below'
 
-  mutateSelection: (selection, stopMutation) ->
+  mutateSelection: (selection) ->
     row = selection.getHeadBufferPosition().row
     row += 1 if @where is 'below'
     point = [row, 0]

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -51,6 +51,8 @@ class Operator extends Base
   # -------------------------
   supportEarlySelect: false
   targetSelected: null
+  canEarlySelect: ->
+    @supportEarlySelect and not @isRepeated()
   # -------------------------
 
   # Called when operation finished
@@ -203,7 +205,7 @@ class Operator extends Base
     @target.setOperator(this)
     @emitDidSetTarget(this)
 
-    if @supportEarlySelect
+    if @canEarlySelect()
       @normalizeSelectionsIfNecessary()
       @createBufferCheckpoint('undo')
       @selectTarget()
@@ -221,7 +223,7 @@ class Operator extends Base
       @vimState.modeManager.normalizeSelections()
 
   startMutation: (fn) ->
-    if @supportEarlySelect
+    if @canEarlySelect()
       # - Skip selection normalization: already normalized before @selectTarget()
       # - Manual checkpoint grouping: to create checkpoint before @selectTarget()
       fn()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -21,8 +21,12 @@ class SelectionWrapper
 
   setBufferRangeSafely: (range, options) ->
     if range
+      # FIXME REMOVE IT after investigation.
+      {preventAutoScrollToLastCursor} = options
+      delete options.preventAutoScrollToLastCursor
+
       @setBufferRange(range, options)
-      if @selection.isLastSelection()
+      if @selection.isLastSelection() and not preventAutoScrollToLastCursor
         @selection.cursor.autoscroll()
 
   getBufferRange: ->

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -118,7 +118,13 @@ class TextObject extends Base
       needToKeepColumn = @needToKeepColumn()
       if needToKeepColumn and not @isMode('visual', 'linewise')
         @vimState.modeManager.activate('visual', 'linewise')
-      swrap(selection).setBufferRangeSafely(range, keepGoalColumn: needToKeepColumn)
+
+      # Prevent autoscroll to closing char on `change-surround-any-pair`.
+      options = {
+        preventAutoScrollToLastCursor: @getOperator()?.supportEarlySelect
+        keepGoalColumn: needToKeepColumn
+      }
+      swrap(selection).setBufferRangeSafely(range, options)
 
       newRange = selection.getBufferRange()
       if newRange.isEqual(oldRange)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -366,6 +366,9 @@ class VimState
     @originalCursorPosition = point
     @originalCursorPositionByMarker = @editor.markBufferPosition(point, invalidate: 'never')
 
+  restoreOriginalCursorPosition: ->
+    @editor.setCursorBufferPosition(@getOriginalCursorPosition())
+
   getOriginalCursorPosition: ->
     @originalCursorPosition
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -152,6 +152,9 @@ class VimState
   onDidSelectTarget: (fn) -> @subscribe @emitter.on('did-select-target', fn)
   emitDidSelectTarget: -> @emitter.emit('did-select-target')
 
+  onDidFailSelectTarget: (fn) -> @subscribe @emitter.on('did-fail-select-target', fn)
+  emitDidFailSelectTarget: -> @emitter.emit('did-fail-select-target')
+
   onWillFinishMutation: (fn) -> @subscribe @emitter.on('on-will-finish-mutation', fn)
   emitWillFinishMutation: -> @emitter.emit('on-will-finish-mutation')
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -121,9 +121,10 @@ class VimState
   toggleClassList: (className, bool=undefined) ->
     @editorElement.classList.toggle(className, bool)
 
-  # FIXME: remove this dengerous approarch ASAP and revert to read-inpu-via-mini-editor
+  # FIXME: I want to remove this dengerious approach, but I couldn't find the better way.
   swapClassName: (classNames...) ->
     oldMode = @mode
+
     @editorElement.classList.remove(oldMode + "-mode")
     @editorElement.classList.remove('vim-mode-plus')
     @editorElement.classList.add(classNames...)


### PR DESCRIPTION
This is BIG tryout might fail. Will see.

## Issue

Some operator takes extra input from user AFTER select target.
For example, when user types `y s i w`(`y s` is mapped to surround in this example), it enter input-waiting state. But this is NOT obvious in UX perspective.

But theoretically when target was provided, operator can select target.
This gives user a important feedback.

## Benefit

User can understand the operator's target visually.
And no longer lost by "What I have to do next?" problem in some operation.
Greatly make it easier to learn complex but worth to learn operation like surround.
