### PR TITLE
internally always keep column of selection in linewise

### DIFF
--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -53,6 +53,9 @@ class ModeManager
       when 'insert' then @activateInsertMode(newSubmode)
       when 'visual' then @activateVisualMode(newSubmode)
 
+    unless newMode is 'visual'
+      swrap.clearProperties(@editor)
+
     @editorElement.classList.remove("#{@mode}-mode")
     @editorElement.classList.remove(@submode)
 

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -171,12 +171,12 @@ class OperationStack
       operation.resetState()
 
     if @mode is 'normal'
-      swrap.clearProperties(@editor)
       @ensureAllSelectionsAreEmpty(operation)
       @ensureAllCursorsAreNotAtEndOfLine()
     else if @mode is 'visual'
       @modeManager.updateNarrowedState()
       @vimState.updatePreviousSelection()
+
     @vimState.updateCursorsVisibility()
     @vimState.reset()
 
@@ -195,7 +195,7 @@ class OperationStack
 
   ensureAllCursorsAreNotAtEndOfLine: ->
     for cursor in @editor.getCursors() when cursor.isAtEndOfLine()
-      moveCursorLeft(cursor, {preserveGoalColumn: true})
+      moveCursorLeft(cursor, preserveGoalColumn: true)
 
   addToClassList: (className) ->
     @editorElement.classList.add(className)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -331,6 +331,7 @@ class Select extends Operator
               swrap.saveProperties(@editor)
             swrap.fixPropertiesForLinewise(@editor)
 
+      @editor.scrollToCursorPosition()
       @activateModeIfNecessary('visual', wise)
 
 class SelectLatestChange extends Select

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -327,7 +327,10 @@ class Select extends Operator
           when 'characterwise'
             swrap.saveProperties(@editor)
           when 'linewise'
+            unless @getConfig('keepColumnOnSelectTextObject')
+              swrap.saveProperties(@editor)
             swrap.fixPropertiesForLinewise(@editor)
+
       @activateModeIfNecessary('visual', wise)
 
 class SelectLatestChange extends Select

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -149,7 +149,7 @@ class SelectionWrapper
     switch wise
       when 'characterwise'
         @translateSelectionEndAndClip('forward')
-        @saveProperties()
+        @saveProperties() unless @hasProperties()
       when 'linewise'
         @complementGoalColumn()
         @saveProperties() unless @hasProperties()
@@ -235,7 +235,6 @@ class SelectionWrapper
         @translateSelectionEndAndClip('backward', translate: false)
       else
         @translateSelectionEndAndClip('backward')
-    @clearProperties()
 
 swrap = (selection) ->
   new SelectionWrapper(selection)
@@ -258,6 +257,15 @@ swrap.saveProperties = (editor) ->
 swrap.clearProperties = (editor) ->
   for selection in editor.getSelections()
     swrap(selection).clearProperties()
+
+swrap.hasProperties = (editor) ->
+  editor.getSelections().every (selection) ->
+    swrap(selection).hasProperties()
+
+{inspect} = require 'util'
+swrap.dumpProperties = (editor) ->
+  for selection in editor.getSelections() when swrap(selection).hasProperties()
+    console.log inspect(swrap(selection).getProperties())
 
 swrap.normalize = (editor) ->
   for selection in editor.getSelections()

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -662,6 +662,7 @@ class PreviousSelection extends TextObject
 class PersistentSelection extends TextObject
   @extend(false)
   wise: null
+  selectOnce: true
 
   selectTextObject: (selection) ->
     if @vimState.hasPersistentSelections()

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -83,9 +83,7 @@ class TextObject extends Base
   # Return true or false
   selectTextObject: (selection) ->
     if range = @getRange(selection)
-      # Prevent autoscroll to closing char on `change-surround-any-pair`.
-      autoscroll = selection.isLastSelection() and not @operator.supportEarlySelect
-      swrap(selection).setBufferRange(range, {autoscroll})
+      swrap(selection).setBufferRange(range)
       return true
 
   # to override
@@ -628,7 +626,6 @@ class SearchMatchForward extends TextObject
   selectTextObject: (selection) ->
     if range = @getRange(selection)
       swrap(selection).setBufferRange(range, {reversed: @reversed ? @backward})
-      selection.cursor.autoscroll()
       return true
 class SearchMatchBackward extends SearchMatchForward
   @extend()

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -57,9 +57,6 @@ class TextObject extends Base
     bufferPosition = @getNormalizedHeadBufferPosition(selection)
     @editor.screenPositionForBufferPosition(bufferPosition)
 
-  needToKeepColumn: ->
-    @isLinewise() and @getConfig('keepColumnOnSelectTextObject') and @operator.instanceof('Select')
-
   resetState: ->
     @selectSucceeded = null
 
@@ -92,16 +89,9 @@ class TextObject extends Base
   # Return true or false
   selectTextObject: (selection) ->
     if range = @getRange(selection)
-      needToKeepColumn = @needToKeepColumn()
-      if needToKeepColumn and not @isMode('visual', 'linewise')
-        @vimState.modeManager.activate('visual', 'linewise')
-
       # Prevent autoscroll to closing char on `change-surround-any-pair`.
-      options = {
-        autoscroll: selection.isLastSelection() and not @operator.supportEarlySelect
-        keepGoalColumn: needToKeepColumn
-      }
-      swrap(selection).setBufferRange(range, options)
+      autoscroll = selection.isLastSelection() and not @operator.supportEarlySelect
+      swrap(selection).setBufferRange(range, {autoscroll})
 
       return true
     else

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -2,8 +2,6 @@
 _ = require 'underscore-plus'
 
 # [TODO] Need overhaul
-#  - [ ] must have getRange(selection) ->
-#  - [ ] Remove selectTextObject?
 #  - [ ] Make expandable by selection.getBufferRange().union(@getRange(selection))
 #  - [ ] Count support(priority low)?
 Base = require './base'

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -123,7 +123,6 @@ class ASmartWord extends SmartWord
   @description: "A word that consists of alphanumeric chars(`/[A-Za-z0-9_]/`) and hyphen `-`"
   @extend()
 class InnerSmartWord extends SmartWord
-  @description: "Currently No diff from `a-smart-word`"
   @extend()
 
 # Just include _, -

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -86,10 +86,7 @@ class TextObject extends Base
       # Prevent autoscroll to closing char on `change-surround-any-pair`.
       autoscroll = selection.isLastSelection() and not @operator.supportEarlySelect
       swrap(selection).setBufferRange(range, {autoscroll})
-
       return true
-    else
-      return false
 
   # to override
   getRange: ->
@@ -632,9 +629,7 @@ class SearchMatchForward extends TextObject
     if range = @getRange(selection)
       swrap(selection).setBufferRange(range, {reversed: @reversed ? @backward})
       selection.cursor.autoscroll()
-      true
-    else
-      false
+      return true
 class SearchMatchBackward extends SearchMatchForward
   @extend()
   backward: true
@@ -654,25 +649,24 @@ class SearchMatchBackward extends SearchMatchForward
 class PreviousSelection extends TextObject
   @extend()
   wise: null
+  selectOnce: true
 
-  select: ->
+  selectTextObject: (selection) ->
     {properties, submode} = @vimState.previousSelection
     if properties? and submode?
-      @selectSucceeded = true
       @wise = submode
       selection = @editor.getLastSelection()
       swrap(selection).selectByProperties(properties, keepGoalColumn: false)
+      return true
 
 class PersistentSelection extends TextObject
   @extend(false)
   wise: null
 
-  select: ->
-    {persistentSelection} = @vimState
-    unless persistentSelection.isEmpty()
-      persistentSelection.setSelectedBufferRanges()
-      @selectSucceeded = true
-      @wise = swrap.detectWise(@editor)
+  selectTextObject: (selection) ->
+    if @vimState.hasPersistentSelections()
+      @vimState.persistentSelection.setSelectedBufferRanges()
+      return true
 class APersistentSelection extends PersistentSelection
   @extend()
 class InnerPersistentSelection extends PersistentSelection

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -45,11 +45,11 @@ class TextObject extends Base
     @wise is 'blockwise'
 
   getNormalizedHeadBufferPosition: (selection) ->
-    head = selection.getHeadBufferPosition()
+    point = selection.getHeadBufferPosition()
     if @isMode('visual') and not selection.isReversed()
-      translatePointAndClip(@editor, head, 'backward')
+      translatePointAndClip(@editor, point, 'backward')
     else
-      head
+      point
 
   resetState: ->
     @selectSucceeded = null

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -51,10 +51,6 @@ class TextObject extends Base
     else
       head
 
-  getNormalizedHeadScreenPosition: (selection) ->
-    bufferPosition = @getNormalizedHeadBufferPosition(selection)
-    @editor.screenPositionForBufferPosition(bufferPosition)
-
   resetState: ->
     @selectSucceeded = null
 


### PR DESCRIPTION
- [mode manager] clear prop at mode activation and new mode wasn’t
visual
- [swrap] no longer clear prop in normalize
- [swrap] don’t overwrite existing prop in normalize

- Now internally text object column is preserved, so
  - when `keepColumnOnSelectTextObject` is `true`, no extra work is necessary.
  - when `keepColumnOnSelectTextObject` is `false`, explicitly update prop with new linewise selection range
