### PR TITLE
Centering on maximize pane

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -119,14 +119,15 @@ module.exports =
     getView = (model) -> atom.views.getView(model)
     classPaneMaximized = 'vim-mode-plus--pane-maximized'
     classHideTabBar = 'vim-mode-plus--hide-tab-bar'
+    classHideStatusBar = 'vim-mode-plus--hide-status-bar'
     classActivePaneAxis = 'vim-mode-plus--active-pane-axis'
 
     workspaceElement = getView(atom.workspace)
     paneElement = getView(atom.workspace.getActivePane())
 
     workspaceClassNames = [classPaneMaximized]
-    if settings.get('hideTabBarOnMaximizePane')
-      workspaceClassNames.push(classHideTabBar)
+    workspaceClassNames.push(classHideTabBar) if settings.get('hideTabBarOnMaximizePane')
+    workspaceClassNames.push(classHideStatusBar) if settings.get('hideStatusBarOnMaximizePane')
 
     addClassList(workspaceElement, workspaceClassNames...)
 

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -155,7 +155,7 @@ class ReplaceModeBackspace extends MiscCommand
   @commandScope: 'atom-text-editor.vim-mode-plus.insert-mode.replace'
   @extend()
   execute: ->
-    @editor.getSelections().forEach (selection) =>
+    for selection in @editor.getSelections()
       # char might be empty.
       char = @vimState.modeManager.getReplacedCharForSelection(selection)
       if char?

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -140,6 +140,8 @@ module.exports = new Settings 'vim-mode-plus',
   hideTabBarOnMaximizePane:
     default: true
     description: "If set to `false`, tab still visible after maximize-pane( `cmd-enter` )"
+  hideStatusBarOnMaximizePane:
+    default: true
   smoothScrollOnFullScrollMotion:
     default: false
     description: "For `ctrl-f` and `ctrl-b`"

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -304,7 +304,7 @@ atom-workspace.vim-mode-plus--pane-maximized {
       }
     }
   }
-  atom-text-editor.vim-mode-plus {
+  atom-text-editor:not(.mini) {
     margin-left: 25%;
   }
   &.vim-mode-plus--hide-tab-bar {

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -282,13 +282,16 @@ atom-text-editor {
 
 // Maximize Pane
 // =========================
-.vim-mode-plus-maximize-pane() {
+atom-workspace.vim-mode-plus--pane-maximized {
   atom-pane-container {
     position: relative;
     atom-pane-axis:not(.vim-mode-plus--active-pane-axis) {
       display: none;
     }
     atom-pane {
+      .item-views {
+        background: @syntax-background-color !important;
+      }
       display: none;
       &.active {
         display: flex;
@@ -301,18 +304,18 @@ atom-text-editor {
       }
     }
   }
-}
-
-.hide-tab-bar() {
-  .tab-bar {
-    display: none;
+  atom-text-editor.vim-mode-plus {
+    margin-left: 25%;
   }
-}
-
-atom-workspace.vim-mode-plus--pane-maximized {
-  .vim-mode-plus-maximize-pane();
   &.vim-mode-plus--hide-tab-bar {
-    .hide-tab-bar()
+    .tab-bar {
+      display: none;
+    }
+  }
+  &.vim-mode-plus--hide-status-bar {
+    .status-bar {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
fix #632

- Set left margin to `25`% for text-editor when maximized.
  - This 25 % value is just chosen based on my UX preference, any better value?)
- Add `hideStatusBarOnMaximizePane` option default `true`

### NOTE

To set left-margin of `atom-text-editor`, I CAN NOT use `atom-text-editor.vim-mode-plus` scope.
Since `vim-mode-plus` className is removed when vmp trying to read user-input(e.g. `m`, `f`).
