### PR TITLE
[tryout] Overhaul visual-mode selection fundamental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # 0.85.0: WIP
+- Improve: In `visual` mode, can select new-line
+- Improve: Now can select line-ending new line char in `visual-mode`.
+  - E.g. Move right by `l` at end of line select new-line.
 - Fix: Respect `v` operator-modifier for `t`( Till ) motion.
   - e.g. In text "ab" whre cursor is at "a"
     - Old: `d t b` delete "a"( Good ), `d v t b` delete "a"( Bad ).
     - New: `d t b` delete "a"( Good ), `d v t b` don't delete "a"( Good ).
 - Improve: When `keepColumnOnSelectTextObject` is `true`, `v i p` respect `goalColumn` of cursor.
   - This improve appears when you type `$ v i p`.
+- Fix: #699 Lost goalColumn in `visual.blockwise` when move across blank-row.
+  - This is regression in v0.84.0.
+- Fix: #119 When `j`, `k` is used as operator's target, don't apply operation when failed to move.
+  - Now more compatible with pure Vim.
+  - Example:
+    - `d j` from last line do nothing. ( In previous version, delete last line ).
+    - `d k` from first line do nothing. ( In previous version, delete first line ).
 
 # 0.84.1:
 - Fix: To fix vim-mode-plus-move-selected-text degradation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.85.0: WIP
+- Improve: When `keepColumnOnSelectTextObject` is `true`, `v i p` respect `goalColumn` of cursor.
+  - This improve appears when you type `$ v i p`.
+
 # 0.84.1:
 - Fix: To fix vim-mode-plus-move-selected-text degradation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 0.85.0: WIP
+- Fix: Respect `v` operator-modifier for `t`( Till ) motion.
+  - e.g. In text "ab" whre cursor is at "a"
+    - Old: `d t b` delete "a"( Good ), `d v t b` delete "a"( Bad ).
+    - New: `d t b` delete "a"( Good ), `d v t b` don't delete "a"( Good ).
 - Improve: When `keepColumnOnSelectTextObject` is `true`, `v i p` respect `goalColumn` of cursor.
   - This improve appears when you type `$ v i p`.
 

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -65,6 +65,7 @@ vimStateMethods = [
 class Base
   Delegato.includeInto(this)
   @delegatesMethods(vimStateMethods..., toProperty: 'vimState')
+  @delegatesProperty('mode', 'submode', toProperty: 'vimState')
 
   constructor: (@vimState, properties=null) ->
     {@editor, @editorElement, @globalState} = @vimState
@@ -240,19 +241,19 @@ class Base
     @constructor.name
 
   getCursorBufferPosition: ->
-    if @isMode('visual')
+    if @mode is 'visual'
       @getCursorPositionForSelection(@editor.getLastSelection())
     else
       @editor.getCursorBufferPosition()
 
   getCursorBufferPositions: ->
-    if @isMode('visual')
+    if @mode is 'visual'
       @editor.getSelections().map(@getCursorPositionForSelection.bind(this))
     else
       @editor.getCursorBufferPositions()
 
   getBufferPositionForCursor: (cursor) ->
-    if @isMode('visual')
+    if @mode is 'visual'
       @getCursorPositionForSelection(cursor.selection)
     else
       cursor.getBufferPosition()

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -181,7 +181,7 @@ class BlockwiseSelection
     @clearSelections(except: head)
     {goalColumn} = head.cursor # FIXME this should not be necessary
     swrap(head).selectByProperties(properties)
-    if head.getBufferRange().end.column is 0
+    if head.getBufferRange().end.column is 0 # FIXME this should be done by restoring selection prop
       swrap(head).translateSelectionEndAndClip('forward')
     head.cursor.goalColumn ?= goalColumn if goalColumn # FIXME this should not be necessary
 

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -11,10 +11,13 @@ class BlockwiseSelection
 
   constructor: (selection) ->
     {@editor} = selection
+    swrap(selection).saveProperties() # TODO#698  remove this?
+    swrap(selection).applyWise('characterwise') # NOTE#698 added this line
+    
     @initialize(selection)
 
     for memberSelection in @getSelections()
-      swrap(memberSelection).saveProperties()
+      swrap(memberSelection).saveProperties() # TODO#698  remove this?
       swrap(memberSelection).setWiseProperty('blockwise')
 
   getSelections: ->

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -179,9 +179,11 @@ class BlockwiseSelection
     properties = @getCharacterwiseProperties()
     head = @getHeadSelection()
     @clearSelections(except: head)
+    {goalColumn} = head.cursor # FIXME this should not be necessary
     swrap(head).selectByProperties(properties)
     if head.getBufferRange().end.column is 0
       swrap(head).translateSelectionEndAndClip('forward')
+    head.cursor.goalColumn ?= goalColumn if goalColumn # FIXME this should not be necessary
 
   autoscroll: (options) ->
     @getHeadSelection().autoscroll(options)

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -13,7 +13,7 @@ class BlockwiseSelection
     {@editor} = selection
     swrap(selection).saveProperties() # TODO#698  remove this?
     swrap(selection).applyWise('characterwise') # NOTE#698 added this line
-    
+
     @initialize(selection)
 
     for memberSelection in @getSelections()

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -11,7 +11,6 @@ class BlockwiseSelection
 
   constructor: (selection) ->
     {@editor} = selection
-    swrap(selection).saveProperties() # TODO#698  remove this?
     swrap(selection).applyWise('characterwise') # NOTE#698 added this line
 
     @initialize(selection)

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -185,6 +185,7 @@ class BlockwiseSelection
     swrap(head).selectByProperties(properties)
     if head.getBufferRange().end.column is 0 # FIXME this should be done by restoring selection prop
       swrap(head).translateSelectionEndAndClip('forward')
+    swrap(head).saveProperties()
     head.cursor.goalColumn ?= goalColumn if goalColumn # FIXME this should not be necessary
 
   autoscroll: (options) ->

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -37,14 +37,11 @@ class CursorStyleManager
     for cursor in @editor.getCursors()
       cursor.setVisible(cursor in cursorsToShow)
 
-    # [NOTE] In BlockwiseSelect we add selections(and corresponding cursors) in bluk.
-    # But corresponding cursorsComponent(HTML element) is added in sync.
-    # So to modify style of cursorsComponent, we have to make sure corresponding cursorsComponent
-    # is available by component in sync to model.
-    # [FIXME]
-    # When ctrl-f, b, d, u in vL mode, I had to call updateSync to show cursor correctly
-    # But it wasn't necessary before I iintroduce `moveToFirstCharacterOnVerticalMotion` for `ctrl-f`
-    @editorElement.component.updateSync()
+    # [NOTE] When activating visual-blockwise-mode multiple slections are added in bulk.
+    # But corresponding cursorsComponent(HTML element) is added asynchronously.
+    # We need to make sure that corresponding cursor's domNode is available to modify it's style.
+    if @submode is 'blockwise'
+      @editorElement.component.updateSync()
 
     # [NOTE] Using non-public API
     cursorNodesById = @editorElement.component.linesComponent.cursorsComponent.cursorNodesById

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -17,15 +17,15 @@ getOffset = (submode, cursor) ->
     when 'characterwise'
       return if selection.isReversed()
       bufferPoint = swrap(selection).getBufferPositionFor('head', from: ['property'])
-      # console.log bufferPoint
       offset = bufferPoint.traversalFrom(cursor.getBufferPosition())
-      # console.log 'ofst', offset.toString()
       return offset
 
+      # TODO-#698 Enabled this again when performance is important.
       # if cursor.isAtBeginningOfLine()
       #   new Point(-1, 0)
       # else
       #   new Point(0, -1)
+
 
     when 'blockwise'
       return if cursor.isAtBeginningOfLine() or selection.isReversed()

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -24,6 +24,7 @@ class CursorStyleManager
     # Intentionally skip in spec mode, since not all spec have DOM attached( and don't want to ).
     return if atom.inSpecMode()
 
+    # We must dispose previous style modification for non-visual-mode
     @styleDisposables?.dispose()
     return unless (@mode is 'visual' and @vimState.getConfig('showCursorInVisualMode'))
 

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -1,81 +1,42 @@
 {Point, Disposable, CompositeDisposable} = require 'atom'
-
+Delegato = require 'delegato'
 swrap = require './selection-wrapper'
-isSpecMode = atom.inSpecMode()
-lineHeight = null
 
-getCursorNode = (editorElement, cursor) ->
-  cursorsComponent = editorElement.component.linesComponent.cursorsComponent
-  cursorsComponent.cursorNodesById[cursor.id]
-
-# Return cursor style offset(top, left)
-# ---------------------------------------
-getOffset = (submode, cursor) ->
-  {selection} = cursor
-  switch submode
-    when 'characterwise'
-      # TODO-#698 Enabled this again when performance is important.
-      # return if selection.isReversed()
-
-      swrap(selection).getCursorTraversalFromPropertyInBufferPosition()
-
-      # TODO-#698 Enabled this again when performance is important.
-      # if cursor.isAtBeginningOfLine()
-      #   new Point(-1, 0)
-      # else
-      #   new Point(0, -1)
-
-    when 'linewise'
-      if selection.editor.isSoftWrapped()
-        swrap(selection).getCursorTraversalFromPropertyInScreenPosition(true)
-      else
-        swrap(selection).getCursorTraversalFromPropertyInBufferPosition(true)
-
-    when 'blockwise'
-      return if cursor.isAtBeginningOfLine() or selection.isReversed()
-      new Point(0, -1)
-
-
-setStyle = (style, {row, column}) ->
-  style.setProperty('top', "#{row * lineHeight}em") unless row is 0
-  style.setProperty('left', "#{column}ch") unless column is 0
-  new Disposable ->
-    style.removeProperty('top')
-    style.removeProperty('left')
-
-# Display cursor in visual mode.
+# Display cursor in visual-mode
 # ----------------------------------
 class CursorStyleManager
+  lineHeight: null
+
+  Delegato.includeInto(this)
+  @delegatesProperty('mode', 'submode', toProperty: 'vimState')
+
   constructor: (@vimState) ->
     {@editorElement, @editor} = @vimState
-    @lineHeightObserver = atom.config.observe 'editor.lineHeight', (newValue) =>
-      lineHeight = newValue
+    @disposable = atom.config.observe 'editor.lineHeight', (newValue) =>
+      @lineHeight = newValue
       @refresh()
 
   destroy: ->
-    @styleDisporser?.dispose()
-    @lineHeightObserver.dispose()
-    {@styleDisporser, @lineHeightObserver} = {}
+    @styleDisposables?.dispose()
+    @disposable.dispose()
 
   refresh: ->
-    {mode, submode} = @vimState
-    @styleDisporser?.dispose()
-    @styleDisporser = new CompositeDisposable
-    return unless mode is 'visual' and @vimState.getConfig('showCursorInVisualMode')
+    # Intentionally skip in spec mode, since not all spec have DOM attached( and don't want to ).
+    return if atom.inSpecMode()
 
+    @styleDisposables?.dispose()
+    return unless (@mode is 'visual' and @vimState.getConfig('showCursorInVisualMode'))
+
+    @styleDisposables = new CompositeDisposable
     cursors = cursorsToShow = @editor.getCursors()
-    if submode is 'blockwise'
+    if @submode is 'blockwise'
       cursorsToShow = @vimState.getBlockwiseSelections().map (bs) -> bs.getHeadSelection().cursor
 
-    # update visibility
     for cursor in cursors
       if cursor in cursorsToShow
         cursor.setVisible(true) unless cursor.isVisible()
       else
         cursor.setVisible(false) if cursor.isVisible()
-
-    # [FIXME] In spec mode, we skip here since not all spec have dom attached.
-    return if isSpecMode
 
     # [NOTE] In BlockwiseSelect we add selections(and corresponding cursors) in bluk.
     # But corresponding cursorsComponent(HTML element) is added in sync.
@@ -86,8 +47,46 @@ class CursorStyleManager
     # But it wasn't necessary before I iintroduce `moveToFirstCharacterOnVerticalMotion` for `ctrl-f`
     @editorElement.component.updateSync()
 
-    for cursor in cursorsToShow when offset = getOffset(submode, cursor)
-      if cursorNode = getCursorNode(@editorElement, cursor)
-        @styleDisporser.add setStyle(cursorNode.style, offset)
+    for cursor in cursorsToShow when @needModifyStyle(cursor.selection) and domNode = @getCursorNode(cursor)
+      @styleDisposables.add(@modifyStyle(cursor, domNode))
+
+  needModifyStyle: (selection) ->
+    switch @submode
+      when 'characterwise'
+        not selection.isReversed()
+      when 'linewise'
+        true
+      when 'blockwise'
+        not (selection.isReversed() or selection.cursor.isAtBeginningOfLine())
+
+  getCursorNode: (cursor) ->
+    @editorElement.component.linesComponent.cursorsComponent.cursorNodesById[cursor.id]
+
+  # Apply selection property's traversal from actual cursor to cursorNode's style
+  modifyStyle: (cursor, domNode) ->
+    selection = cursor.selection
+    {row, column} = switch @submode
+      when 'characterwise'
+        swrap(selection).getCursorTraversalFromPropertyInBufferPosition()
+        # TODO-#698 Enabled this again when performance is important.
+        # if cursor.isAtBeginningOfLine()
+        #   new Point(-1, 0)
+        # else
+        #   new Point(0, -1)
+      when 'linewise'
+        if selection.editor.isSoftWrapped()
+          swrap(selection).getCursorTraversalFromPropertyInScreenPosition(true)
+        else
+          swrap(selection).getCursorTraversalFromPropertyInBufferPosition(true)
+      when 'blockwise'
+        new Point(0, -1)
+
+    style = domNode.style
+
+    style.setProperty('top', "#{row * @lineHeight}em") if row
+    style.setProperty('left', "#{column}ch") if column
+    new Disposable ->
+      style.removeProperty('top')
+      style.removeProperty('left')
 
 module.exports = CursorStyleManager

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -28,15 +28,14 @@ class CursorStyleManager
     return unless (@mode is 'visual' and @vimState.getConfig('showCursorInVisualMode'))
 
     @styleDisposables = new CompositeDisposable
-    cursors = cursorsToShow = @editor.getCursors()
     if @submode is 'blockwise'
       cursorsToShow = @vimState.getBlockwiseSelections().map (bs) -> bs.getHeadSelection().cursor
+    else
+      cursorsToShow = @editor.getCursors()
 
-    for cursor in cursors
-      if cursor in cursorsToShow
-        cursor.setVisible(true) unless cursor.isVisible()
-      else
-        cursor.setVisible(false) if cursor.isVisible()
+    # In blockwise, show only blockwise-head cursor
+    for cursor in @editor.getCursors()
+      cursor.setVisible(cursor in cursorsToShow)
 
     # [NOTE] In BlockwiseSelect we add selections(and corresponding cursors) in bluk.
     # But corresponding cursorsComponent(HTML element) is added in sync.

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -16,10 +16,16 @@ getOffset = (submode, cursor) ->
   switch submode
     when 'characterwise'
       return if selection.isReversed()
-      if cursor.isAtBeginningOfLine()
-        new Point(-1, 0)
-      else
-        new Point(0, -1)
+      bufferPoint = swrap(selection).getBufferPositionFor('head', from: ['property'])
+      # console.log bufferPoint
+      offset = bufferPoint.traversalFrom(cursor.getBufferPosition())
+      # console.log 'ofst', offset.toString()
+      return offset
+
+      # if cursor.isAtBeginningOfLine()
+      #   new Point(-1, 0)
+      # else
+      #   new Point(0, -1)
 
     when 'blockwise'
       return if cursor.isAtBeginningOfLine() or selection.isReversed()

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -1,6 +1,7 @@
 {Point, Disposable, CompositeDisposable} = require 'atom'
 
 swrap = require './selection-wrapper'
+{pointIsAtEndOfLineAtNonEmptyRow} = require './utils'
 isSpecMode = atom.inSpecMode()
 lineHeight = null
 
@@ -25,16 +26,18 @@ getOffset = (submode, cursor) ->
       new Point(0, -1)
 
     when 'linewise'
-      bufferPoint = swrap(selection).getBufferPositionFor('head', from: ['property'])
       editor = cursor.editor
+      column = swrap(selection).getBufferPositionFor('head', from: ['property']).column
+      row = swrap(selection).getRowFor('head')
+      bufferPoint = editor.clipBufferPosition([row, column])
+      if pointIsAtEndOfLineAtNonEmptyRow(editor, bufferPoint)
+        bufferPoint.column -= 1
 
       if editor.isSoftWrapped()
         screenPoint = editor.screenPositionForBufferPosition(bufferPoint)
         offset = screenPoint.traversalFrom(cursor.getScreenPosition())
       else
         offset = bufferPoint.traversalFrom(cursor.getBufferPosition())
-      if not selection.isReversed() and cursor.isAtBeginningOfLine()
-        offset.row = -1
       offset
 
 setStyle = (style, {row, column}) ->

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -89,6 +89,12 @@ class ModeManager
     @vimState.reset()
     # Component is not necessary avaiable see #98.
     @editorElement.component?.setInputEnabled(false)
+
+    # In visual-mode, cursor can place at EOL. move left if cursor is at EOL
+    # We should not do this in visual-mode deactivation phase.
+    # e.g. `A` directly shift from visua-mode to `insert-mode`, and cursor should remain at EOL.
+    for cursor in @editor.getCursors() when cursor.isAtEndOfLine()
+      moveCursorLeft(cursor, preserveGoalColumn: true)
     new Disposable
 
   # Operator Pending

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -179,11 +179,9 @@ class ModeManager
       for bs in @vimState.getBlockwiseSelections()
         bs.restoreCharacterwise() # TODO-#698 in this state, selection is multiple-selection in vC-wise
       @vimState.clearBlockwiseSelections()
-      for selection in @editor.getSelections()
-        swrap(selection).saveProperties()
+      swrap.saveProperties(@editor)
 
-    for selection in @editor.getSelections() when not selection.isEmpty()
-      swrap(selection).normalize()
+    swrap.normalize(@editor)
 
   # Narrow to selection
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -174,7 +174,6 @@ class ModeManager
       for bs in @vimState.getBlockwiseSelections()
         bs.restoreCharacterwise() # NOTE#698 in this state, selection is multiple-selection in vC-wise
       @vimState.clearBlockwiseSelections()
-      swrap.saveProperties(@editor)
 
     swrap.normalize(@editor)
 

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -19,11 +19,8 @@ class ModeManager
   destroy: ->
     @subscriptions.dispose()
 
-  isMode: (mode, submodes) ->
-    if submodes?
-      (@mode is mode) and (@submode in [].concat(submodes))
-    else
-      @mode is mode
+  isMode: (mode, submode=null) ->
+    (mode is @mode) and (submode is @submode)
 
   # Event
   # -------------------------

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -154,8 +154,8 @@ class ModeManager
   #   which is the range in visual-mode.
   activateVisualMode: (newSubmode) ->
     @vimState.assertWithException(newSubmode?, "activate visual-mode without submode")
-    for selection in @editor.getSelections() when swrapped = swrap(selection)
-      swrapped.saveProperties() unless swrapped.hasProperties()
+    for selection in @editor.getSelections() when $selection = swrap(selection)
+      $selection.saveProperties() unless $selection.hasProperties()
 
     @normalizeSelections()
 

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -155,11 +155,19 @@ class ModeManager
       swrapped.saveProperties() unless swrapped.hasProperties()
 
     @normalizeSelections()
+
     if newSubmode is 'blockwise'
       swrap.applyWise(@editor, 'characterwise')
       @vimState.selectBlockwise()
     else
       swrap.applyWise(@editor, newSubmode)
+
+    # OLD one
+    #   swrap.applyWise(@editor, 'characterwise')
+    #   if newSubmode is 'blockwise'
+    #     @vimState.selectBlockwise()
+    #   else if newSubmode is 'linewise'
+    #     swrap.applyWise(@editor, newSubmode)
 
     new Disposable =>
       @normalizeSelections()

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -168,13 +168,6 @@ class ModeManager
     else
       swrap.applyWise(@editor, newSubmode)
 
-    # OLD one
-    #   swrap.applyWise(@editor, 'characterwise')
-    #   if newSubmode is 'blockwise'
-    #     @vimState.selectBlockwise()
-    #   else if newSubmode is 'linewise'
-    #     swrap.applyWise(@editor, newSubmode)
-
     new Disposable =>
       @normalizeSelections()
       selection.clear(autoscroll: false) for selection in @editor.getSelections()

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -163,7 +163,6 @@ class ModeManager
     @normalizeSelections()
 
     if newSubmode is 'blockwise'
-      swrap.applyWise(@editor, 'characterwise')
       @vimState.selectBlockwise()
     else
       swrap.applyWise(@editor, newSubmode)
@@ -176,7 +175,7 @@ class ModeManager
   normalizeSelections: ->
     if @submode is 'blockwise'
       for bs in @vimState.getBlockwiseSelections()
-        bs.restoreCharacterwise() # TODO-#698 in this state, selection is multiple-selection in vC-wise
+        bs.restoreCharacterwise() # NOTE#698 in this state, selection is multiple-selection in vC-wise
       @vimState.clearBlockwiseSelections()
       swrap.saveProperties(@editor)
 

--- a/lib/motion-search.coffee
+++ b/lib/motion-search.coffee
@@ -154,7 +154,7 @@ class Search extends SearchBase
         searchByProjectFind(@editor, input)
 
   handleCancelSearch: ->
-    @vimState.resetNormalMode() unless @isMode('visual') or @isMode('insert')
+    @vimState.resetNormalMode() unless @mode in ['visual', 'insert']
     @restoreEditorState?()
     @vimState.reset()
     @finish()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -135,6 +135,8 @@ class Motion extends Base
       return
     return if not @isInclusive() and not @isLinewise()
 
+    return if @wise is 'blockwise' # Lift-off
+
     # to select @inclusive-ly
     swrap(selection).translateSelectionEndAndClip('forward')
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -41,6 +41,7 @@ class Motion extends Base
   jump: false
   verticalMotion: false
   moveSucceeded: null
+  moveSuccessOnLinewise: false
 
   constructor: ->
     super
@@ -90,7 +91,7 @@ class Motion extends Base
       selection.modifySelection =>
         @moveWithSaveJump(selection.cursor)
 
-      succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessIfLinewise and @isLinewise())
+      succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
         wrapped = swrap(selection)
         wrapped.translateSelectionEndAndClip('forward')
@@ -675,7 +676,7 @@ class MoveToFirstLine extends Motion
   wise: 'linewise'
   jump: true
   verticalMotion: true
-  moveSuccessIfLinewise: true
+  moveSuccessOnLinewise: true
 
   moveCursor: (cursor) ->
     @setCursorBufferRow(cursor, getValidVimBufferRow(@editor, @getRow()))
@@ -700,7 +701,7 @@ class MoveToLineByPercent extends MoveToFirstLine
 class MoveToRelativeLine extends Motion
   @extend(false)
   wise: 'linewise'
-  moveSuccessIfLinewise: true
+  moveSuccessOnLinewise: true
 
   moveCursor: (cursor) ->
     setBufferRow(cursor, cursor.getBufferRow() + @getCount(-1))

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -121,10 +121,7 @@ class Motion extends Base
         for selection in @editor.getSelections()
           wrapped = swrap(selection)
           wrapped.complementGoalColumn()
-          unless wrapped.hasProperties()
-            wrapped.saveProperties()
           wrapped.expandOverLine()
-          wrapped.setWiseProperty(@wise)
       when 'blockwise'
         @vimState.selectBlockwise()
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -118,10 +118,7 @@ class Motion extends Base
     # Modify selection to submode-wisely
     switch @wise
       when 'linewise'
-        for selection in @editor.getSelections()
-          wrapped = swrap(selection)
-          wrapped.complementGoalColumn()
-          wrapped.expandOverLine()
+        @vimState.selectLinewiseOld()
       when 'blockwise'
         @vimState.selectBlockwise()
 
@@ -135,9 +132,6 @@ class Motion extends Base
       return
     return unless @isInclusive() or @isLinewise()
 
-    if @isMode('visual') and cursorIsAtEndOfLineAtNonEmptyRow(cursor)
-      # Avoid puting cursor on EOL in visual-mode as long as cursor's row was non-empty.
-      swrap(selection).translateSelectionHeadAndClip('backward')
     # to select @inclusive-ly
     swrap(selection).translateSelectionEndAndClip('forward')
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -118,7 +118,13 @@ class Motion extends Base
     # Modify selection to submode-wisely
     switch @wise
       when 'linewise'
-        @vimState.selectLinewise()
+        for selection in @editor.getSelections()
+          wrapped = swrap(selection)
+          wrapped.complementGoalColumn()
+          unless wrapped.hasProperties()
+            wrapped.saveProperties()
+          wrapped.expandOverLine()
+          wrapped.setWiseProperty(@wise)
       when 'blockwise'
         @vimState.selectBlockwise()
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -94,10 +94,8 @@ class Motion extends Base
       succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
         $selection = swrap(selection)
-        $selection.translateSelectionEndAndClip('forward')
-        $selection.saveProperties()
+        $selection.saveProperties(true) # save property by telling this selection is already normalized
         @vimState.mutationManager.setCheckpointForSelection(selection, 'did-move')
-        $selection.normalize()
         if @wise is 'blockwise'
           @vimState.selectBlockwiseForSelection(selection)
         else

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -49,20 +49,8 @@ class Motion extends Base
       @wise = @vimState.submode
     @initialize()
 
-  isInclusive: ->
-    @inclusive
-
-  isJump: ->
-    @jump
-
-  isVerticalMotion: ->
-    @verticalMotion
-
-  isLinewise: ->
-    @wise is 'linewise'
-
-  isBlockwise: ->
-    @wise is 'blockwise'
+  isLinewise: -> @wise is 'linewise'
+  isBlockwise: -> @wise is 'blockwise'
 
   forceWise: (wise) ->
     if wise is 'characterwise'
@@ -79,7 +67,7 @@ class Motion extends Base
     cursor.setScreenPosition(point) if point?
 
   moveWithSaveJump: (cursor) ->
-    if cursor.isLastCursor() and @isJump()
+    if cursor.isLastCursor() and @jump
       cursorPosition = cursor.getBufferPosition()
 
     @moveCursor(cursor)
@@ -111,7 +99,7 @@ class Motion extends Base
         swrap(selection).translateSelectionEndAndClip('forward')
         swrap(selection).saveProperties() if @isMode('visual')
 
-      else if succeeded and (@isInclusive() or @isLinewise())
+      else if succeeded and (@inclusive or @isLinewise())
         swrap(selection).translateSelectionEndAndClip('forward')
 
     @editor.mergeCursors()
@@ -132,7 +120,7 @@ class Motion extends Base
     return @moveSucceeded ? not selection.isEmpty()
 
   setCursorBuffeRow: (cursor, row, options) ->
-    if @isVerticalMotion() and @getConfig('moveToFirstCharacterOnVerticalMotion')
+    if @verticalMotion and @getConfig('moveToFirstCharacterOnVerticalMotion')
       cursor.setBufferPosition(@getFirstCharacterPositionForBufferRow(row), options)
     else
       setBufferRow(cursor, row, options)

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -40,6 +40,7 @@ class Motion extends Base
   wise: 'characterwise'
   jump: false
   verticalMotion: false
+  moveSucceeded: null
 
   constructor: ->
     super
@@ -128,7 +129,8 @@ class Motion extends Base
     selection.modifySelection =>
       @moveWithSaveJump(cursor)
 
-    if not @isMode('visual') and not @is('CurrentSelection') and selection.isEmpty() # Failed to move.
+    if not @isMode('visual') and not @is('CurrentSelection') and
+        (if @moveSucceeded? then not @moveSucceeded else selection.isEmpty())
       return
     return if not @isInclusive() and not @isLinewise()
 
@@ -925,11 +927,8 @@ class Till extends Find
 
   getPoint: ->
     @point = super
-
-  selectByMotion: (selection) ->
-    super
-    if selection.isEmpty() and (@point? and not @backwards)
-      swrap(selection).translateSelectionEndAndClip('forward')
+    @moveSucceeded = @point?
+    return @point
 
 # keymap: T
 class TillBackwards extends Till

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -45,8 +45,8 @@ class Motion extends Base
   constructor: ->
     super
 
-    if @vimState.mode is 'visual'
-      @wise = @vimState.submode
+    if @mode is 'visual'
+      @wise = @submode
     @initialize()
 
   isLinewise: -> @wise is 'linewise'
@@ -84,8 +84,8 @@ class Motion extends Base
         @moveWithSaveJump(cursor)
 
   setMutationCheckPointCheckPointIfNecessary: ->
-    if @isMode('visual')
-      if @isMode('visual', 'linewise') and @editor.getLastSelection().isReversed()
+    if @mode is 'visual'
+      if @submode is 'linewise' and @editor.getLastSelection().isReversed()
         @vimState.mutationManager.setCheckpoint('did-move')
     else
       @vimState.mutationManager.setCheckpoint('did-move')
@@ -95,9 +95,9 @@ class Motion extends Base
       succeeded = @selectByMotion(selection)
       continue if @wise is 'blockwise'
 
-      if @isMode('visual') or @is('CurrentSelection') # guaranteed to be @inclusive = true
+      if @mode is 'visual' or @is('CurrentSelection') # guaranteed to be @inclusive = true
         swrap(selection).translateSelectionEndAndClip('forward')
-        swrap(selection).saveProperties() if @isMode('visual')
+        swrap(selection).saveProperties() if @mode is 'visual'
 
       else if succeeded and (@inclusive or @isLinewise())
         swrap(selection).translateSelectionEndAndClip('forward')
@@ -150,7 +150,7 @@ class CurrentSelection extends Motion
     @pointInfoByCursor = new Map
 
   moveCursor: (cursor) ->
-    if @isMode('visual')
+    if @mode is 'visual'
       if @isBlockwise()
         @blockwiseSelectionExtent = swrap(cursor.selection).getBlockwiseSelectionExtent()
       else
@@ -165,7 +165,7 @@ class CurrentSelection extends Motion
         cursor.setBufferPosition(point.traverse(@selectionExtent))
 
   select: ->
-    if @isMode('visual')
+    if @mode is 'visual'
       super
     else
       for cursor in @editor.getCursors() when pointInfo = @pointInfoByCursor.get(cursor)

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -88,8 +88,7 @@ class Motion extends Base
     for selection in @editor.getSelections()
       @selectByMotion(selection)
 
-    if (@mode isnt 'visual') or (@submode is 'linewise' and @editor.getLastSelection().isReversed())
-      @vimState.mutationManager.setCheckpoint('did-move')
+    @vimState.mutationManager.setCheckpoint('did-move')
 
     # Modify selection to submode-wisely
     switch @wise
@@ -108,7 +107,8 @@ class Motion extends Base
 
     if (@mode is 'visual' or @is('CurrentSelection')) or (succeeded and (@inclusive or @isLinewise()))
       swrap(selection).translateSelectionEndAndClip('forward')
-      swrap(selection).saveProperties() if @mode is 'visual'
+
+    swrap(selection).saveProperties() if @mode is 'visual'
 
   setCursorBufferRow: (cursor, row, options) ->
     if @verticalMotion and @getConfig('moveToFirstCharacterOnVerticalMotion')

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -99,7 +99,12 @@ class Motion extends Base
 
   select: ->
     for selection in @editor.getSelections()
-      @selectByMotion(selection)
+      succeeded = @selectByMotion(selection)
+      if (succeeded or @isMode('visual') or @is('CurrentSelection')) and
+          (@isInclusive() or @isLinewise()) and
+          @wise isnt 'blockwise'
+
+        swrap(selection).translateSelectionEndAndClip('forward')
 
     @editor.mergeCursors()
     @editor.mergeIntersectingSelections()
@@ -124,21 +129,9 @@ class Motion extends Base
         @vimState.selectBlockwise()
 
   selectByMotion: (selection) ->
-    {cursor} = selection
-
     selection.modifySelection =>
-      @moveWithSaveJump(cursor)
-
-    moveSucceeded = @moveSucceeded ? not selection.isEmpty()
-
-    if not @isMode('visual') and not @is('CurrentSelection') and not moveSucceeded
-      return
-    return if not @isInclusive() and not @isLinewise()
-
-    return if @wise is 'blockwise' # Lift-off
-
-    # to select @inclusive-ly
-    swrap(selection).translateSelectionEndAndClip('forward')
+      @moveWithSaveJump(selection.cursor)
+    @moveSucceeded ? not selection.isEmpty()
 
   setCursorBuffeRow: (cursor, row, options) ->
     if @isVerticalMotion() and @getConfig('moveToFirstCharacterOnVerticalMotion')

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -45,9 +45,7 @@ class Motion extends Base
   constructor: ->
     super
 
-    # visual mode can overwrite default wise
     if @vimState.mode is 'visual'
-      @inclusive = true
       @wise = @vimState.submode
     @initialize()
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -93,15 +93,15 @@ class Motion extends Base
 
       succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
-        wrapped = swrap(selection)
-        wrapped.translateSelectionEndAndClip('forward')
-        wrapped.saveProperties()
+        $selection = swrap(selection)
+        $selection.translateSelectionEndAndClip('forward')
+        $selection.saveProperties()
         @vimState.mutationManager.setCheckpointForSelection(selection, 'did-move')
-        wrapped.normalize()
+        $selection.normalize()
         if @wise is 'blockwise'
           @vimState.selectBlockwiseForSelection(selection)
         else
-          wrapped.applyWise(@wise)
+          $selection.applyWise(@wise)
 
     if @wise is 'blockwise'
       @vimState.getLastBlockwiseSelection().autoscrollIfReversed()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -119,7 +119,7 @@ class Motion extends Base
       @moveWithSaveJump(selection.cursor)
     return @moveSucceeded ? not selection.isEmpty()
 
-  setCursorBuffeRow: (cursor, row, options) ->
+  setCursorBufferRow: (cursor, row, options) ->
     if @verticalMotion and @getConfig('moveToFirstCharacterOnVerticalMotion')
       cursor.setBufferPosition(@getFirstCharacterPositionForBufferRow(row), options)
     else
@@ -691,7 +691,7 @@ class MoveToFirstLine extends Motion
   verticalMotion: true
 
   moveCursor: (cursor) ->
-    @setCursorBuffeRow(cursor, getValidVimBufferRow(@editor, @getRow()))
+    @setCursorBufferRow(cursor, getValidVimBufferRow(@editor, @getRow()))
     cursor.autoscroll(center: true)
 
   getRow: ->
@@ -736,7 +736,7 @@ class MoveToTopOfScreen extends Motion
 
   moveCursor: (cursor) ->
     bufferRow = @editor.bufferRowForScreenRow(@getScreenRow())
-    @setCursorBuffeRow(cursor, bufferRow)
+    @setCursorBufferRow(cursor, bufferRow)
 
   getScrolloff: ->
     if @isAsTargetExceptSelect()
@@ -816,7 +816,7 @@ class Scroll extends Motion
 
   moveCursor: (cursor) ->
     bufferRow = @getBufferRow(cursor)
-    @setCursorBuffeRow(cursor, @getBufferRow(cursor), autoscroll: false)
+    @setCursorBufferRow(cursor, @getBufferRow(cursor), autoscroll: false)
 
     if cursor.isLastCursor()
       if @isSmoothScrollEnabled()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -130,7 +130,7 @@ class Motion extends Base
 
     if not @isMode('visual') and not @is('CurrentSelection') and selection.isEmpty() # Failed to move.
       return
-    return unless @isInclusive() or @isLinewise()
+    return if not @isInclusive() and not @isLinewise()
 
     # to select @inclusive-ly
     swrap(selection).translateSelectionEndAndClip('forward')

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -85,6 +85,7 @@ class Motion extends Base
     @editor.mergeCursors()
     @editor.mergeIntersectingSelections()
 
+  # NOTE: Modify selection by modtion, selection is already "normalized" before this function is called.
   select: ->
     isOrWasVisual = @mode is 'visual' or @is('CurrentSelection') # need to care was visual for `.` repeated.
     for selection in @editor.getSelections()
@@ -94,8 +95,7 @@ class Motion extends Base
       succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
         $selection = swrap(selection)
-        $selection.saveProperties(true) # save property by telling this selection is already normalized
-        @vimState.mutationManager.setCheckpointForSelection(selection, 'did-move')
+        $selection.saveProperties(true) # save property of "already-normalized-selection"
         if @wise is 'blockwise'
           @vimState.selectBlockwiseForSelection(selection)
         else

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -129,8 +129,9 @@ class Motion extends Base
     selection.modifySelection =>
       @moveWithSaveJump(cursor)
 
-    if not @isMode('visual') and not @is('CurrentSelection') and
-        (if @moveSucceeded? then not @moveSucceeded else selection.isEmpty())
+    moveSucceeded = @moveSucceeded ? not selection.isEmpty()
+
+    if not @isMode('visual') and not @is('CurrentSelection') and not moveSucceeded
       return
     return if not @isInclusive() and not @isLinewise()
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -96,6 +96,7 @@ class Motion extends Base
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
         $selection = swrap(selection)
         $selection.saveProperties(true) # save property of "already-normalized-selection"
+
         if @wise is 'blockwise'
           @vimState.selectBlockwiseForSelection(selection)
         else

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -42,16 +42,19 @@ class MutationManager
 
   setCheckpoint: (checkpoint) ->
     for selection in @editor.getSelections()
-      if @mutationsBySelection.has(selection)
-        @mutationsBySelection.get(selection).update(checkpoint)
-      else
-        if @vimState.mode is 'visual'
-          initialPoint = swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
-        else
-          initialPoint = swrap(selection).getBufferPositionFor('head')
+      @setCheckpointForSelection(selection, checkpoint)
 
-        options = {selection, initialPoint, checkpoint, @markerLayer, useMarker: @options.useMarker, @vimState}
-        @mutationsBySelection.set(selection, new Mutation(options))
+  setCheckpointForSelection: (selection, checkpoint) ->
+    if @mutationsBySelection.has(selection)
+      @mutationsBySelection.get(selection).update(checkpoint)
+    else
+      if @vimState.mode is 'visual'
+        initialPoint = swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
+      else
+        initialPoint = swrap(selection).getBufferPositionFor('head')
+
+      options = {selection, initialPoint, checkpoint, @markerLayer, useMarker: @options.useMarker, @vimState}
+      @mutationsBySelection.set(selection, new Mutation(options))
 
   getMutationForSelection: (selection) ->
     @mutationsBySelection.get(selection)

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -50,7 +50,7 @@ class MutationManager
         else
           initialPoint = swrap(selection).getBufferPositionFor('head')
 
-        options = {selection, initialPoint, checkpoint, @markerLayer, useMarker: @options.useMarker}
+        options = {selection, initialPoint, checkpoint, @markerLayer, useMarker: @options.useMarker, @vimState}
         @mutationsBySelection.set(selection, new Mutation(options))
 
   getMutationForSelection: (selection) ->
@@ -133,7 +133,7 @@ class MutationManager
 #  e.g. Some selection is created at 'will-select' checkpoint, others at 'did-select' or 'did-select-occurrence'
 class Mutation
   constructor: (options) ->
-    {@selection, @initialPoint, checkpoint, @markerLayer, @useMarker} = options
+    {@selection, @initialPoint, checkpoint, @markerLayer, @useMarker, @vimState} = options
 
     @createdAt = checkpoint
     if @useMarker
@@ -177,4 +177,7 @@ class Mutation
     if stay
       @getInitialPoint(clip: true)
     else
-      @bufferRangeByCheckpoint['did-move']?.start ? @bufferRangeByCheckpoint['did-select']?.start
+      {mode, submode, editor} = @vimState
+      if (mode isnt 'visual') or (submode is 'linewise' and editor.getLastSelection().isReversed())
+        point = @bufferRangeByCheckpoint['did-move']?.start
+      point ? @bufferRangeByCheckpoint['did-select']?.start

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -180,7 +180,7 @@ class Mutation
     if stay
       @getInitialPoint(clip: true)
     else
-      {mode, submode, editor} = @vimState
-      if (mode isnt 'visual') or (submode is 'linewise' and editor.getLastSelection().isReversed())
-        point = @bufferRangeByCheckpoint['did-move']?.start
+      {mode, submode} = @vimState
+      if (mode isnt 'visual') or (submode is 'linewise' and @selection.isReversed())
+        point = swrap(@selection).getBufferPositionFor('start', from: ['property'])
       point ? @bufferRangeByCheckpoint['did-select']?.start

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -45,7 +45,7 @@ class MutationManager
       if @mutationsBySelection.has(selection)
         @mutationsBySelection.get(selection).update(checkpoint)
       else
-        if @vimState.isMode('visual')
+        if @vimState.mode is 'visual'
           initialPoint = swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
         else
           initialPoint = swrap(selection).getBufferPositionFor('head')

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -141,7 +141,7 @@ class InsertAfter extends ActivateInsertMode
 class InsertAtBeginningOfLine extends ActivateInsertMode
   @extend()
   execute: ->
-    if @isMode('visual', ['characterwise', 'linewise'])
+    if @mode is 'visual' and @submode in ['characterwise', 'linewise']
       @editor.splitSelectionsIntoLines()
     @editor.moveToBeginningOfLine()
     super
@@ -212,7 +212,7 @@ class InsertByTarget extends ActivateInsertMode
 
   execute: ->
     @onDidSelectTarget =>
-      @modifySelection() if @vimState.isMode('visual')
+      @modifySelection() if @vimState.mode is 'visual'
       for selection in @editor.getSelections()
         swrap(selection).setBufferPositionTo(@which)
     super

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -330,12 +330,12 @@ class Select extends Operator
             # When target is persistent-selection, new selection is added after selectTextObject.
             # So we have to assure all selection have selction property.
             # Maybe this logic can be moved to operation stack.
-            for selection in @editor.getSelections() when wrapped = swrap(selection)
+            for selection in @editor.getSelections() when $selection = swrap(selection)
               if @getConfig('keepColumnOnSelectTextObject')
-                wrapped.saveProperties() unless wrapped.hasProperties()
+                $selection.saveProperties() unless $selection.hasProperties()
               else
-                wrapped.saveProperties()
-              wrapped.fixPropertyRowToRowRange()
+                $selection.saveProperties()
+              $selection.fixPropertyRowToRowRange()
 
       @editor.scrollToCursorPosition()
       @activateModeIfNecessary('visual', wise)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -335,7 +335,7 @@ class Select extends Operator
                 wrapped.saveProperties() unless wrapped.hasProperties()
               else
                 wrapped.saveProperties()
-              wrapped.fixPropertiesForLinewise()
+              wrapped.fixPropertyRowToRowRange()
 
       @editor.scrollToCursorPosition()
       @activateModeIfNecessary('visual', wise)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -145,10 +145,10 @@ class Operator extends Base
     # This change cursor position.
     if @selectPersistentSelectionIfNecessary()
       # [FIXME] selection-wise is not synched if it already visual-mode
-      unless @isMode('visual')
+      unless @mode is 'visual'
         @vimState.modeManager.activate('visual', swrap.detectWise(@editor))
 
-    @target = 'CurrentSelection' if @isMode('visual') and @acceptCurrentSelection
+    @target = 'CurrentSelection' if (@mode is 'visual') and @acceptCurrentSelection
     @setTarget(@new(@target)) if _.isString(@target)
 
   subscribeResetOccurrencePatternIfNeeded: ->
@@ -214,7 +214,7 @@ class Operator extends Base
     @vimState.register.set({text, selection}) if text
 
   normalizeSelectionsIfNecessary: ->
-    if @target?.isMotion() and @isMode('visual')
+    if @target?.isMotion() and @mode is 'visual'
       @vimState.modeManager.normalizeSelections()
 
   startMutation: (fn) ->
@@ -322,7 +322,7 @@ class Select extends Operator
 
     if @target.isTextObject() and @target.selectSucceeded
       wise = @target.wise
-      if @isMode('visual')
+      if @mode is 'visual'
         switch wise
           when 'characterwise'
             swrap.saveProperties(@editor)
@@ -414,7 +414,7 @@ class TogglePresetOccurrence extends Operator
       pattern = null
       isNarrowed = @vimState.modeManager.isNarrowed()
 
-      if @isMode('visual') and not isNarrowed
+      if @mode is 'visual' and not isNarrowed
         @occurrenceType = 'base'
         pattern = new RegExp(_.escapeRegExp(@editor.getSelectedText()), 'g')
       else

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -1,7 +1,3 @@
-# TODO#698 remove when finished
-{inspect} = require 'util'
-p = (args...) -> console.log inspect(args...)
-
 {Range, Point, Disposable} = require 'atom'
 {
   translatePointAndClip

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -1,4 +1,4 @@
-# TODO-#698 remove when finished
+# TODO#698 remove when finished
 {inspect} = require 'util'
 p = (args...) -> console.log inspect(args...)
 
@@ -151,12 +151,11 @@ class SelectionWrapper
       [start, end] = [tail, head]
     [start.row, end.row] = @selection.getBufferRowRange()
 
-  # wise must be 'characterwise' or 'linewise'
+  # NOTE:
+  # 'wise' must be 'characterwise' or 'linewise'
+  # Use this for normalized(non-select-right-ed) selection.
   applyWise: (wise) ->
-    assertWithException(@hasProperties(), "trying to applyWise on properties-less selection")
-    # NOTE:
-    # Must call against normalized selection
-    # Don't call non-normalized selection
+    assertWithException(@hasProperties(), "trying to applyWise #{wise} on properties-less selection")
     switch wise
       when 'characterwise'
         @translateSelectionEndAndClip('forward') # equivalent to core selection.selectRight but keep goalColumn
@@ -285,6 +284,9 @@ swrap.dumpProperties = (editor) ->
   for selection in editor.getSelections() when swrap(selection).hasProperties()
     console.log inspect(swrap(selection).getProperties())
 
+swrap.hasProperties = (editor) ->
+  editor.getSelections().every (selection) -> swrap(selection).hasProperties()
+
 swrap.normalize = (editor) ->
   for selection in editor.getSelections()
     swrap(selection).normalize()
@@ -296,6 +298,10 @@ swrap.applyWise = (editor, value) ->
 swrap.fixPropertyRowToRowRange = (editor) ->
   for selection in editor.getSelections()
     swrap(selection).fixPropertyRowToRowRange()
+
+swrap.setWiseProperty = (editor, wise) ->
+  for selection in editor.getSelections()
+    swrap(selection).setWiseProperty(wise)
 
 # Return function to restore
 # Used in vmp-move-selected-text

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -140,6 +140,7 @@ class SelectionWrapper
 
   # wise must be 'characterwise' or 'linewise'
   applyWise: (wise) ->
+    assertWithException(@hasProperties(), "trying to applyWise on properties-less selection")
     # NOTE:
     # Must call against normalized selection
     # Don't call non-normalized selection
@@ -148,9 +149,6 @@ class SelectionWrapper
         @translateSelectionEndAndClip('forward') # equivalent to core selection.selectRight but keep goalColumn
       when 'linewise'
         @complementGoalColumn()
-        @saveProperties() unless @hasProperties()
-        # throw new Errow("applyWise linewise without prop")
-
         # Even if end.column is 0, expand over that end.row( don't care selection.getRowRange() )
         {start, end} = @getBufferRange()
         range = getBufferRangeForRowRange(@selection.editor, [start.row, end.row])

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -129,8 +129,7 @@ class SelectionWrapper
     else
       # We selectRight-ed in visual-mode, this translation de-effect select-right-effect
       # So that we can activate-visual-mode without special translation after restoreing properties.
-      {end} = @getBufferRange()
-      end = translatePointAndClip(@selection.editor, end, 'backward')
+      end = translatePointAndClip(@selection.editor, @getBufferRange().end, 'backward')
       if @selection.isReversed()
         properties = {head: head, tail: end}
       else
@@ -157,6 +156,7 @@ class SelectionWrapper
         @translateSelectionEndAndClip('forward') # equivalent to core selection.selectRight but keep goalColumn
       when 'linewise'
         @complementGoalColumn()
+
         # Even if end.column is 0, expand over that end.row( don't care selection.getRowRange() )
         {start, end} = @getBufferRange()
         range = getBufferRangeForRowRange(@selection.editor, [start.row, end.row])

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -13,7 +13,7 @@ p = (args...) -> console.log inspect(args...)
   assertWithException
 } = require './utils'
 
-propertyStore = new Map
+propertyStore = new WeakMap
 
 class SelectionWrapper
   constructor: (@selection) ->

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -27,19 +27,6 @@ class SelectionWrapper
   getBufferRange: ->
     @selection.getBufferRange()
 
-  getCursorTraversalFromPropertyInBufferPosition: (clip) ->
-    bufferPosition = @getBufferPositionFor('head', from: ['property'])
-    if clip
-      bufferPosition = @selection.editor.clipBufferPosition(bufferPosition)
-    bufferPosition.traversalFrom(@selection.cursor.getBufferPosition())
-
-  getCursorTraversalFromPropertyInScreenPosition: (clip) ->
-    bufferPosition = @getBufferPositionFor('head', from: ['property'])
-    if clip
-      bufferPosition = @selection.editor.clipBufferPosition(bufferPosition)
-    screenPosition = @selection.editor.screenPositionForBufferPosition(bufferPosition)
-    screenPosition.traversalFrom(@selection.cursor.getScreenPosition())
-
   getBufferPositionFor: (which, {from}={}) ->
     from ?= ['selection']
 

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -232,6 +232,7 @@ class SelectionWrapper
   normalize: ->
     assertWithException(not @selection.isEmpty(), "attempted to normalize for empty selection")
     assertWithException(@hasProperties(), "attempted to normalize for un-propertized selection")
+
     if @getProperties().wise is 'linewise'
       @fixPropertyRowToRowRange()
     @selectByProperties(@getProperties())

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -150,7 +150,11 @@ class SelectionWrapper
         @complementGoalColumn()
         @saveProperties() unless @hasProperties()
         # throw new Errow("applyWise linewise without prop")
-        @expandOverLine()
+
+        # Even if end.column is 0, expand over that end.row( don't care selection.getRowRange() )
+        {start, end} = @getBufferRange()
+        range = getBufferRangeForRowRange(@selection.editor, [start.row, end.row])
+        @setBufferRange(range)
 
     @setWiseProperty(wise)
 

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -115,10 +115,10 @@ class SelectionWrapper
       point = translatePointAndClip(editor, tailPoint, 'forward')
       new Range(tailPoint, point)
 
-  saveProperties: ->
+  saveProperties: (isNormalized) ->
     head = @selection.getHeadBufferPosition()
     tail = @selection.getTailBufferPosition()
-    if @selection.isEmpty()
+    if @selection.isEmpty() or isNormalized
       properties = {head, tail}
     else
       # We selectRight-ed in visual-mode, this translation de-effect select-right-effect
@@ -243,9 +243,9 @@ swrap.detectWise = (editor) ->
   else
     'characterwise'
 
-swrap.saveProperties = (editor) ->
+swrap.saveProperties = (editor, isNormalized) ->
   for selection in editor.getSelections()
-    swrap(selection).saveProperties()
+    swrap(selection).saveProperties(isNormalized)
 
 swrap.clearProperties = (editor) ->
   for selection in editor.getSelections()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -119,6 +119,7 @@ class SelectionWrapper
         properties.tail = endPoint
       else
         properties.head = endPoint
+    # properties.head.column = @selection.cursor.goalColumn if @selection.cursor.goalColumn
     @setProperties(properties)
 
   fixPropertiesForLinewise: ->
@@ -130,16 +131,6 @@ class SelectionWrapper
     else
       [start, end] = [tail, head]
     [start.row, end.row] = @selection.getBufferRowRange()
-
-    # Clip property till one column left before EOL
-    # When `keepColumnOnSelectTextObject` was true,
-    #  cursor marker in vL-mode exceed EOL
-    # FIXME: respect goalcolumn
-    editor = @selection.editor
-    startEOL = getEndOfLineForBufferRow(editor, start.row)
-    endEOL = getEndOfLineForBufferRow(editor, end.row)
-    start.column = Math.min(start.column, limitNumber(startEOL.column - 1, min: 0))
-    end.column = Math.min(end.column, limitNumber(endEOL.column - 1, min: 0))
 
   # wise must be 'characterwise' or 'linewise'
   applyWise: (wise) ->

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -87,12 +87,6 @@ class SelectionWrapper
   getRowCount: ->
     @getRows().length
 
-  # Native selection.expandOverLine is not aware of actual rowRange of selection.
-  expandOverLine: ->
-    rowRange = @selection.getBufferRowRange()
-    range = getBufferRangeForRowRange(@selection.editor, rowRange)
-    @setBufferRange(range)
-
   getRowFor: (where) ->
     [startRow, endRow] = @selection.getBufferRowRange()
     if @selection.isReversed()
@@ -156,7 +150,6 @@ class SelectionWrapper
         @translateSelectionEndAndClip('forward') # equivalent to core selection.selectRight but keep goalColumn
       when 'linewise'
         @complementGoalColumn()
-
         # Even if end.column is 0, expand over that end.row( don't care selection.getRowRange() )
         {start, end} = @getBufferRange()
         range = getBufferRangeForRowRange(@selection.editor, [start.row, end.row])
@@ -178,19 +171,6 @@ class SelectionWrapper
     # No problem if head is greater than tail, Range constructor swap start/end.
     @setBufferRange([tail, head], options)
     @setReversedState(head.isLessThan(tail))
-
-  applyColumnFromProperties: ->
-    selectionProperties = @getProperties()
-    return unless selectionProperties?
-    {head, tail} = selectionProperties
-
-    if @selection.isReversed()
-      [start, end] = [head, tail]
-    else
-      [start, end] = [tail, head]
-    [start.row, end.row] = @selection.getBufferRowRange()
-    @setBufferRange([start, end])
-    @translateSelectionEndAndClip('backward', translate: false)
 
   # set selections bufferRange with default option {autoscroll: false, preserveFolds: true}
   setBufferRange: (range, options={}) ->
@@ -294,10 +274,6 @@ swrap.applyWise = (editor, value) ->
 swrap.fixPropertyRowToRowRange = (editor) ->
   for selection in editor.getSelections()
     swrap(selection).fixPropertyRowToRowRange()
-
-swrap.setWiseProperty = (editor, wise) ->
-  for selection in editor.getSelections()
-    swrap(selection).setWiseProperty(wise)
 
 # Return function to restore
 # Used in vmp-move-selected-text

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -31,6 +31,19 @@ class SelectionWrapper
   getBufferRange: ->
     @selection.getBufferRange()
 
+  getCursorTraversalFromPropertyInBufferPosition: (clip) ->
+    bufferPosition = @getBufferPositionFor('head', from: ['property'])
+    if clip
+      bufferPosition = @selection.editor.clipBufferPosition(bufferPosition)
+    bufferPosition.traversalFrom(@selection.cursor.getBufferPosition())
+
+  getCursorTraversalFromPropertyInScreenPosition: (clip) ->
+    bufferPosition = @getBufferPositionFor('head', from: ['property'])
+    if clip
+      bufferPosition = @selection.editor.clipBufferPosition(bufferPosition)
+    screenPosition = @selection.editor.screenPositionForBufferPosition(bufferPosition)
+    screenPosition.traversalFrom(@selection.cursor.getScreenPosition())
+
   getBufferPositionFor: (which, {from}={}) ->
     from ?= ['selection']
 

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -229,10 +229,15 @@ class SelectionWrapper
     tail = @selection.getTailBufferPosition()
     new Point(head.row - tail.row, head.column - tail.column)
 
+  # What's the normalize?
+  # Normalization is restore selection range from property.
+  # As a result it range became range where end of selection moved to left.
+  # This end-move-to-left de-efect of end-mode-to-right effect( this is visual-mode orientation )
   normalize: ->
-    assertWithException(not @selection.isEmpty(), "attempted to normalize for empty selection")
-    assertWithException(@hasProperties(), "attempted to normalize for un-propertized selection")
+    # empty selection IS already 'normalized'
+    return if @selection.isEmpty()
 
+    assertWithException(@hasProperties(), "attempted to normalize but no properties to restore")
     if @getProperties().wise is 'linewise'
       @fixPropertyRowToRowRange()
     @selectByProperties(@getProperties())

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -110,11 +110,27 @@ class SelectionWrapper
 
   saveProperties: ->
     properties = @captureProperties()
+
     unless @selection.isEmpty()
       # We selectRight-ed in visual-mode, this translation de-effect select-right-effect
       # So that we can activate-visual-mode without special translation after restoreing properties.
-      endPoint = @getBufferRange().end.translate([0, -1])
-      endPoint = @selection.editor.clipBufferPosition(endPoint)
+
+      {start, end} = @getBufferRange()
+
+      if end.column is 0
+        # console.log 'hey!'
+        endPoint = new Point(limitNumber(end.row - 1, min: start.row) , Infinity)
+        endPoint = @selection.editor.clipBufferPosition(endPoint)
+
+        # end.column)
+        # endPoint = new Range(start, [endRow, Infinity])
+      else
+        console.log "HEY!"
+        endPoint = end.translate([0, -1])
+        endPoint = @selection.editor.clipBufferPosition(endPoint)
+
+      # endPoint = @getBufferRange().end.translate([0, -1])
+      # endPoint = @selection.editor.clipBufferPosition(endPoint)
       if @selection.isReversed()
         properties.tail = endPoint
       else

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -361,9 +361,7 @@ class Paragraph extends TextObject
 
   getRange: (selection) ->
     originalRange = selection.getBufferRange()
-    fromRow = swrap(selection).getRowFor('head')
-    # fromRow = @getCursorPositionForSelection(selection).row
-
+    fromRow = @getCursorPositionForSelection(selection).row
     if @isMode('visual', 'linewise')
       if selection.isReversed()
         fromRow--
@@ -379,8 +377,7 @@ class Indentation extends Paragraph
   @deriveInnerAndA()
 
   getRange: (selection) ->
-    fromRow = swrap(selection).getRowFor('head')
-    # fromRow = @getCursorPositionForSelection(selection).row
+    fromRow = @getCursorPositionForSelection(selection).row
 
     baseIndentLevel = @getIndentLevelForBufferRow(fromRow)
     predict = (row) =>

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -156,7 +156,7 @@ class Pair extends TextObject
       start = start.traverse([1, 0])
 
     if getLineTextToBufferPosition(@editor, end).match(/^\s*$/)
-      if @isMode('visual')
+      if @mode is 'visual'
         # This is slightly innconsistent with regular Vim
         # - regular Vim: select new line after EOL
         # - vim-mode-plus: select to EOL(before new line)
@@ -491,7 +491,7 @@ class SearchMatchForward extends TextObject
   backward: false
 
   findMatch: (fromPoint, pattern) ->
-    fromPoint = translatePointAndClip(@editor, fromPoint, "forward") if @isMode('visual')
+    fromPoint = translatePointAndClip(@editor, fromPoint, "forward") if (@mode is 'visual')
     found = null
     @scanForward pattern, {from: [fromPoint.row, 0]}, ({range, stop}) ->
       if range.end.isGreaterThan(fromPoint)
@@ -533,7 +533,7 @@ class SearchMatchBackward extends SearchMatchForward
   backward: true
 
   findMatch: (fromPoint, pattern) ->
-    fromPoint = translatePointAndClip(@editor, fromPoint, "backward") if @isMode('visual')
+    fromPoint = translatePointAndClip(@editor, fromPoint, "backward") if (@mode is 'visual')
     found = null
     @scanBackward pattern, {from: [fromPoint.row, Infinity]}, ({range, stop}) ->
       if range.start.isLessThan(fromPoint)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -586,6 +586,7 @@ getLargestFoldRangeContainsBufferRow = (editor, row) ->
   if startPoint? and endPoint?
     new Range(startPoint, endPoint)
 
+# take bufferPosition
 translatePointAndClip = (editor, point, direction, {translate}={}) ->
   translate ?= true
   point = Point.fromObject(point)
@@ -598,10 +599,9 @@ translatePointAndClip = (editor, point, direction, {translate}={}) ->
 
       if point.isEqual(eol)
         dontClip = true
-
-      if point.isGreaterThan(eol)
-        point = new Point(point.row + 1, 0)
+      else if point.isGreaterThan(eol)
         dontClip = true
+        point = new Point(point.row + 1, 0) # move point to new-line selected point
 
       point = Point.min(point, editor.getEofBufferPosition())
 
@@ -609,6 +609,7 @@ translatePointAndClip = (editor, point, direction, {translate}={}) ->
       point = point.translate([0, -1]) if translate
 
       if point.column < 0
+        dontClip = true
         newRow = point.row - 1
         eol = editor.bufferRangeForBufferRow(newRow).end
         point = new Point(newRow, eol.column)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -274,7 +274,7 @@ class VimState
       else
         @activate('visual', wise)
     else
-      @activate('normal') if @isMode('visual')
+      @activate('normal') if @mode is 'visual'
 
   saveProperties: (event) ->
     return unless @isInterestingEvent(event)

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -122,16 +122,6 @@ class VimState
 
   # Other
   # -------------------------
-  # TODO#698 Remove when done
-  selectLinewiseOld: ->
-    for selection in @editor.getSelections() when wrapped = swrap(selection)
-      wrapped.complementGoalColumn()
-      wrapped.expandOverLine()
-
-  selectLinewise: ->
-    swrap.applyWise(@editor, 'linewise')
-
-  # -------------------------
   toggleClassList: (className, bool=undefined) ->
     @editorElement.classList.toggle(className, bool)
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -122,7 +122,7 @@ class VimState
 
   # Other
   # -------------------------
-  # TODO-#698 Remove when done
+  # TODO#698 Remove when done
   selectLinewiseOld: ->
     for selection in @editor.getSelections() when wrapped = swrap(selection)
       wrapped.complementGoalColumn()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -13,7 +13,6 @@ SearchInputElement = require './search-input'
   matchScopes
   assert
   assertWithException
-  moveCursorLeft
 } = require './utils'
 swrap = require './selection-wrapper'
 
@@ -232,11 +231,6 @@ class VimState
     if @editor.isAlive()
       @resetNormalMode()
       @reset()
-      # In visual-mode, cursor can place at EOL. move left if cursor is at EOL
-      # We should not do this in visual-mode deactivation phase.
-      # e.g. `A` directly shift from visua-mode to `insert-mode`, and cursor should remain at EOL.
-      for cursor in @editor.getCursors() when cursor.isAtEndOfLine()
-        moveCursorLeft(cursor, preserveGoalColumn: true)
       @editorElement.component?.setInputEnabled(true)
       @editorElement.classList.remove(packageScope, 'normal-mode')
 

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -99,10 +99,15 @@ describe "Motion Find", ->
       ensure ['d 2 t', input: 'b'],
         text: 'abcbcabc\n'
 
-    it "selects character under cursor even when no movement happens", ->
+    it "delete char under cursor even when no movement happens since it's inclusive motion", ->
       set cursor: [0, 0]
       ensure ['d t', input: 'b'],
         text: 'bcabcabcabc\n'
+    it "do nothing when inclusiveness inverted by v operator-modifier", ->
+      text: "abcabcabcabc\n"
+      set cursor: [0, 0]
+      ensure ['d v t', input: 'b'],
+        text: 'abcabcabcabc\n'
 
     it "T behaves exclusively when composes with operator", ->
       set cursor: [0, 3]

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -75,7 +75,7 @@ describe "Motion Search", ->
       it 'searches to the correct column in visual linewise mode', ->
         ensure ['V /', search: 'ef'],
           selectedText: "abc\ndef\n",
-          characterwiseHead: [1, 1]
+          propertyHead: [1, 1]
           cursor: [2, 0]
           mode: ['visual', 'linewise']
 

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -372,16 +372,6 @@ describe "Operator general", ->
         it "deletes both lines", ->
           ensure 'd k', text: "a\nb\n", cursor: [1, 0]
 
-      # [TODO] write more generic operator test. #119
-      # This is general behavior of all operator.
-      # When it cant move, its target selection should be empty so nothing happen.
-      xdescribe "when it can't move", ->
-        textOriginal = "a\nb\n"
-        cursorOriginal = [0, 0]
-        it "deletes delete nothing", ->
-          set text: textOriginal, cursor: cursorOriginal
-          ensure 'd k', text: textOriginal, cursor: cursorOriginal
-
     describe "when followed by a G", ->
       beforeEach ->
         originalText = "12345\nabcde\nABCDE"

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -646,7 +646,7 @@ describe "Operator TransformString", ->
           milk
 
           """
-      # TODO-#698 FIX when finished
+      # TODO#698 FIX when finished
       xit "surround text for each word in visual selection", ->
         ensure 'v i p m s "',
           textC: """

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -646,7 +646,8 @@ describe "Operator TransformString", ->
           milk
 
           """
-      it "surround text for each word in visual selection", ->
+      # TODO-#698 FIX when finished
+      xit "surround text for each word in visual selection", ->
         ensure 'v i p m s "',
           textC: """
 

--- a/spec/persistent-selection-spec.coffee
+++ b/spec/persistent-selection-spec.coffee
@@ -65,6 +65,13 @@ describe "Persistent Selection", ->
           ensurePersistentSelection 'j .',
             length: 2
             text: ['ooo', 'xxx']
+        it "create-persistent-selection forr current selection and repeatable by .", ->
+          ensurePersistentSelection 'v enter',
+            length: 1
+            text: ['o']
+          ensurePersistentSelection 'j .',
+            length: 2
+            text: ['o', 'x']
 
       describe "[No behavior diff currently] inner-persistent-selection and a-persistent-selection", ->
         it "apply operator to across all persistent-selections", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -36,8 +36,11 @@ withMockPlatform = (target, platform, fn) ->
 buildKeydownEvent = (key, options) ->
   KeymapManager.buildKeydownEvent(key, options)
 
-headFromProperty = (selection) ->
+getHeadProperty = (selection) ->
   swrap(selection).getBufferPositionFor('head', from: ['property'])
+
+getTailProperty = (selection) ->
+  swrap(selection).getBufferPositionFor('tail', from: ['property'])
 
 buildKeydownEventFromKeystroke = (keystroke, target) ->
   modifier = ['ctrl', 'alt', 'shift', 'cmd']
@@ -250,7 +253,8 @@ class VimEditor
     'selectionIsReversed',
     'persistentSelectionBufferRange', 'persistentSelectionCount'
     'occurrenceCount', 'occurrenceText'
-    'characterwiseHead'
+    'propertyHead'
+    'propertyTail'
     'scrollTop',
     'mark'
     'mode',
@@ -387,8 +391,12 @@ class VimEditor
     actual = (@editor.getTextInBufferRange(r) for r in ranges)
     expect(actual).toEqual(toArray(text))
 
-  ensureCharacterwiseHead: (points) ->
-    actual = (headFromProperty(s) for s in @editor.getSelections())
+  ensurePropertyHead: (points) ->
+    actual = (getHeadProperty(s) for s in @editor.getSelections())
+    expect(actual).toEqual(toArrayOfPoint(points))
+
+  ensurePropertyTail: (points) ->
+    actual = (getTailProperty(s) for s in @editor.getSelections())
     expect(actual).toEqual(toArrayOfPoint(points))
 
   ensureScrollTop: (scrollTop) ->

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1003,8 +1003,9 @@ describe "TextObject", ->
 
       describe "expansion and deletion", ->
         beforeEach ->
+          # [NOTE] Intentionally omit `!` prefix of DOCTYPE since it represent last cursor in textC.
           htmlLikeText = """
-          <!DOCTYPE html>
+          <DOCTYPE html>
           <html lang="en">
           <head>
           __<meta charset="UTF-8" />
@@ -1013,7 +1014,7 @@ describe "TextObject", ->
           <body>
           __<div>
           ____<div>
-          ______<div>
+          |______<div>
           ________<p><a>
           ______</div>
           ____</div>
@@ -1021,10 +1022,9 @@ describe "TextObject", ->
           </body>
           </html>\n
           """
-          set text_: htmlLikeText
+          set textC_: htmlLikeText
 
         it "can expand selection when repeated", ->
-          set cursor: [9, 0]
           ensure 'v i t', selectedText_: """
             \n________<p><a>
             ______
@@ -1070,7 +1070,7 @@ describe "TextObject", ->
         it 'delete inner-tag and repatable', ->
           set cursor: [9, 0]
           ensure "d i t", text_: """
-            <!DOCTYPE html>
+            <DOCTYPE html>
             <html lang="en">
             <head>
             __<meta charset="UTF-8" />
@@ -1086,7 +1086,7 @@ describe "TextObject", ->
             </html>\n
             """
           ensure "3 .", text_: """
-            <!DOCTYPE html>
+            <DOCTYPE html>
             <html lang="en">
             <head>
             __<meta charset="UTF-8" />
@@ -1096,7 +1096,7 @@ describe "TextObject", ->
             </html>\n
             """
           ensure ".", text_: """
-            <!DOCTYPE html>
+            <DOCTYPE html>
             <html lang="en"></html>\n
             """
 

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1332,6 +1332,14 @@ describe "TextObject", ->
 
   describe "Paragraph", ->
     text = null
+    ensureParagraph = (keystroke, options) ->
+      unless options.setCursor
+        throw new Errow("no setCursor provided")
+      set cursor: options.setCursor
+      delete options.setCursor
+      ensure(keystroke, options)
+      ensure('escape', mode: 'normal')
+
     beforeEach ->
       text = new TextData """
 
@@ -1353,33 +1361,27 @@ describe "TextObject", ->
 
     describe "inner-paragraph", ->
       it "select consequtive blank rows", ->
-        set cursor: [0, 0]; ensure 'v i p', selectedText: text.getLines([0])
-        set cursor: [2, 0]; ensure 'v i p', selectedText: text.getLines([2])
-        set cursor: [5, 0]; ensure 'v i p', selectedText: text.getLines([5..6])
+        ensureParagraph 'v i p', setCursor: [0, 0], selectedText: text.getLines([0])
+        ensureParagraph 'v i p', setCursor: [2, 0], selectedText: text.getLines([2])
+        ensureParagraph 'v i p', setCursor: [5, 0], selectedText: text.getLines([5..6])
       it "select consequtive non-blank rows", ->
-        set cursor: [1, 0]; ensure 'v i p', selectedText: text.getLines([1])
-        set cursor: [3, 0]; ensure 'v i p', selectedText: text.getLines([3..4])
-        set cursor: [7, 0]; ensure 'v i p', selectedText: text.getLines([7..9])
+        ensureParagraph 'v i p', setCursor: [1, 0], selectedText: text.getLines([1])
+        ensureParagraph 'v i p', setCursor: [3, 0], selectedText: text.getLines([3..4])
+        ensureParagraph 'v i p', setCursor: [7, 0], selectedText: text.getLines([7..9])
       it "operate on inner paragraph", ->
-        set cursor: [7, 0]
-        ensure 'y i p',
-          cursor: [7, 0]
-          register: '"': text: text.getLines([7, 8, 9])
+        ensureParagraph 'y i p', setCursor: [7, 0], register: '"': text: text.getLines([7, 8, 9])
 
     describe "a-paragraph", ->
       it "select two paragraph as one operation", ->
-        set cursor: [0, 0]; ensure 'v a p', selectedText: text.getLines([0, 1])
-        set cursor: [2, 0]; ensure 'v a p', selectedText: text.getLines([2..4])
-        set cursor: [5, 0]; ensure 'v a p', selectedText: text.getLines([5..9])
+        ensureParagraph 'v a p', setCursor: [0, 0], selectedText: text.getLines([0, 1])
+        ensureParagraph 'v a p', setCursor: [2, 0], selectedText: text.getLines([2..4])
+        ensureParagraph 'v a p', setCursor: [5, 0], selectedText: text.getLines([5..9])
       it "select two paragraph as one operation", ->
-        set cursor: [1, 0]; ensure 'v a p', selectedText: text.getLines([1..2])
-        set cursor: [3, 0]; ensure 'v a p', selectedText: text.getLines([3..6])
-        set cursor: [7, 0]; ensure 'v a p', selectedText: text.getLines([7..10])
+        ensureParagraph 'v a p', setCursor: [1, 0], selectedText: text.getLines([1..2])
+        ensureParagraph 'v a p', setCursor: [3, 0], selectedText: text.getLines([3..6])
+        ensureParagraph 'v a p', setCursor: [7, 0], selectedText: text.getLines([7..10])
       it "operate on a paragraph", ->
-        set cursor: [3, 0]
-        ensure 'y a p',
-          cursor: [3, 0]
-          register: '"': text: text.getLines([3..6])
+        ensureParagraph 'y a p', setCursor: [3, 0], register: '"': text: text.getLines([3..6])
 
   describe 'Comment', ->
     beforeEach ->

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -482,11 +482,11 @@ describe "VimState", ->
 
         it "keep goalColumn when shift linewise to characterwise", ->
           ensure 'V', selectedText: text.getLines([0]), characterwiseHead: [0, 0], mode: ['visual', 'linewise']
-          ensure '$', selectedText: text.getLines([0]), characterwiseHead: [0, 15], mode: ['visual', 'linewise']
-          ensure 'j', selectedText: text.getLines([0, 1]), characterwiseHead: [1, 9], mode: ['visual', 'linewise']
-          ensure 'j', selectedText: text.getLines([0..2]), characterwiseHead: [2, 6], mode: ['visual', 'linewise']
-          ensure 'v', selectedText: text.getLines([0..2], chomp: true), characterwiseHead: [2, 6], mode: ['visual', 'characterwise']
-          ensure 'j', selectedText: text.getLines([0..3], chomp: true), cursor: [3, 11], mode: ['visual', 'characterwise']
+          ensure '$', selectedText: text.getLines([0]), characterwiseHead: [0, 16], mode: ['visual', 'linewise']
+          ensure 'j', selectedText: text.getLines([0, 1]), characterwiseHead: [1, 10], mode: ['visual', 'linewise']
+          ensure 'j', selectedText: text.getLines([0..2]), characterwiseHead: [2, 7], mode: ['visual', 'linewise']
+          ensure 'v', selectedText: text.getLines([0..2]), characterwiseHead: [2, 7], mode: ['visual', 'characterwise']
+          ensure 'j', selectedText: text.getLines([0..3]), characterwiseHead: [3, 11], mode: ['visual', 'characterwise']
           ensure 'v', cursor: [3, 10], mode: 'normal'
           ensure 'j', cursor: [4, 15], mode: 'normal'
 
@@ -504,8 +504,9 @@ describe "VimState", ->
         ensure 'v', mode: ['visual', 'characterwise'], cursor: [0, 8]
       it "adjust cursor position 1 column left when deactivated", ->
         ensure 'v escape', mode: 'normal', cursor: [0, 7]
-      it "[CHANGED from vim-mode] can not select new line in characterwise visual mode", ->
-        ensure 'v l l', cursor: [0, 8]
+      it "can select new line in visual mode", ->
+        ensure 'v', cursor: [0, 8], characterwiseHead: [0, 7]
+        ensure 'l', cursor: [1, 0], characterwiseHead: [0, 8]
         ensure 'escape', mode: 'normal', cursor: [0, 7]
 
     describe "deactivating visual mode on blank line", ->
@@ -586,7 +587,7 @@ describe "VimState", ->
     describe "visual-mode.characterwise", ->
       it "[single row] is narrowed", ->
         ensure 'v $',
-          selectedText: '1:-----'
+          selectedText: '1:-----\n'
           mode: ['visual', 'characterwise']
           selectionIsNarrowed: false
         ensureNormalModeState()

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -481,12 +481,12 @@ describe "VimState", ->
             cursor: [0, 0]
 
         it "keep goalColumn when shift linewise to characterwise", ->
-          ensure 'V', selectedText: text.getLines([0]), characterwiseHead: [0, 0], mode: ['visual', 'linewise']
-          ensure '$', selectedText: text.getLines([0]), characterwiseHead: [0, 16], mode: ['visual', 'linewise']
-          ensure 'j', selectedText: text.getLines([0, 1]), characterwiseHead: [1, 10], mode: ['visual', 'linewise']
-          ensure 'j', selectedText: text.getLines([0..2]), characterwiseHead: [2, 7], mode: ['visual', 'linewise']
-          ensure 'v', selectedText: text.getLines([0..2]), characterwiseHead: [2, 7], mode: ['visual', 'characterwise']
-          ensure 'j', selectedText: text.getLines([0..3]), characterwiseHead: [3, 11], mode: ['visual', 'characterwise']
+          ensure 'V', selectedText: text.getLines([0]), propertyHead: [0, 0], mode: ['visual', 'linewise']
+          ensure '$', selectedText: text.getLines([0]), propertyHead: [0, 16], mode: ['visual', 'linewise']
+          ensure 'j', selectedText: text.getLines([0, 1]), propertyHead: [1, 10], mode: ['visual', 'linewise']
+          ensure 'j', selectedText: text.getLines([0..2]), propertyHead: [2, 7], mode: ['visual', 'linewise']
+          ensure 'v', selectedText: text.getLines([0..2]), propertyHead: [2, 7], mode: ['visual', 'characterwise']
+          ensure 'j', selectedText: text.getLines([0..3]), propertyHead: [3, 11], mode: ['visual', 'characterwise']
           ensure 'v', cursor: [3, 10], mode: 'normal'
           ensure 'j', cursor: [4, 15], mode: 'normal'
 
@@ -505,8 +505,8 @@ describe "VimState", ->
       it "adjust cursor position 1 column left when deactivated", ->
         ensure 'v escape', mode: 'normal', cursor: [0, 7]
       it "can select new line in visual mode", ->
-        ensure 'v', cursor: [0, 8], characterwiseHead: [0, 7]
-        ensure 'l', cursor: [1, 0], characterwiseHead: [0, 8]
+        ensure 'v', cursor: [0, 8], propertyHead: [0, 7]
+        ensure 'l', cursor: [1, 0], propertyHead: [0, 8]
         ensure 'escape', mode: 'normal', cursor: [0, 7]
 
     describe "deactivating visual mode on blank line", ->

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -1,5 +1,4 @@
 {getVimState, TextData} = require './spec-helper'
-swrap = require '../lib/selection-wrapper'
 
 describe "Visual Blockwise", ->
   [set, ensure, keystroke, editor, editorElement, vimState] = []
@@ -425,13 +424,11 @@ describe "Visual Blockwise", ->
       ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true, headReversed: true
     it "when [reversed = false, headReversed = true]", ->
       set cursor: [0, 6]
-      # FIXME: changing `2 j` to `j j` spec fail
-      ensure "h h h 2 j", cursor: [[0, 3], [1, 0], [2, 3]], selectedTextOrdered: selectedBlockTexts
+      ensure "h h h j j", cursor: [[0, 3], [1, 0], [2, 3]], selectedTextOrdered: selectedBlockTexts
       ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false, headReversed: true
     it "when [reversed = true, headReversed = false]", ->
       set cursor: [2, 3]
-      # FIXME: changing `2 k` to `k k` spec fail
-      ensure "l l l 2 k", cursor: [[0, 7], [1, 0], [2, 7]], selectedTextOrdered: selectedBlockTexts
+      ensure "l l l k k", cursor: [[0, 7], [1, 0], [2, 7]], selectedTextOrdered: selectedBlockTexts
       ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true, headReversed: false
 
   # [FIXME] not appropriate put here, re-consider all spec file layout later.

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -1,7 +1,7 @@
 {getVimState, TextData} = require './spec-helper'
 swrap = require '../lib/selection-wrapper'
 
-fdescribe "Visual Blockwise", ->
+describe "Visual Blockwise", ->
   [set, ensure, keystroke, editor, editorElement, vimState] = []
   textInitial = """
     01234567890123456789
@@ -80,6 +80,7 @@ fdescribe "Visual Blockwise", ->
       when 'top' then first
       when 'bottom' then last
     bs = vimState.getLastBlockwiseSelection()
+
     expect(bs.getHeadSelection()).toBe head
     tail = switch o.tail
       when 'top' then first
@@ -402,6 +403,36 @@ fdescribe "Visual Blockwise", ->
       it 'case-5', -> ensureCharacterwiseWasRestored('v l 3 k')
       it 'case-6', -> ensureCharacterwiseWasRestored('v 2 l 3 k')
       it 'case-7', -> set cursor: [5, 0]; ensureCharacterwiseWasRestored('v 5 l 3 k')
+
+  describe "keep goalColumn", ->
+    selectedBlockTexts = []
+    beforeEach ->
+      selectedBlockTexts = ["3456", "", "DEFG"]
+      set text: """
+        012345678
+
+        ABCDEFGHI\n
+        """
+      ensure "ctrl-v", mode: ['visual', 'blockwise']
+
+    it "when [reversed = false, headReversed = false]", ->
+      set cursor: [0, 3]
+      ensure "l l l j j", cursor: [[0, 7], [1, 0], [2, 7]], selectedTextOrdered: selectedBlockTexts
+      ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false, headReversed: false
+    it "when [reversed = true, headReversed = true]", ->
+      set cursor: [2, 6]
+      ensure "h h h k k", cursor: [[0, 3], [1, 0], [2, 3]], selectedTextOrdered: selectedBlockTexts
+      ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true, headReversed: true
+    it "when [reversed = false, headReversed = true]", ->
+      set cursor: [0, 6]
+      # FIXME: changing `2 j` to `j j` spec fail
+      ensure "h h h 2 j", cursor: [[0, 3], [1, 0], [2, 3]], selectedTextOrdered: selectedBlockTexts
+      ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false, headReversed: true
+    it "when [reversed = true, headReversed = false]", ->
+      set cursor: [2, 3]
+      # FIXME: changing `2 k` to `k k` spec fail
+      ensure "l l l 2 k", cursor: [[0, 7], [1, 0], [2, 7]], selectedTextOrdered: selectedBlockTexts
+      ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true, headReversed: false
 
   # [FIXME] not appropriate put here, re-consider all spec file layout later.
   describe "gv feature", ->

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -1,7 +1,7 @@
 {getVimState, TextData} = require './spec-helper'
 swrap = require '../lib/selection-wrapper'
 
-describe "Visual Blockwise", ->
+fdescribe "Visual Blockwise", ->
   [set, ensure, keystroke, editor, editorElement, vimState] = []
   textInitial = """
     01234567890123456789
@@ -89,9 +89,13 @@ describe "Visual Blockwise", ->
     for s in others
       expect(bs.getHeadSelection()).not.toBe s
       expect(bs.getTailSelection()).not.toBe s
+
     if o.reversed?
+      expect(bs.isReversed()).toBe o.reversed
+
+    if o.headReversed?
       for s in selections
-        expect(s.isReversed()).toBe o.reversed
+        expect(s.isReversed()).toBe o.headReversed
 
   beforeEach ->
     getVimState (state, vimEditor) ->
@@ -230,16 +234,16 @@ describe "Visual Blockwise", ->
     describe 'o', ->
       it "change blockwiseHead to opposite side and reverse selection", ->
         keystroke 'o'
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
         keystroke 'o'
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
     describe 'capital O', ->
       it "reverse each selection", ->
         keystroke 'O'
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: true
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: true
         keystroke 'O'
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
 
   describe "shift from characterwise to blockwise", ->
     describe "when selection is not reversed", ->
@@ -258,7 +262,7 @@ describe "Visual Blockwise", ->
             '+'
             'C'
           ]
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
 
       it 'case-2', ->
         ensure 'h 3 j ctrl-v',
@@ -269,7 +273,7 @@ describe "Visual Blockwise", ->
             '-+'
             '-C'
           ]
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: true
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: true
 
       it 'case-3', ->
         ensure '2 h 3 j ctrl-v',
@@ -280,7 +284,7 @@ describe "Visual Blockwise", ->
             '--+'
             '--C'
           ]
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: true
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: true
 
       it 'case-4', ->
         ensure 'l 3 j ctrl-v',
@@ -291,7 +295,7 @@ describe "Visual Blockwise", ->
             '++'
             'C-'
           ]
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
       it 'case-5', ->
         ensure '2 l 3 j ctrl-v',
           mode: ['visual', 'blockwise']
@@ -301,7 +305,7 @@ describe "Visual Blockwise", ->
             '+++'
             'C--'
           ]
-        ensureBlockwiseSelection head: 'bottom', tail: 'top', reversed: false
+        ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
 
     describe "when selection is reversed", ->
       beforeEach ->
@@ -319,7 +323,7 @@ describe "Visual Blockwise", ->
             '+'
             'C'
           ]
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
       it 'case-2', ->
         ensure 'h 3 k ctrl-v',
@@ -330,7 +334,7 @@ describe "Visual Blockwise", ->
             '-+'
             '-C'
           ]
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
       it 'case-3', ->
         ensure '2 h 3 k ctrl-v',
@@ -341,7 +345,7 @@ describe "Visual Blockwise", ->
             '--+'
             '--C'
           ]
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: true
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
       it 'case-4', ->
         ensure 'l 3 k ctrl-v',
@@ -352,7 +356,7 @@ describe "Visual Blockwise", ->
             '++'
             'C-'
           ]
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: false
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: false
 
       it 'case-5', ->
         ensure '2 l 3 k ctrl-v',
@@ -363,7 +367,7 @@ describe "Visual Blockwise", ->
             '+++'
             'C--'
           ]
-        ensureBlockwiseSelection head: 'top', tail: 'bottom', reversed: false
+        ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: false
 
   describe "shift from blockwise to characterwise", ->
     preserveSelection = ->


### PR DESCRIPTION
Related #667

Dumps what I'm thinking now( will update during working  ).
:tada: Let's break :bomb: existing working code to move forward further.  

# What I'll get

This issue is **super heavy**, but when finished I'll get following :gift:.

- Code consistency
- Can uniformly handle `normal-mode` vs `visual-mode` motion/text-object
- Less `visual-mode` special handling code.
- `visual-mode` can select new-line at right of EOL( pure-Vim compatibility )
- Can remove dirty cursor position translation in cursorStyleManager, it just show cursor at saved-selection-properties.
- No longer need move selection-end-to-left to normalize `visual-mode`'s cursor position, instead just set cursor position to preserved selection properties.

# What to achieve in behavioral-wise?

In `visual-mode.characterwise`, `l` at end of line select new-line and `d` can delete that newline result in two line concatenated.

# Spec

- Atom have multiple-selection
- vmp in `visual-mode` independently keep selection property by each selection.
- selection property is used to move cursor in `vL` and in other places.
- In operator, text-object, there is possibility to multiply selection from single-selection during operation(e.g. occurrence).
  - Even in this case selection-properties must be available for that newly created selection.
- When vmp enter `vC` mode, it select-right(one column or more if `atomicSoftTabs` enabled)
- When vmp escape `vC` to `normal-mode`, it move selection end to left.
  - If selection was reversed, this has no effect, since cursor is set to start of selection.
- When entering `vC` mode at blank-row, it select new-line.
  - Since cursor is already at EOL.
  - At this state selection property is hast to be saved at EOL position, not at column 0 of next-line of actually selected-line.
- In `normal-mode`, cursor must not placed at EOL except blank line.
- In `vC` mode, cursor can move to EOL and select-right from that place result in new-line selected.
- When new-line selected, cursor is **actually** at column 0 of next line of visually-selected-line(it's atoms selection nature).
  - But in vmp, it save selection prop at EOL, cursor-style-manager shows cursor at selection prop position
  - So when `vC` select newline, cursor is shown up at right of EOL(as like in pure-Vim).
- in `vL` mode, cursor range is basically range of `start=[startRow, 0], end=[endRow, 0]`.
- when escaped from `vL` to normal, it restore preserved-selection-prop.
- Atom's nature not allowing cursor move independently from selection, so we can't move cursor in `vL` state.
  - vmp restore cursor position from prop( I call this as **normalization** )
  - Motion require no special care for `visual-mode` by move cursor from this normalized position.
  - After movement finished, motion save selection-prop then re-select `vL` wise-ly.
  - As result, you see cursor moved in `vL` mode
- I cannot think abount `vB` mode now, let it break.

# TODO

- save selection prop in visual mode
- update selection-prop unless selection have corresponding prop
- selection prop is saved as select-end-move-lefted state so that normalized cursor position become equivalent to normal-mode cursor position.
- Since `vC` allow cursor positioned at EOL, when returned to `normal-mode`
  - it restore cursor position from saved-prop
  - additionally adjust cursor to one column left from EOL if cursor is at EOL.
- Cursor style manager just show cursor at property-position but it adjust cursor not showing at EOL exceeding position.
  - Since selection-prop is not clipped by actual buffer-position, it's column can exceed EOL(impossible position).
  - In such case, cursor-style-manager clip selection prop so that cursor appear at possibile position.
  - Don't clip selection-prop itself, since it's can be column `Infinity` when `$ v`, and this `goalColumn` should be maintained as long as motion is vertical-movement.
- Care `wrapLeftRightMotion` situation.
- Make sure work with `editor.atomicSoftTabs` set to `true` and `false`.
