### PR TITLE
Automatically adjust indentation level when inserting newlines

### DIFF
--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -187,7 +187,7 @@ class InsertAboveWithNewline extends ActivateInsertMode
 
   adjustIndent: ->
     currentRow = @editor.getCursorBufferPosition().row
-    if currentRow > 0 and @editor.lineTextForBufferRow(currentRow - 1) == ''
+    if currentRow > 0 and @editor.lineTextForBufferRow(currentRow - 1) is ''
       @editor.autoIndentBufferRow(currentRow)
 
   mutateText: ->

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -185,8 +185,17 @@ class InsertAboveWithNewline extends ActivateInsertMode
 
     lastCursor.setBufferPosition(cursorPosition)
 
+  adjustIndentLevel: ->
+    newBufferLine = @editor.getCursorBufferPosition().row
+    indentText = @editor.buildIndentString(@editor.suggestedIndentForBufferRow(newBufferLine))
+    currentText = @editor.lineTextForBufferRow(newBufferLine)
+    @editor.setTextInBufferRange([[newBufferLine, 0], [newBufferLine, currentText.length]], indentText)
+    @editor.setCursorBufferPosition([newBufferLine, indentText.length])
+
   mutateText: ->
     @editor.insertNewlineAbove()
+    if @editor.autoIndent
+      @adjustIndentLevel()
 
   repeatInsert: (selection, text) ->
     selection.insertText(text.trimLeft(), autoIndent: true)
@@ -195,6 +204,8 @@ class InsertBelowWithNewline extends InsertAboveWithNewline
   @extend()
   mutateText: ->
     @editor.insertNewlineBelow()
+    if @editor.autoIndent
+      @adjustIndentLevel()
 
 # Advanced Insertion
 # -------------------------

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -185,17 +185,14 @@ class InsertAboveWithNewline extends ActivateInsertMode
 
     lastCursor.setBufferPosition(cursorPosition)
 
-  adjustIndentLevel: ->
-    newBufferLine = @editor.getCursorBufferPosition().row
-    indentText = @editor.buildIndentString(@editor.suggestedIndentForBufferRow(newBufferLine))
-    currentText = @editor.lineTextForBufferRow(newBufferLine)
-    @editor.setTextInBufferRange([[newBufferLine, 0], [newBufferLine, currentText.length]], indentText)
-    @editor.setCursorBufferPosition([newBufferLine, indentText.length])
+  adjustIndent: ->
+    currentRow = @editor.getCursorBufferPosition().row
+    if currentRow > 0 and @editor.lineTextForBufferRow(currentRow - 1) == ''
+      @editor.autoIndentBufferRow(currentRow)
 
   mutateText: ->
     @editor.insertNewlineAbove()
-    if @editor.autoIndent
-      @adjustIndentLevel()
+    @adjustIndent() if @editor.autoIndent
 
   repeatInsert: (selection, text) ->
     selection.insertText(text.trimLeft(), autoIndent: true)
@@ -204,8 +201,7 @@ class InsertBelowWithNewline extends InsertAboveWithNewline
   @extend()
   mutateText: ->
     @editor.insertNewlineBelow()
-    if @editor.autoIndent
-      @adjustIndentLevel()
+    @adjustIndent() if @editor.autoIndent
 
 # Advanced Insertion
 # -------------------------

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -300,7 +300,7 @@ describe "Operator ActivateInsertMode family", ->
         __def
         __def
         __012
-        __de|f
+        ____de|f
         ____4spaces\n
         """
 

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -300,7 +300,7 @@ describe "Operator ActivateInsertMode family", ->
         __def
         __def
         __012
-        ____de|f
+        __de|f
         ____4spaces\n
         """
 


### PR DESCRIPTION
If the editor setting `Editor/Auto Indent` is turned on, we can optimize cursor position after newlines are inserted.

Before pull request (cursor denoted by `|` with indent level of 4 spaces)

```javascript
if (something) {

|

}
```

Pressing `O` results in

```javascript
if (something) {

|


}
```

After pull request:

```javascript
if (something) {

|

}
```

Pressing `O` results in

```javascript
if (something) {

    |


}
```

The change to the test reflects what the behavior in Vim does as far as I can tell. Let me know if I'm misinterpreting something.