### PR TITLE
bracket finding now retry with different syntax-scope area

### DIFF
--- a/lib/occurrence-manager.coffee
+++ b/lib/occurrence-manager.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 
 {
   shrinkRangeEndToBeforeNewLine
-  scanBufferRow
+  collectRangeInBufferRow
 } = require './utils'
 
 isInvalidMarker = (marker) -> not marker.isValid()
@@ -42,7 +42,7 @@ class OccurrenceManager
       subwordPattern = @editor.getLastCursor().subwordRegExp()
       isSubwordRange = (range) =>
         row = range.start.row
-        subwordRanges = subwordRangesByRow[row] ?= scanBufferRow(@editor, row, subwordPattern)
+        subwordRanges = subwordRangesByRow[row] ?= collectRangeInBufferRow(@editor, row, subwordPattern)
         subwordRanges.some (subwordRange) -> subwordRange.isEqual(range)
 
     @editor.scan pattern, ({range, matchText}) =>

--- a/lib/pair-finder.coffee
+++ b/lib/pair-finder.coffee
@@ -124,20 +124,21 @@ class PairFinder
       }
 
 class BracketFinder extends PairFinder
+  retry: false
+
   setPatternForPair: (pair) ->
     [open, close] = pair
     @pattern = ///(#{_.escapeRegExp(open)})|(#{_.escapeRegExp(close)})///g
 
+  # This method can be called recursively
   find: (from, options) ->
-    @retry ?= false
-    @initialScopeState = new ScopeState(@editor, from)
+    @initialScopeState ?= new ScopeState(@editor, from)
 
     return found if found = super
 
-    unless @retry
+    if not @retry
       @retry = true
-      @closeRange = null
-      @closeScopeState = null
+      [@closeRange, @closeScopeState] = []
       @find(from, options)
 
   filterEvent: ({range}) ->
@@ -146,10 +147,10 @@ class BracketFinder extends PairFinder
       @closeScopeState ?= new ScopeState(@editor, @closeRange.start)
       @closeScopeState.isEqual(scopeState)
     else
-      if @retry
-        not @initialScopeState.isEqual(scopeState)
-      else
+      if not @retry
         @initialScopeState.isEqual(scopeState)
+      else
+        not @initialScopeState.isEqual(scopeState)
 
   getEventState: ({match, range}) ->
     state = switch

--- a/lib/pair-finder.coffee
+++ b/lib/pair-finder.coffee
@@ -4,7 +4,7 @@ _ = require 'underscore-plus'
   isEscapedCharRange
   getEndOfLineForBufferRow
   scanBufferRow
-  getScanRange
+  scanEditorInDirection
 } = require './utils'
 
 isMatchScope = (pattern, scopes) ->
@@ -53,19 +53,13 @@ class PairFinder
     true
 
   findPair: (which, direction, from) ->
-    scanRange = getScanRange(@editor, direction, from, {@allowNextLine})
-    editorScanner = switch direction
-      when 'forward' then @editor.scanInBufferRange.bind(@editor)
-      when 'backward' then @editor.backwardsScanInBufferRange.bind(@editor)
-
     stack = []
     found = null
 
     # Quote is not nestable. So when we encounter 'open' while finding 'close',
     # it is forwarding pair, so stoppable is not @allowForwarding
     findingNonForwardingClosingQuote = (this instanceof QuoteFinder) and which is 'close' and not @allowForwarding
-
-    editorScanner @getPattern(), scanRange, (event) =>
+    scanEditorInDirection @editor, direction, @getPattern(), from, {@allowNextLine}, (event) =>
       {range, stop} = event
 
       return if isEscapedCharRange(@editor, range)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -234,17 +234,18 @@ class Pair extends TextObject
     new Range(start, end)
 
   getFinder: ->
+    options = {allowNextLine: @isAllowNextLine(), @allowForwarding}
     if @pair[0] is @pair[1]
-      finder = new QuoteFinder(@editor, allowNextLine: @isAllowNextLine())
+      finder = new QuoteFinder(@editor, options)
     else
-      finder = new BracketFinder(@editor, allowNextLine: @isAllowNextLine())
+      finder = new BracketFinder(@editor, options)
 
     finder.setPatternForPair(@pair)
     finder
 
   getPairInfo: (from) ->
     finder = @getFinder()
-    pairInfo = finder.find(from, {@allowForwarding})
+    pairInfo = finder.find(from)
     unless pairInfo?
       return null
     pairInfo.innerRange = @adjustRange(pairInfo.innerRange) if @adjustInnerRange
@@ -286,7 +287,10 @@ class AnyPair extends Pair
 
   getRanges: (selection) ->
     prefix = if @isInner() then 'Inner' else 'A'
-    (range for klass in @member when (range = @getRangeBy(prefix + klass, selection)))
+    ranges = []
+    for klass in @member when range = @getRangeBy(prefix + klass, selection)
+      ranges.push(range)
+    ranges
 
   getRange: (selection) ->
     ranges = @getRanges(selection)
@@ -451,7 +455,7 @@ class Tag extends Pair
     tagRange?.start ? from
 
   getFinder: ->
-    new TagFinder(@editor, allowNextLine: @isAllowNextLine())
+    new TagFinder(@editor, {allowNextLine: @isAllowNextLine(), @allowForwarding})
 
   getPairInfo: (from) ->
     super(@getTagStartPoint(from))

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -863,6 +863,18 @@ getScanRange = (editor, direction, from, {allowNextLine}={}) ->
       else
         new Range([from.row, 0], from)
 
+getEditorScanner = (editor, direction) ->
+  switch direction
+    when 'forward'
+      editor.scanInBufferRange.bind(editor)
+    when 'backward'
+      editor.backwardsScanInBufferRange.bind(editor)
+
+scanEditorInDirection = (editor, direction, pattern, from, options, fn) ->
+  scanRange = getScanRange(editor, direction, from, options)
+  scanner = getEditorScanner(editor, direction)
+  scanner(pattern, scanRange, fn)
+
 module.exports = {
   getParent
   getAncestors
@@ -974,4 +986,6 @@ module.exports = {
   getRightCharacterForBufferPosition
   getLeftCharacterForBufferPosition
   getScanRange
+  getEditorScanner
+  scanEditorInDirection
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -849,6 +849,20 @@ expandRangeToWhiteSpaces = (editor, range, directions=[]) ->
 
   return range # fallback
 
+getScanRange = (editor, direction, from, {allowNextLine}={}) ->
+  allowNextLine ?= true
+  switch direction
+    when 'forward'
+      if allowNextLine
+        new Range(from, editor.buffer.getEndPosition())
+      else
+        new Range(from, getEndOfLineForBufferRow(editor, from.row))
+    when 'backward'
+      if allowNextLine
+        new Range([0, 0], from)
+      else
+        new Range([from.row, 0], from)
+
 module.exports = {
   getParent
   getAncestors
@@ -959,4 +973,5 @@ module.exports = {
   expandRangeToWhiteSpaces
   getRightCharacterForBufferPosition
   getLeftCharacterForBufferPosition
+  getScanRange
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -618,7 +618,7 @@ scanEditor = (editor, pattern) ->
     ranges.push(range)
   ranges
 
-scanBufferRow = (editor, row, pattern) ->
+collectRangeInBufferRow = (editor, row, pattern) ->
   ranges = []
   scanRange = editor.bufferRangeForBufferRow(row)
   editor.scanInBufferRange pattern, scanRange, ({range}) ->
@@ -954,7 +954,7 @@ module.exports = {
   shrinkRangeEndToBeforeNewLine
   scanInRanges
   scanEditor
-  scanBufferRow
+  collectRangeInBufferRow
   findRangeInBufferRow
   isRangeContainsSomePoint
   destroyNonLastSelection

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -572,8 +572,7 @@ describe "TextObject", ->
           selectedText: """
           {"  '"' }
           """
-      xit "[search from outside of double-quote] skips bracket in within-line-balanced-double-quotes", ->
-        # FIXME to success this spec
+      it "[search from inside of double-quote] skips bracket in within-line-balanced-double-quotes", ->
         set
           textC: """
           {  "h|ello {" }


### PR DESCRIPTION
DONE:

I know this is still Not perfect. But will stop now to tackle this further.

## What was changed?

- `BracketFinder`( `PairFinder` of `{, }`, `(, )`, `[, ]`, `<, >`) now care about **syntax-scope** when finding pair char.
- Finding order is always:
  - First, find close char in forwarding direction.
  - Then, find open char in backward direction.
- Strategy
  - When we find **close** char: Try to find from same scope at cursor(when cursor is in comment, we search in comment scope)
  - When we find **open** char: Opening char must match scope with closing char's scope
    - So `}` in comment and `{` in normal code area never be matched
  - If we can't find matching pair range then `BracketFinder` **retry** to finding close and open in **different scope**
    - If cursor was at normalCodeArea(not in comment/string/inner-double-quote), then retry with non-normalCodeArea
    - If cursor was at non-normalCodeArea then retry with normalCodeArea

- I noticed some corner case the matching area still not intuitive.
- But this is never be perfect, and as long as I checked manually in different wired text, I can't find any regression introduced by this **smarter-behavior**.
- I know **smartness** vs intuitiveness(or explicitness) problem, smartness tend to break user's expectation.
- But for this addition, I feel it reduced chance to break user's expectation, so will merge it.
