### PR TITLE
Change order characterwise

### DIFF
--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -8,7 +8,7 @@ _ = require 'underscore-plus'
   limitNumber
   toggleCaseForCharacter
   splitTextByNewLine
-  changeOrderOfArgumentInTextBy
+  sortArgumentsInTextBy
 } = require './utils'
 swrap = require './selection-wrapper'
 Base = require './base'
@@ -630,7 +630,7 @@ class ChangeOrder extends TransformString
     if @target.isLinewise()
       @getNewList(splitTextByNewLine(text)).join("\n") + "\n"
     else
-      changeOrderOfArgumentInTextBy(text, (args) => @getNewList(args))
+      sortArgumentsInTextBy(text, (args) => @getNewList(args))
 
   changeTextOrderWithKeepingSplitter: (text) ->
 

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -650,6 +650,11 @@ class SplitByArgumentsWithRemoveSeparator extends SplitByArguments
   @registerToSelectList()
   keepSeparator: false
 
+class SplitByArgumentsOfInnerAnyPair extends SplitByArguments
+  @extend()
+  @registerToSelectList()
+  target: "InnerAnyPair"
+
 class ChangeOrder extends TransformString
   @extend(false)
   getNewText: (text) ->
@@ -663,6 +668,10 @@ class Reverse extends ChangeOrder
   @registerToSelectList()
   getNewList: (rows) ->
     rows.reverse()
+
+class ReverseInnerAnyPair extends Reverse
+  @extend()
+  target: "InnerAnyPair"
 
 class Rotate extends ChangeOrder
   @extend()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -8,7 +8,7 @@ _ = require 'underscore-plus'
   limitNumber
   toggleCaseForCharacter
   splitTextByNewLine
-  splitAndJoinBy
+  changeOrderOfArgumentInTextBy
 } = require './utils'
 swrap = require './selection-wrapper'
 Base = require './base'
@@ -630,11 +630,7 @@ class ChangeOrder extends TransformString
     if @target.isLinewise()
       @getNewList(splitTextByNewLine(text)).join("\n") + "\n"
     else
-      if "," in text
-        pattern = /,\s+/
-      else
-        pattern = /\s+/
-      splitAndJoinBy text, pattern, (items) => @getNewList(items)
+      changeOrderOfArgumentInTextBy(text, (args) => @getNewList(args))
 
   changeTextOrderWithKeepingSplitter: (text) ->
 

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -640,6 +640,20 @@ class Reverse extends ChangeOrder
   getNewList: (rows) ->
     rows.reverse()
 
+class Rotate extends ChangeOrder
+  @extend()
+  @registerToSelectList()
+  getNewList: (rows) ->
+    rows.unshift(rows.pop())
+    rows
+
+class RotateBackwards extends ChangeOrder
+  @extend()
+  @registerToSelectList()
+  getNewList: (rows) ->
+    rows.push(rows.shift())
+    rows
+
 class Sort extends ChangeOrder
   @extend()
   @registerToSelectList()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -8,6 +8,7 @@ _ = require 'underscore-plus'
   limitNumber
   toggleCaseForCharacter
   splitTextByNewLine
+  splitAndJoinBy
 } = require './utils'
 swrap = require './selection-wrapper'
 Base = require './base'
@@ -625,37 +626,40 @@ class SplitStringWithKeepingSplitter extends SplitString
 
 class ChangeOrder extends TransformString
   @extend(false)
-  wise: 'linewise'
-
   getNewText: (text) ->
-    @getNewRows(splitTextByNewLine(text)).join("\n") + "\n"
+    if @target.isLinewise()
+      @getNewList(splitTextByNewLine(text)).join("\n") + "\n"
+    else
+      if "," in text
+        pattern = /,\s+/
+      else
+        pattern = /\s+/
+      splitAndJoinBy text, pattern, (items) => @getNewList(items)
+
+  changeTextOrderWithKeepingSplitter: (text) ->
 
 class Reverse extends ChangeOrder
   @extend()
   @registerToSelectList()
-  @description: "Reverse lines(e.g reverse selected three line)"
-  getNewRows: (rows) ->
+  getNewList: (rows) ->
     rows.reverse()
 
 class Sort extends ChangeOrder
   @extend()
   @registerToSelectList()
-  @description: "Sort lines alphabetically"
-  getNewRows: (rows) ->
+  getNewList: (rows) ->
     rows.sort()
 
 class SortCaseInsensitively extends ChangeOrder
   @extend()
   @registerToSelectList()
-  @description: "Sort lines alphabetically (case insensitive)"
-  getNewRows: (rows) ->
+  getNewList: (rows) ->
     rows.sort (rowA, rowB) ->
       rowA.localeCompare(rowB, sensitivity: 'base')
 
 class SortByNumber extends ChangeOrder
   @extend()
   @registerToSelectList()
-  @description: "Sort lines numerically"
-  getNewRows: (rows) ->
+  getNewList: (rows) ->
     _.sortBy rows, (row) ->
       Number.parseInt(row) or Infinity

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -777,7 +777,7 @@ splitAndJoinBy = (text, pattern, fn) ->
     result += item + separator
   leadingSpaces + result + trailingSpaces
 
-changeOrderOfArgumentInTextBy = (text, fn) ->
+sortArgumentsInTextBy = (text, fn) ->
   leadingSpaces = trailingSpaces = ''
   start = text.search(/\S/)
   end = text.search(/\s*$/)
@@ -971,6 +971,6 @@ module.exports = {
   humanizeBufferRange
   expandRangeToWhiteSpaces
   splitAndJoinBy
-  changeOrderOfArgumentInTextBy
+  sortArgumentsInTextBy
   scanEditorInDirection
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -786,11 +786,10 @@ changeOrderOfArgumentInTextBy = (text, fn) ->
   trailingSpaces = text[end...] if end isnt -1
   text = text[start...end]
   {tokens, separators} = splitIntoTokensAndSeparators(text)
-  separators.push('')
   items = fn(tokens)
   result = ''
   for [item, separator] in _.zip(items, separators)
-    result += item + separator
+    result += item + (separator ? '')
   leadingSpaces + result + trailingSpaces
 
 splitIntoTokensAndSeparators = (text) ->
@@ -838,15 +837,16 @@ splitIntoTokensAndSeparators = (text) ->
         separator = ''
 
       token += char
-  if token
-    tokens.push(token)
+
+  tokens.push(token) if token
+  separators.push(separator) if separator
 
   if separators.some((separator) -> ',' in separator)
     # When some separator contains `,` treat white-space separator is just part of token.
     # So we move white-space only sparator into tokens by joining mis-separatoed tokens.
     newTokens = []
     newSeparators = []
-    while separators.length
+    while (separators.length and tokens.length)
       separator = separators.shift()
       token = tokens.shift()
       if ',' in separator
@@ -854,7 +854,7 @@ splitIntoTokensAndSeparators = (text) ->
         newSeparators.push(separator)
       else
         tokens.unshift(token + separator + tokens.shift())
-    newTokens.push(tokens.shift())
+    newTokens.push(tokens.shift()) if tokens.length
     tokens = newTokens
     separators = newSeparators
 

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1143,6 +1143,17 @@ describe "Operator general", ->
         text: '\n2\n\n4\n\n'
         cursor: [[1, 0], [3, 0]]
 
+    it "auto indent when replaced with singe new line", ->
+      set
+        textC_: """
+        __a|bc
+        """
+      ensure 'r enter',
+        textC_: """
+        __a
+        __|c
+        """
+
     it "composes properly with motions", ->
       ensure ['2 r', input: 'x'], text: 'xx\nxx\n\n'
 

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1240,7 +1240,7 @@ describe "Operator TransformString", ->
           f\n
           """
 
-  fdescribe "Change Order faimliy: Reverse, Sort, SortCaseInsensitively, SortByNumber", ->
+  describe "Change Order faimliy: Reverse, Sort, SortCaseInsensitively, SortByNumber", ->
     beforeEach ->
       atom.keymaps.add "test",
         'atom-text-editor.vim-mode-plus:not(.insert-mode)':

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1247,6 +1247,44 @@ describe "Operator TransformString", ->
           'g r': 'vim-mode-plus:reverse'
           'g s': 'vim-mode-plus:sort'
           'g S': 'vim-mode-plus:sort-by-number'
+    describe "characterwise target", ->
+      describe "Reverse", ->
+        it "[comma separated] reverse text", ->
+          set textC: "   ( dog, ca|t, fish, rabbit, duck, gopher, squid )"
+          ensure 'g r i (', textC_: "   (| squid, gopher, duck, rabbit, fish, cat, dog )"
+        it "[comma sparated] reverse text", ->
+          set textC: "   ( 'dog ca|t', 'fish rabbit', 'duck gopher squid' )"
+          ensure 'g r i (', textC_: "   (| 'duck gopher squid', 'fish rabbit', 'dog cat' )"
+        it "[space sparated] reverse text", ->
+          set textC: "   ( dog ca|t fish rabbit duck gopher squid )"
+          ensure 'g r i (', textC_: "   (| squid gopher duck rabbit fish cat dog )"
+        it "[comma sparated multi-line] reverse text", ->
+          set textC: """
+            {
+              |1, 2, 3, 4,
+              5, 6,
+              7,
+              8, 9
+            }
+            """
+          ensure 'g r i {',
+            textC: """
+            {
+              9, 8, 7, 6,
+              5, 4,
+              3,
+              2, 1
+            }
+            """
+      describe "Sort", ->
+        it "[comma separated] sort text", ->
+          set textC: "   ( dog, ca|t, fish, rabbit, duck, gopher, squid )"
+          ensure 'g s i (', textC: "   (| cat, dog, duck, fish, gopher, rabbit, squid )"
+      describe "SortByNumber", ->
+        it "[comma separated] sort by number", ->
+          set textC_: "___(9, 1, |10, 5)"
+          ensure 'g S i (', textC_: "___(|1, 5, 9, 10)"
+
     describe "linewise target", ->
       beforeEach ->
         set

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1270,11 +1270,57 @@ describe "Operator TransformString", ->
           ensure 'g r i {',
             textC: """
             {
-              9, 8, 7, 6,
+            |  9, 8, 7, 6,
               5, 4,
               3,
               2, 1
             }
+            """
+        it "[comma sparated multi-line] keep comma followed to last entry", ->
+          set textC: """
+            [
+              |1, 2, 3, 4,
+              5, 6,
+            ]
+            """
+          ensure 'g r i [',
+            textC: """
+            [
+            |  6, 5, 4, 3,
+              2, 1,
+            ]
+            """
+        it "[comma sparated multi-line] aware of nexted pair and quotes and escaped quote", ->
+          set textC: """
+            (
+              |"(a, b, c)", "[( d e f", test(g, h, i),
+              "\\"j, k, l",
+              '\\'m, n', test(o, p),
+            )
+            """
+          ensure 'g r i (',
+            textC: """
+            (
+            |  test(o, p), '\\'m, n', "\\"j, k, l",
+              test(g, h, i),
+              "[( d e f", "(a, b, c)",
+            )
+            """
+        it "[space sparated multi-line] aware of nexted pair and quotes and escaped quote", ->
+          set textC_: """
+            (
+              |"(a, b, c)" "[( d e f"      test(g, h, i)
+              "\\"j, k, l"___
+              '\\'m, n'    test(o, p)
+            )
+            """
+          ensure 'g r i (',
+            textC_: """
+            (
+            |  test(o, p) '\\'m, n'      "\\"j, k, l"
+              test(g, h, i)___
+              "[( d e f"    "(a, b, c)"
+            )
             """
       describe "Sort", ->
         it "[comma separated] sort text", ->

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1240,92 +1240,93 @@ describe "Operator TransformString", ->
           f\n
           """
 
-  describe "Reverse, Sort, SortByNumber", ->
+  fdescribe "Change Order faimliy: Reverse, Sort, SortCaseInsensitively, SortByNumber", ->
     beforeEach ->
       atom.keymaps.add "test",
         'atom-text-editor.vim-mode-plus:not(.insert-mode)':
           'g r': 'vim-mode-plus:reverse'
           'g s': 'vim-mode-plus:sort'
           'g S': 'vim-mode-plus:sort-by-number'
-      set
-        textC: """
-        |z
-
-        10a
-        b
-        a
-
-        5
-        1\n
-        """
-    describe "Reverse", ->
-      it "reverse rows", ->
-        ensure 'g r G',
+    describe "linewise target", ->
+      beforeEach ->
+        set
           textC: """
-          |1
-          5
+          |z
 
-          a
-          b
           10a
-
-          z\n
-          """
-    describe "Sort", ->
-      it "sort rows", ->
-        ensure 'g s G',
-          textC: """
-          |
-
-          1
-          10a
-          5
-          a
-          b
-          z\n
-          """
-    describe "SortByNumber", ->
-      it "sort rows numerically", ->
-        ensure "g S G",
-          textC: """
-          |1
-          5
-          10a
-          z
-
           b
           a
-          \n
+
+          5
+          1\n
           """
+      describe "Reverse", ->
+        it "reverse rows", ->
+          ensure 'g r G',
+            textC: """
+            |1
+            5
 
-  describe "SortCaseInsensitively", ->
-    beforeEach ->
-      atom.keymaps.add "test",
-        'atom-text-editor.vim-mode-plus:not(.insert-mode)':
-          'g s': 'vim-mode-plus:sort-case-insensitively'
-    it "Sort rows case-insensitively", ->
-      set
-        textC: """
-        |apple
-        Beef
-        APPLE
-        DOG
-        beef
-        Apple
-        BEEF
-        Dog
-        dog\n
-        """
+            a
+            b
+            10a
 
-      ensure "g s G",
-        text: """
-        apple
-        Apple
-        APPLE
-        beef
-        Beef
-        BEEF
-        dog
-        Dog
-        DOG\n
-        """
+            z\n
+            """
+      describe "Sort", ->
+        it "sort rows", ->
+          ensure 'g s G',
+            textC: """
+            |
+
+            1
+            10a
+            5
+            a
+            b
+            z\n
+            """
+      describe "SortByNumber", ->
+        it "sort rows numerically", ->
+          ensure "g S G",
+            textC: """
+            |1
+            5
+            10a
+            z
+
+            b
+            a
+            \n
+            """
+      describe "SortCaseInsensitively", ->
+        beforeEach ->
+          atom.keymaps.add "test",
+            'atom-text-editor.vim-mode-plus:not(.insert-mode)':
+              'g s': 'vim-mode-plus:sort-case-insensitively'
+        it "Sort rows case-insensitively", ->
+          set
+            textC: """
+            |apple
+            Beef
+            APPLE
+            DOG
+            beef
+            Apple
+            BEEF
+            Dog
+            dog\n
+            """
+
+          ensure "g s G",
+            text: """
+            apple
+            Apple
+            APPLE
+            beef
+            Beef
+            BEEF
+            dog
+            Dog
+            DOG\n
+            """


### PR DESCRIPTION
Achieve #681

Affect all ChangeOrder child operator(`Reverse`, `Sort` etc)

- Old behavior
  - These operator always works on `linewise` and change order of rows.

- New behavior
  - If target was linewise, change order of rows
  - If target was characterwise change text by split and join.
    - Splitter text is comma or white-space(include "\n"), determined huristically.
