### PR TITLE
fix multiselection cursor problem

### DIFF
--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -67,7 +67,10 @@ class CursorStyleManager
       screenPosition = @editor.screenPositionForBufferPosition(bufferPosition)
       {row, column} = screenPosition.traversalFrom(cursor.getScreenPosition())
     else
-      {row, column} = bufferPosition.traversalFrom(cursor.getBufferPosition())
+      if cursor.isAtBeginningOfLine()
+        {row, column} = new Point(-1, 0)
+      else
+        {row, column} = new Point(0, -1)
 
     style = domNode.style
     style.setProperty('top', "#{@lineHeight * row}px") if row


### PR DESCRIPTION
This fixes an issue with multiselection. I have experienced it in another [package](https://atom.io/packages/token-navigation) that I created. The fix is picked up from a commit (0e4e722fddfbd65116389772704b997e4a1108ee) from previous release that I found git-bisecting.

From what I saw this didn't break anything, but I didn't fully understand the code so I might be missing something.