### PR TITLE
add case-insensitive-sort command

### DIFF
--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -655,7 +655,7 @@ class Sort extends ChangeOrder
   getNewRows: (rows) ->
     rows.sort()
 
-class CaseInsensitiveSort extends ChangeOrder
+class SortCaseInsensitively extends ChangeOrder
   @extend()
   @registerToSelectList()
   @description: "Sort lines alphabetically (case insensitive)"

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -660,12 +660,11 @@ class CaseInsensitiveSort extends ChangeOrder
   @registerToSelectList()
   @description: "Sort lines alphabetically (case insensitive)"
   getNewRows: (rows) ->
-    mapped = rows.map (el, i) ->
-      {index: i, value: el.toLowerCase()}
-    mapped.sort (a, b) ->
-      +(a.value > b.value) or +(a.value is b.value) - 1
-    mapped.map (el) ->
-      rows[el.index]
+    rows.sort (a, b) ->
+      r = a.toLowerCase().localeCompare(b.toLowerCase())
+      if r is 0
+        r = a.localeCompare(b)
+      r
 
 class SortByNumber extends ChangeOrder
   @extend()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -655,6 +655,18 @@ class Sort extends ChangeOrder
   getNewRows: (rows) ->
     rows.sort()
 
+class CaseInsensitiveSort extends ChangeOrder
+  @extend()
+  @registerToSelectList()
+  @description: "Sort lines alphabetically (case insensitive)"
+  getNewRows: (rows) ->
+    mapped = rows.map (el, i) ->
+      {index: i, value: el.toLowerCase()}
+    mapped.sort (a, b) ->
+      +(a.value > b.value) or +(a.value is b.value) - 1
+    mapped.map (el) ->
+      rows[el.index]
+
 class SortByNumber extends ChangeOrder
   @extend()
   @registerToSelectList()


### PR DESCRIPTION
Adds a case-insensitive-sort command. This - along with the sort and reverse commands - means I can uninstall the Lines package. (I don't use unique or shuffle)