### PR TITLE
more non-disturbing tab/shift mapping for move-to-occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.81.0: WIP
+- Improve, Breaking: Remove `fallbackTabAndShiftTabInNormalMode`
+  - This was necessary since `tab`, `shift-tab` was mapped to `move-to-next-occurrence` and `move-to-previous-occurrence`.
+  - When `true`, fallback `tab`, `shift-tab` to `editor:indent` or `editor:outdent-selected-rows` when no `occurrence-marker` exist.
+  - But now, these mapping is defined in `has-occurrence` scope, which means `occurrence-marker` exists on editor.
+  - So your `tab`, `shift-tab` is no longer conflict if no `occurrence-marker` exits.
+
 # 0.80.0:
 - Breaking: Disable `I`, `A` special keymap in `has-occurrence` scope.
   - To avoid surprising user. Now behave as normal `I` amnd `A`.
@@ -11,7 +18,7 @@
 
 - Fix: No longer throw exception when specified register has no value(=text) on `p`, `P` operation. #656.
 - Fix: Now selection peroperties cleared on each normal-mode operationFinsish to avoid hover counter is shown at incorrect position.
-- Developer: Spec helper `ensureMode` no longer mutate passed array itself. 
+- Developer: Spec helper `ensureMode` no longer mutate passed array itself.
 - Developer: `reload-packages` command now reload depending packages in correct order.
 
 # 0.79.1:

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -234,8 +234,6 @@
   '[': 'vim-mode-plus:move-up-to-edge'
   ']': 'vim-mode-plus:move-down-to-edge'
 
-  'tab': 'vim-mode-plus:move-to-next-occurrence'
-  'shift-tab': 'vim-mode-plus:move-to-previous-occurrence'
   # '[ [': 'vim-mode-plus:move-to-previous-fold-start'
   # '] [': 'vim-mode-plus:move-to-next-fold-start'
   # '[ ]': 'vim-mode-plus:move-to-previous-fold-end'
@@ -248,6 +246,10 @@
 
   # 'g n': 'vim-mode-plus:move-to-next-number'
   # 'g N': 'vim-mode-plus:move-to-previous-number'
+
+'atom-text-editor.vim-mode-plus.has-occurrence:not(.insert-mode)':
+  'tab': 'vim-mode-plus:move-to-next-occurrence'
+  'shift-tab': 'vim-mode-plus:move-to-previous-occurrence'
 
 'atom-text-editor.vim-mode-plus:not(.insert-mode):not(.operator-pending-mode)':
   'z enter': 'vim-mode-plus:scroll-cursor-to-top'

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -1069,20 +1069,10 @@ class MoveToNextNumber extends MoveToPreviousNumber
 
 class MoveToNextOccurrence extends Motion
   @extend()
+  # Ensure this command is available when has-occurrence
+  @commandScope: 'atom-text-editor.vim-mode-plus.has-occurrence'
   jump: true
   direction: 'next'
-
-  initialize: ->
-    if @vimState.occurrenceManager.hasMarkers()
-      super
-    else
-      if settings.get('fallbackTabAndShiftTabInNormalMode')
-        switch getKeystrokeForEvent(@vimState._event)
-          when 'tab'
-            atom.commands.dispatch(@editorElement, 'editor:indent')
-          when 'shift-tab'
-            atom.commands.dispatch(@editorElement, 'editor:outdent-selected-rows')
-      @abort()
 
   getRanges: ->
     @vimState.occurrenceManager.getMarkers().map (marker) ->

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -157,13 +157,6 @@ module.exports = new Settings 'vim-mode-plus',
   statusBarModeStringStyle:
     default: 'short'
     enum: ['short', 'long']
-  fallbackTabAndShiftTabInNormalMode:
-    default: true
-    description: """
-    tab, shift-tab is mapped to move-to-next-occurrence, move-to-previous-occurrence in normal-mode.<br>
-    Setting true fallbacks to original behavior `editor:indent`, `editor:outdent-selected-rows`, if
-     no occurrence-marker was set on that editor.
-    """
   throwErrorOnNonEmptySelectionInNormalMode:
     default: false
     description: "[Dev use] Throw error when non-empty selection was remained in normal-mode at the timing of operation finished"


### PR DESCRIPTION
Refs #597

I found better way to solve original issue.
This is better since, vmp's `tab`, `shift` keymap is narrowed, less chance to conflict other packages which also want to map `tab`, `shift-tab`.

Don't eat keymap scope for the scope which I do just delegating that dispatch.

/cc @averrin 