### PR TITLE
While demo-mode is active, postpone destroying operator-flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.88.0: WIP
+- Improve: Better integration with `demo-mode` package
+  - Postpone destroying operator-flash while demo-mode's hover indicator is displayed.
 # 0.87.0:
 - New: #732 Add integration with `demo-mode` package.
   - `demo-mode` is new Atom package I've released recently, it was originally developed as part of vim-mode-plus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.88.0: WIP
 - Improve: Better integration with `demo-mode` package
   - Postpone destroying operator-flash while demo-mode's hover indicator is displayed.
+- Improve: When undo/redoing occurrence operation, flash was suppressed when all occurrence start and end with same column, but now flashed.
+
 # 0.87.0:
 - New: #732 Add integration with `demo-mode` package.
   - `demo-mode` is new Atom package I've released recently, it was originally developed as part of vim-mode-plus.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -90,8 +90,8 @@ module.exports =
       vimState.destroy()
     VimState.clear()
 
-  subscribe: (arg) ->
-    @subscriptions.add(arg)
+  subscribe: (args...) ->
+    @subscriptions.add(args...)
 
   unsubscribe: (arg) ->
     @subscriptions.remove(arg)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -211,10 +211,11 @@ module.exports =
     @subscribe new Disposable =>
       @statusBarManager.detach()
 
-  consumeDemoMode: ({onWillAddItem, onDidStart, onDidStop}) ->
+  consumeDemoMode: ({onWillAddItem, onDidStart, onDidStop, onDidRemoveHover}) ->
     @subscribe(
       onDidStart(-> globalState.set('demoModeIsActive', true))
       onDidStop(-> globalState.set('demoModeIsActive', false))
+      onDidRemoveHover(@destroyAllDemoModeFlasheMarkers.bind(this))
       onWillAddItem(({item, event}) =>
         if event.binding.command.startsWith('vim-mode-plus:')
           commandElement = item.getElementsByClassName('command')[0]
@@ -226,6 +227,10 @@ module.exports =
         item.appendChild(element)
       )
     )
+
+  destroyAllDemoModeFlasheMarkers: ->
+    VimState.forEach (vimState) ->
+      vimState.flashManager.destroyDemoModeMarkers()
 
   getKindForCommand: (command) ->
     if command.startsWith('vim-mode-plus')

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -84,7 +84,7 @@ class Undo extends MiscCommand
       ranges.length > 1 and ranges.every(isSingleLineRange)
 
     if newRanges.length > 0
-      return if @isMultipleAndAllRangeHaveSameColumnRanges(newRanges)
+      return if @isMultipleAndAllRangeHaveSameColumnAndConsecutiveRows(newRanges)
       newRanges = newRanges.map (range) => humanizeBufferRange(@editor, range)
       newRanges = @filterNonLeadingWhiteSpaceRange(newRanges)
 
@@ -93,7 +93,7 @@ class Undo extends MiscCommand
       else
         @flash(newRanges, type: 'undo-redo')
     else
-      return if @isMultipleAndAllRangeHaveSameColumnRanges(oldRanges)
+      return if @isMultipleAndAllRangeHaveSameColumnAndConsecutiveRows(oldRanges)
 
       if isMultipleSingleLineRanges(oldRanges)
         oldRanges = @filterNonLeadingWhiteSpaceRange(oldRanges)
@@ -103,12 +103,25 @@ class Undo extends MiscCommand
     ranges.filter (range) =>
       not isLeadingWhiteSpaceRange(@editor, range)
 
-  isMultipleAndAllRangeHaveSameColumnRanges: (ranges) ->
+  # [TODO] Improve further by checking oldText, newText?
+  # [Purpose of this is function]
+  # Suppress flash when undo/redoing toggle-comment while flashing undo/redo of occurrence operation.
+  # This huristic approach never be perfect.
+  # Ultimately cannnot distinguish occurrence operation.
+  isMultipleAndAllRangeHaveSameColumnAndConsecutiveRows: (ranges) ->
     return false if ranges.length <= 1
 
-    {start, end} = ranges[0]
-    startColumn = start.column
-    endColumn = end.column
+    {start: {column: startColumn}, end: {column: endColumn}} = ranges[0]
+    previousRow = null
+    for range in ranges
+      {start, end} = range
+      unless ((start.column is startColumn) and (end.column is endColumn))
+        return false
+
+      if previousRow? and (previousRow + 1 isnt start.row)
+        return false
+      previousRow = start.row
+    return true
 
     ranges.every ({start, end}) ->
       (start.column is startColumn) and (end.column is endColumn)

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -102,7 +102,6 @@ atom-text-editor.vim-mode-plus.insert-mode.replace,
   // flashOnOperate
 .flash-animation(vim-mode-plus-flash-operator, @flash-base-color);
 .flash-animation(vim-mode-plus-flash-operator-long, @flash-base-color);
-.flash-animation(vim-mode-plus-flash-operator-demo, @flash-base-color);
 .flash-animation(vim-mode-plus-flash-operator-occurrence, @flash-added-color);
 .flash-animation(vim-mode-plus-flash-operator-remove-occurrence, @flash-removed-color);
 

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -126,7 +126,6 @@ atom-text-editor .vim-mode-plus-flash {
   // flashOnOperate
   &.operator .region { .flash(vim-mode-plus-flash-operator, .3s)}
   &.operator-long .region { .flash(vim-mode-plus-flash-operator, .8s)}
-  &.operator-demo .region { .flash(vim-mode-plus-flash-operator, 2.0s)}
   &.operator-occurrence .region { .flash(vim-mode-plus-flash-operator-occurrence, .8s)}
   &.operator-remove-occurrence .region { .flash(vim-mode-plus-flash-operator-remove-occurrence, .8s)}
 
@@ -134,6 +133,15 @@ atom-text-editor .vim-mode-plus-flash {
   &.undo-redo .region { .flash(vim-mode-plus-flash-undo-redo, .5s)}
   &.undo-redo-multiple-changes .region { .flash(vim-mode-plus-flash-undo-redo-multiple-changes, .5s)}
   &.undo-redo-multiple-delete .region { .flash(vim-mode-plus-flash-undo-redo-multiple-delete, .5s)}
+
+  // used for demo-mode integration to stop flash while demo-mode's hover is active
+  &.operator-demo .region { background: @flash-base-color }
+  &.operator-long-demo .region { background: @flash-base-color }
+  &.operator-occurrence-demo .region { background: @flash-added-color }
+  &.operator-remove-occurrence-demo .region { background: @flash-removed-color }
+  &.undo-redo-demo .region { background: @flash-base-color }
+  &.undo-redo-multiple-changes-demo .region { background: @flash-added-color }
+  &.undo-redo-multiple-delete-demo .region { background: @flash-removed-color }
 
   &.search .region {
     .flash(vim-mode-plus-flash-search, .5s);


### PR DESCRIPTION
depends on new demo-mode service ‘onDidRemoveHover’.

Fix #735 