### PR TITLE
Auto Indent On Paste (Atom setting) not respected with put from vim registers

### DIFF
--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -635,7 +635,8 @@ class PutBeforeWithAutoIndent extends PutBefore
     # varFortyTwo: value
     actualIndent = Number.MAX_SAFE_INTEGER
     for bufferRow in [newRange.start.row..newRange.end.row - 1]
-      actualIndent = Math.min(actualIndent, getIndentLevelForBufferRow(@editor, bufferRow))
+      if @editor.lineTextForBufferRow(bufferRow) isnt ''
+        actualIndent = Math.min(actualIndent, getIndentLevelForBufferRow(@editor, bufferRow))
 
     indentDelta = neededIndent - actualIndent
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -638,6 +638,9 @@ class PutBeforeWithAutoIndent extends PutBefore
       if @editor.lineTextForBufferRow(bufferRow) isnt ''
         actualIndent = Math.min(actualIndent, getIndentLevelForBufferRow(@editor, bufferRow))
 
+    # The user put blank lines only, prevent autoIndent
+    return newRange if actualIndent is Number.MAX_SAFE_INTEGER
+
     indentDelta = neededIndent - actualIndent
 
     if indentDelta > 0

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -614,23 +614,43 @@ class PutBefore extends Operator
       selection.insertText("\n") unless @isMode('visual', 'linewise')
       newRange = selection.insertText(text)
 
-    if @editor.autoIndentOnPaste
-      neededIndent = @editor.suggestedIndentForBufferRow(newRange.start.row)
-      actualIndent = getIndentLevelForBufferRow(@editor, newRange.start.row)
-      indentDelta = neededIndent - actualIndent
-
-      if indentDelta > 0
-        indentText = @editor.buildIndentString(indentDelta)
-        for bufferRow in [newRange.start.row..newRange.end.row - 1]
-          insertTextAtBufferPosition(@editor, [bufferRow, 0], indentText)
-      else if indentDelta < 0
-        charsToRemove = @editor.buildIndentString(Math.abs(indentDelta)).length
-        for bufferRow in [newRange.start.row..newRange.end.row - 1]
-          @editor.setTextInBufferRange([[bufferRow, 0], [bufferRow, charsToRemove]], '')
-
     return newRange
 
 class PutAfter extends PutBefore
+  @extend()
+  location: 'after'
+
+class PutBeforeWithAutoIndent extends PutBefore
+  @extend()
+
+  pasteLinewise: (selection, text) ->
+    newRange = super(selection, text)
+
+    neededIndent = @editor.suggestedIndentForBufferRow(newRange.start.row)
+
+    # We must calculate the min here to ensure we're not deleting non-space characters from the line.
+    # This occurs if the register contents has greater indentation on the first line than the others,
+    # such as:
+    #      varOne: value
+    # varFortyTwo: value
+    actualIndent = Number.MAX_SAFE_INTEGER
+    for bufferRow in [newRange.start.row..newRange.end.row - 1]
+      actualIndent = Math.min(actualIndent, getIndentLevelForBufferRow(@editor, bufferRow))
+
+    indentDelta = neededIndent - actualIndent
+
+    if indentDelta > 0
+      indentText = @editor.buildIndentString(indentDelta)
+      for bufferRow in [newRange.start.row..newRange.end.row - 1]
+        insertTextAtBufferPosition(@editor, [bufferRow, 0], indentText)
+    else if indentDelta < 0
+      charsToRemove = @editor.buildIndentString(Math.abs(indentDelta)).length
+      for bufferRow in [newRange.start.row..newRange.end.row - 1]
+        @editor.setTextInBufferRange([[bufferRow, 0], [bufferRow, charsToRemove]], '')
+
+    return newRange
+
+class PutAfterWithAutoIndent extends PutBeforeWithAutoIndent
   @extend()
   location: 'after'
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -616,7 +616,7 @@ class PutBefore extends Operator
 
     if @editor.autoIndentOnPaste
       neededIndent = @editor.suggestedIndentForBufferRow(newRange.start.row)
-      actualIndent = getIndentLevelForBufferRow(@editor, newRange.start.row);
+      actualIndent = getIndentLevelForBufferRow(@editor, newRange.start.row)
       indentDelta = neededIndent - actualIndent
 
       if indentDelta > 0

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1040,6 +1040,42 @@ describe "Operator general", ->
           }
           """
 
+    describe "with multiple linewise contents with blanks and putting with auto indent", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.packages.activatePackage('language-javascript')
+        runs ->
+          indentText = editor.buildIndentString(1)
+          set
+            grammar: 'source.js'
+            textC: """
+            if (1) {
+            #{editor.buildIndentString(1)}|if (2) {
+            #{editor.buildIndentString(1)}}
+            }
+            """
+            register: '"': {text: """
+            if(3) {
+            #{editor.buildIndentString(1)}abc
+            #{''}
+            #{editor.buildIndentString(1)}def
+            }
+            """, type: 'linewise'}
+
+      it "inserts the contents of the default register", ->
+        ensureOperation 'vim-mode-plus:put-after-with-auto-indent',
+          textC: """
+          if (1) {
+          #{editor.buildIndentString(1)}if (2) {
+          #{editor.buildIndentString(2)}|if(3) {
+          #{editor.buildIndentString(3)}abc
+          #{editor.buildIndentString(2)}
+          #{editor.buildIndentString(3)}def
+          #{editor.buildIndentString(2)}}
+          #{editor.buildIndentString(1)}}
+          }
+          """
+
     describe "pasting twice", ->
       beforeEach ->
         set

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -287,6 +287,13 @@ class VimEditor
       method = 'ensure' + _.capitalize(_.camelize(name))
       this[method](options[name])
 
+  ensureOperation: (operation, options) =>
+    atom.commands.dispatch(atom.views.getView(@editor), operation)
+    
+    for name in ensureOptionsOrdered when options[name]?
+      method = 'ensure' + _.capitalize(_.camelize(name))
+      this[method](options[name])
+
   ensureText: (text) ->
     expect(@editor.getText()).toEqual(text)
 


### PR DESCRIPTION
Hi, thanks for all of your hard work on this project!

I'm running into a discrepancy between normal Atom behavior and vim-mode-plus behavior. Given some sample code with a few levels of indentation:

```js
if (someCondition) {
  if (otherCondition) {

  }
}
console.log('hi');
```

if I cut/copy the `console.log` line, go into the inner-most block, and paste, Atom follows the `Editor/Auto Indent On Paste` setting and I end up with

```js
if (someCondition) {
  if (otherCondition) {
    console.log('hi');
  }
}
```

If I do the same thing with Vim keybindings `dd` and then `p` (or `P`), the indent level from the original line is maintained:

```js
if (someCondition) {
  if (otherCondition) {
console.log('hi');
  }
}
```

Standalone vim puts the line in the expected/desired spot. Is there a way to make vim-mode-plus follow this behavior as well?