### PR TITLE
Add width and tweak margin to center maximize-pane mode

### DIFF
--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -313,7 +313,8 @@ atom-workspace.vim-mode-plus--pane-maximized {
     }
   }
   atom-text-editor:not(.mini) {
-    margin-left: 20%;
+    margin-left: 25%;
+    width: 50%;
   }
   &.vim-mode-plus--hide-tab-bar {
     .tab-bar {


### PR DESCRIPTION
Explicitly declare a width value for `atom-text-editor:not(.mini)` (in this case `50%`) and tweak `margin-left` to `25%` to center maximize-pane mode. See the example below:
![screen shot 2017-02-14 at 3 38 35 pm](https://cloud.githubusercontent.com/assets/278293/22919785/bac6bf30-f2cc-11e6-8214-3bed93f4ac4d.png)

Caveat: `atom-text-editor`'s useable space is limited to 50% only, which could present a problem if your editor window is too narrow.
![screen shot 2017-02-14 at 3 43 49 pm](https://cloud.githubusercontent.com/assets/278293/22919740/6cf67020-f2cc-11e6-8f78-8049cc9c3cb3.png)