### PR TITLE
no longer use HTMLElement for search-input for easy-dev by hot-reload-package

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -629,17 +629,6 @@ getRangeByTranslatePointAndClip = (editor, range, which, direction) ->
     when 'end'
       new Range(range.start, newPoint)
 
-# Reloadable registerElement
-registerElement = (name, options) ->
-  element = document.createElement(name)
-  # if constructor is HTMLElement, we haven't registerd yet
-  if element.constructor is HTMLElement
-    Element = document.registerElement(name, options)
-  else
-    Element = element.constructor
-    Element.prototype = options.prototype if options.prototype?
-  Element
-
 getPackage = (name, fn) ->
   new Promise (resolve) ->
     if atom.packages.isPackageActive(name)
@@ -845,7 +834,6 @@ module.exports = {
   isIncludeFunctionScopeForRow
   detectScopeStartPositionForScope
   getBufferRows
-  registerElement
   smartScrollToBufferPosition
   matchScopes
   moveCursorDownBuffer

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -7,7 +7,7 @@ _ = require 'underscore-plus'
 
 settings = require './settings'
 HoverManager = require './hover-manager'
-SearchInputElement = require './search-input'
+SearchInput = require './search-input'
 {
   getVisibleEditors
   matchScopes
@@ -67,9 +67,7 @@ class VimState
     @occurrenceManager = new OccurrenceManager(this)
     @mutationManager = new MutationManager(this)
     @flashManager = new FlashManager(this)
-
-    @searchInput = new SearchInputElement().initialize(this)
-
+    @searchInput = new SearchInput(this)
     @operationStack = new OperationStack(this)
     @cursorStyleManager = new CursorStyleManager(this)
     @blockwiseSelections = []


### PR DESCRIPTION
Related somewhat to #717, But this PR isnt to solve that issue( since I can't reproduce it in the first place ).

I don't want to use HTMLElement in vmp code for easy-dev to reload package by `vim-mode-plus:reload-packages` command which is available in dev-mode.

Using custom HTML make hot reload impossible. So make search-input as normal class instance which hold mini-editor as `this.container` instance var.