### PR TITLE
new updateRegisterOnChangeOrSubstitute config, default true

### DIFF
--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -303,7 +303,7 @@ class Change extends ActivateInsertMode
     #   }
     isLinewiseTarget = swrap.detectWise(@editor) is 'linewise'
     for selection in @editor.getSelections()
-      @setTextToRegisterForSelection(selection)
+      @setTextToRegisterForSelection(selection) if @getConfig('updateRegisterOnChangeOrSubstitute')
       if isLinewiseTarget
         selection.insertText("\n", autoIndent: true)
         selection.cursor.moveLeft()

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -113,6 +113,12 @@ module.exports = new Settings 'vim-mode-plus',
     """
   groupChangesWhenLeavingInsertMode: true
   useClipboardAsDefaultRegister: true
+  updateRegisterOnChangeOrSubstitute:
+    default: true
+    description: """
+    When set to `false` any `change` or `substitute` operation no longer change register content<br>
+    Affects `c`, `C`, `s`, `S`.
+    """
   startInInsertMode: false
   startInInsertModeScopes:
     default: []

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -292,6 +292,14 @@ class VimEditor
       method = 'ensure' + _.capitalize(_.camelize(name))
       this[method](options[name])
 
+  bindEnsureOption: (optionsBase) =>
+    (keystroke, options) =>
+      intersectingOptions = _.intersection(_.keys(options), _.keys(optionsBase))
+      if intersectingOptions.length
+        throw new Error("conflict with bound options #{inspect(intersectingOptions)}")
+
+      @ensure(keystroke, _.defaults(_.clone(options), optionsBase))
+
   ensureByDispatch: (command, options) =>
     dispatch(atom.views.getView(@editor), command)
     for name in ensureOptionsOrdered when options[name]?


### PR DESCRIPTION
Fix #739

- By default `c`, `s`, `C`, `S` update register content, but I'm not sure this default behavior is useful.
- This PR add config option to change this default behavior.
- New `updateRegisterOnChangeOrSubstitute` config, default `true`
- when set to `false`, `c`, `s`, `C`, `S` no longer update register content.
