### PR TITLE
Make BracketFinder aware of inside/outside of double-quote

### DIFF
--- a/lib/pair-finder.coffee
+++ b/lib/pair-finder.coffee
@@ -102,10 +102,10 @@ class BracketFinder extends PairFinder
 
   filterEvent: ({range}) ->
     if @fromInDoubleQuotes
+      # Search from inside of double-quotes: Don't care char is in double-quotes.
       true
     else
-      # HACK: If search start is NOT in double quotes,
-      # Only pick char which is NOT in double-quotes.
+      # Search from outside of double-quotes: Ignore char inside of double-quotes.
       not @isInDoubleQuotes(range.start)
 
   getEventState: ({match, range}) ->

--- a/lib/pair-finder.coffee
+++ b/lib/pair-finder.coffee
@@ -91,10 +91,10 @@ class BracketFinder extends PairFinder
 
   isInDoubleQuotes: (point) ->
     {total, left, balanced} = @getCharacterRangeInformation('"', point)
-    if total.length is 0
+    if total.length is 0 or not balanced
       false
     else
-      balanced and left.length % 2 is 1
+      left.length % 2 is 1
 
   find: (from, options) ->
     @fromInDoubleQuotes = @isInDoubleQuotes(from)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -243,7 +243,7 @@ class Pair extends TextObject
     finder
 
   getPairInfo: (from) ->
-    finder = @getFinder(from)
+    finder = @getFinder()
     pairInfo = finder.find(from, {@allowForwarding})
     unless pairInfo?
       return null


### PR DESCRIPTION
Fix #556

## Behavior change

- When `BracketFinder` search from
  - **inside of double-quote**: Find char from all area(don't care found char is inside/outside of double-quote).
  - **outside of double-quote**: Find char only from outside of double-quote.

I noticed resulting behavior is still slightly different from pure-Vim.
I cannot say which is sensible behavior in corner case(e.g. quote is un-balanced in one-line and try to find bracket in double-quote)
From my impression, pure-Vim also seems to work deterministic way.
