### PR TITLE
Swrap as lazy prop

### DIFF
--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -1,30 +1,14 @@
 _ = require 'underscore-plus'
 Delegato = require 'delegato'
-CSON = null
-path = null
-
-# {
-#   getVimEofBufferPosition
-#   getVimLastBufferRow
-#   getVimLastScreenRow
-#   getWordBufferRangeAndKindAtBufferPosition
-#   getFirstCharacterPositionForBufferRow
-#   getBufferRangeForRowRange
-#   getIndentLevelForBufferRow
-#   scanEditorInDirection
-# } = require './utils'
-
-__$u = null
-$u = ->
-  __$u ?= require('./utils')
-
 settings = require './settings'
 
 [
+  CSON
+  path
   Input
   selectList
   getEditorState  # set by Base.init()
-] = []
+] = [] # set null
 
 VMP_LOADING_FILE = null
 VMP_LOADED_FILES = []
@@ -75,7 +59,7 @@ vimStateMethods = [
 class Base
   Delegato.includeInto(this)
   @delegatesMethods(vimStateMethods..., toProperty: 'vimState')
-  @delegatesProperty('mode', 'submode', 'swrap', toProperty: 'vimState')
+  @delegatesProperty('mode', 'submode', 'swrap', 'utils', toProperty: 'vimState')
 
   constructor: (@vimState, properties=null) ->
     {@editor, @editorElement, @globalState, @swrap} = @vimState
@@ -191,31 +175,31 @@ class Base
     inputUI.focus(options)
 
   getVimEofBufferPosition: ->
-    $u().getVimEofBufferPosition(@editor)
+    @utils.getVimEofBufferPosition(@editor)
 
   getVimLastBufferRow: ->
-    $u().getVimLastBufferRow(@editor)
+    @utils.getVimLastBufferRow(@editor)
 
   getVimLastScreenRow: ->
-    $u().getVimLastScreenRow(@editor)
+    @utils.getVimLastScreenRow(@editor)
 
   getWordBufferRangeAndKindAtBufferPosition: (point, options) ->
-    $u().getWordBufferRangeAndKindAtBufferPosition(@editor, point, options)
+    @utils.getWordBufferRangeAndKindAtBufferPosition(@editor, point, options)
 
   getFirstCharacterPositionForBufferRow: (row) ->
-    $u().getFirstCharacterPositionForBufferRow(@editor, row)
+    @utils.getFirstCharacterPositionForBufferRow(@editor, row)
 
   getBufferRangeForRowRange: (rowRange) ->
-    $u().getBufferRangeForRowRange(@editor, rowRange)
+    @utils.getBufferRangeForRowRange(@editor, rowRange)
 
   getIndentLevelForBufferRow: (row) ->
-    $u().getIndentLevelForBufferRow(@editor, row)
+    @utils.getIndentLevelForBufferRow(@editor, row)
 
   scanForward: (args...) ->
-    $u().scanEditorInDirection(@editor, 'forward', args...)
+    @utils.scanEditorInDirection(@editor, 'forward', args...)
 
   scanBackward: (args...) ->
-    $u().scanEditorInDirection(@editor, 'backward', args...)
+    @utils.scanEditorInDirection(@editor, 'backward', args...)
 
   instanceof: (klassName) ->
     this instanceof Base.getClass(klassName)

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -73,7 +73,7 @@ class Base
   @delegatesProperty('mode', 'submode', 'swrap', toProperty: 'vimState')
 
   constructor: (@vimState, properties=null) ->
-    {@editor, @editorElement, @globalState} = @vimState
+    {@editor, @editorElement, @globalState, @swrap} = @vimState
     @name = @constructor.name
     _.extend(this, properties) if properties?
 

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -13,7 +13,8 @@ path = null
   getIndentLevelForBufferRow
   scanEditorInDirection
 } = require './utils'
-swrap = require './selection-wrapper'
+swrap = null
+
 settings = require './settings'
 
 [
@@ -247,6 +248,7 @@ class Base
       cursor.getBufferPosition()
 
   getCursorPositionForSelection: (selection) ->
+    swrap ?= require './selection-wrapper'
     swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
 
   toString: ->
@@ -364,7 +366,7 @@ class Base
   @registerCommandFromSpec: (name, spec) ->
     {commandScope, commandPrefix, commandName, getClass} = spec
     commandScope ?= 'atom-text-editor'
-    commandName = (commandPrefix ? 'vim-mode-plus') + ':' + _.dasherize(name)
+    commandName ?= (commandPrefix ? 'vim-mode-plus') + ':' + _.dasherize(name)
     atom.commands.add commandScope, commandName, (event) ->
       vimState = getEditorState(@getModel()) ? getEditorState(atom.workspace.getActiveTextEditor())
       if vimState? # Possibly undefined See #85

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -3,16 +3,21 @@ Delegato = require 'delegato'
 CSON = null
 path = null
 
-{
-  getVimEofBufferPosition
-  getVimLastBufferRow
-  getVimLastScreenRow
-  getWordBufferRangeAndKindAtBufferPosition
-  getFirstCharacterPositionForBufferRow
-  getBufferRangeForRowRange
-  getIndentLevelForBufferRow
-  scanEditorInDirection
-} = require './utils'
+# {
+#   getVimEofBufferPosition
+#   getVimLastBufferRow
+#   getVimLastScreenRow
+#   getWordBufferRangeAndKindAtBufferPosition
+#   getFirstCharacterPositionForBufferRow
+#   getBufferRangeForRowRange
+#   getIndentLevelForBufferRow
+#   scanEditorInDirection
+# } = require './utils'
+
+__$u = null
+$u = ->
+  __$u ?= require('./utils')
+
 settings = require './settings'
 
 [
@@ -186,31 +191,31 @@ class Base
     inputUI.focus(options)
 
   getVimEofBufferPosition: ->
-    getVimEofBufferPosition(@editor)
+    $u().getVimEofBufferPosition(@editor)
 
   getVimLastBufferRow: ->
-    getVimLastBufferRow(@editor)
+    $u().getVimLastBufferRow(@editor)
 
   getVimLastScreenRow: ->
-    getVimLastScreenRow(@editor)
+    $u().getVimLastScreenRow(@editor)
 
   getWordBufferRangeAndKindAtBufferPosition: (point, options) ->
-    getWordBufferRangeAndKindAtBufferPosition(@editor, point, options)
+    $u().getWordBufferRangeAndKindAtBufferPosition(@editor, point, options)
 
   getFirstCharacterPositionForBufferRow: (row) ->
-    getFirstCharacterPositionForBufferRow(@editor, row)
+    $u().getFirstCharacterPositionForBufferRow(@editor, row)
 
   getBufferRangeForRowRange: (rowRange) ->
-    getBufferRangeForRowRange(@editor, rowRange)
+    $u().getBufferRangeForRowRange(@editor, rowRange)
 
   getIndentLevelForBufferRow: (row) ->
-    getIndentLevelForBufferRow(@editor, row)
+    $u().getIndentLevelForBufferRow(@editor, row)
 
   scanForward: (args...) ->
-    scanEditorInDirection(@editor, 'forward', args...)
+    $u().scanEditorInDirection(@editor, 'forward', args...)
 
   scanBackward: (args...) ->
-    scanEditorInDirection(@editor, 'backward', args...)
+    $u().scanEditorInDirection(@editor, 'backward', args...)
 
   instanceof: (klassName) ->
     this instanceof Base.getClass(klassName)

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -13,8 +13,6 @@ path = null
   getIndentLevelForBufferRow
   scanEditorInDirection
 } = require './utils'
-swrap = null
-
 settings = require './settings'
 
 [
@@ -72,7 +70,7 @@ vimStateMethods = [
 class Base
   Delegato.includeInto(this)
   @delegatesMethods(vimStateMethods..., toProperty: 'vimState')
-  @delegatesProperty('mode', 'submode', toProperty: 'vimState')
+  @delegatesProperty('mode', 'submode', 'swrap', toProperty: 'vimState')
 
   constructor: (@vimState, properties=null) ->
     {@editor, @editorElement, @globalState} = @vimState
@@ -248,8 +246,7 @@ class Base
       cursor.getBufferPosition()
 
   getCursorPositionForSelection: (selection) ->
-    swrap ?= require './selection-wrapper'
-    swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
+    @swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
 
   toString: ->
     str = @name

--- a/lib/blockwise-selection.coffee
+++ b/lib/blockwise-selection.coffee
@@ -1,8 +1,12 @@
 _ = require 'underscore-plus'
 
 {sortRanges, assertWithException, trimRange} = require './utils'
-swrap = require './selection-wrapper'
 settings = require './settings'
+
+__swrap = null
+swrap = (args...) ->
+  __swrap ?= require './selection-wrapper'
+  __swrap(args...)
 
 class BlockwiseSelection
   editor: null

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -1,6 +1,5 @@
 {Point, Disposable, CompositeDisposable} = require 'atom'
 Delegato = require 'delegato'
-swrap = require './selection-wrapper'
 
 # Display cursor in visual-mode
 # ----------------------------------
@@ -50,7 +49,7 @@ class CursorStyleManager
       @styleDisposables.add @modifyStyle(cursor, cursorNode)
 
   getCursorBufferPositionToDisplay: (selection) ->
-    bufferPosition = swrap(selection).getBufferPositionFor('head', from: ['property'])
+    bufferPosition = @vimState.swrap(selection).getBufferPositionFor('head', from: ['property'])
     if @editor.hasAtomicSoftTabs() and not selection.isReversed()
       screenPosition = @editor.screenPositionForBufferPosition(bufferPosition.translate([0, +1]), clipDirection: 'forward')
       bufferPositionToDisplay = @editor.bufferPositionForScreenPosition(screenPosition).translate([0, -1])

--- a/lib/developer.coffee
+++ b/lib/developer.coffee
@@ -6,11 +6,6 @@ fs = require 'fs-plus'
 Base = require './base'
 generateIntrospectionReport = null
 settings = require './settings'
-__$u = null
-$u = ->
-  __$u ?= require('./utils')
-
-packageScope = 'vim-mode-plus'
 getEditorState = null
 
 invalidateRequireCacheForPackage = (packPath) ->
@@ -111,7 +106,7 @@ class Developer
     console.timeEnd('activate')
 
   addCommand: (name, fn) ->
-    atom.commands.add('atom-text-editor', "#{packageScope}:#{name}", fn)
+    atom.commands.add('atom-text-editor', "vim-mode-plus:#{name}", fn)
 
   clearDebugOutput: (name, fn) ->
     filePath = fs.normalize(settings.get('debugOutputFilePath'))
@@ -172,14 +167,15 @@ class Developer
         .replace(/\|/g, '&#124;')
         .replace(/\s+/, '')
 
+    {getKeyBindingForCommand, getAncestors} = @vimstate.utils
     commands = (
       for name, klass of Base.getClassRegistry() when klass.isCommand()
-        kind = $u().getAncestors(klass).map((k) -> k.name)[-2..-2][0]
+        kind = getAncestors(klass).map((k) -> k.name)[-2..-2][0]
         commandName = klass.getCommandName()
         description = klass.getDesctiption()?.replace(/\n/g, '<br/>')
 
         keymap = null
-        if keymaps = $u().getKeyBindingForCommand(commandName, packageName: "vim-mode-plus")
+        if keymaps = getKeyBindingForCommand(commandName, packageName: "vim-mode-plus")
           keymap = keymaps.map ({keystrokes, selector}) ->
             "`#{compactSelector(selector)}` <code>#{compactKeystrokes(keystrokes)}</code>"
           .join("<br/>")

--- a/lib/developer.coffee
+++ b/lib/developer.coffee
@@ -4,7 +4,7 @@ fs = require 'fs-plus'
 {Emitter, Disposable, BufferedProcess, CompositeDisposable} = require 'atom'
 
 Base = require './base'
-{generateIntrospectionReport} = require './introspection'
+generateIntrospectionReport = null
 settings = require './settings'
 {debug, getAncestors, getKeyBindingForCommand} = require './utils'
 
@@ -228,6 +228,7 @@ class Developer
       args: ['-g', editor.getPath(), "+call cursor(#{row+1}, #{column+1})"]
 
   generateIntrospectionReport: ->
+    generateIntrospectionReport ?= require './introspection'
     generateIntrospectionReport _.values(Base.getClassRegistry()),
       excludeProperties: [
         'run'

--- a/lib/highlight-search-manager.coffee
+++ b/lib/highlight-search-manager.coffee
@@ -1,5 +1,4 @@
 {CompositeDisposable} = require 'atom'
-{scanEditor, matchScopes} = require './utils'
 
 # General purpose utility class to make Atom's marker management easier.
 module.exports =
@@ -37,7 +36,7 @@ class HighlightSearchManager
     return unless @vimState.getConfig('highlightSearch')
     return unless @vimState.isVisible()
     return unless pattern = @globalState.get('highlightSearchPattern')
-    return if matchScopes(@editorElement, @vimState.getConfig('highlightSearchExcludeScopes'))
+    return if @vimState.utils.matchScopes(@editorElement, @vimState.getConfig('highlightSearchExcludeScopes'))
 
-    for range in scanEditor(@editor, pattern)
+    for range in @vimState.utils.scanEditor(@editor, pattern)
       @markerLayer.markBufferRange(range, invalidate: 'inside')

--- a/lib/hover-manager.coffee
+++ b/lib/hover-manager.coffee
@@ -1,5 +1,3 @@
-swrap = require './selection-wrapper'
-
 module.exports =
 class HoverManager
   constructor: (@vimState) ->
@@ -14,7 +12,7 @@ class HoverManager
       @vimState.getLastBlockwiseSelection().getHeadSelection().getHeadBufferPosition()
     else
       selection = @editor.getLastSelection()
-      swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
+      @vimState.swrap(selection).getBufferPositionFor('head', from: ['property', 'selection'])
 
   set: (text, point=@getPoint(), options={}) ->
     unless @marker?

--- a/lib/introspection.coffee
+++ b/lib/introspection.coffee
@@ -192,7 +192,4 @@ inspectInstance = (obj, options={}) ->
 getCommandFromClass = (klass) ->
   if klass.isCommand() then klass.getCommandName() else null
 
-module.exports = {
-  generateIntrospectionReport
-  inspectInstance
-}
+module.exports = generateIntrospectionReport

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -78,9 +78,7 @@ module.exports =
         globalState.set('highlightSearchPattern', null)
 
     @subscribe(settings.observeConditionalKeymaps()...)
-
-    # console.log 'main---'
-    @reportRequireCache(focus: 'selection-wrapper', excludeNodModules: true)
+    # @reportRequireCache(excludeNodModules: true)
 
   reportRequireCache: ({focus, excludeNodModules}) ->
     {inspect} = require 'util'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,7 +6,7 @@ Base = require './base'
 globalState = require './global-state'
 settings = require './settings'
 VimState = require './vim-state'
-{forEachPaneAxis} = require './utils'
+forEachPaneAxis = null
 
 module.exports =
   config: settings.config
@@ -41,6 +41,7 @@ module.exports =
 
     @subscribe atom.workspace.observeTextEditors (editor) =>
       @createVimState(editor) unless editor.isMini()
+
     @subscribe atom.workspace.onDidChangeActivePaneItem =>
       @demaximizePane()
 
@@ -77,6 +78,25 @@ module.exports =
         globalState.set('highlightSearchPattern', null)
 
     @subscribe(settings.observeConditionalKeymaps()...)
+
+    # console.log 'main---'
+    @reportRequireCache(focus: 'selection-wrapper', excludeNodModules: true)
+
+  reportRequireCache: ({focus, excludeNodModules}) ->
+    {inspect} = require 'util'
+    path = require 'path'
+    packPath = atom.packages.getLoadedPackage("vim-mode-plus").path
+    cachedPaths = Object.keys(require.cache)
+      .filter (p) -> p.startsWith(packPath + path.sep)
+      .map (p) -> p.replace(packPath, '')
+
+    for cachedPath in cachedPaths
+      if excludeNodModules and cachedPath.search(/node_modules/) >= 0
+        continue
+      if focus and cachedPath.search(///#{focus}///) >= 0
+        cachedPath = '*' + cachedPath
+
+      console.log cachedPath
 
   observeVimMode: (fn) ->
     fn() if atom.packages.isPackageActive('vim-mode')
@@ -149,6 +169,7 @@ module.exports =
 
     workspaceElement.classList.add(workspaceClassNames...)
 
+    forEachPaneAxis ?= require('./utils').forEachPaneAxis
     forEachPaneAxis (axis) ->
       paneAxisElement = getView(axis)
       if paneAxisElement.contains(paneElement)

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -1,6 +1,5 @@
 {Range, Point} = require 'atom'
 Base = require './base'
-swrap = require './selection-wrapper'
 _ = require 'underscore-plus'
 
 {
@@ -35,7 +34,7 @@ class Mark extends MiscCommand
 class ReverseSelections extends MiscCommand
   @extend()
   execute: ->
-    swrap.setReversedState(@editor, not @editor.getLastSelection().isReversed())
+    @swrap.setReversedState(@editor, not @editor.getLastSelection().isReversed())
     if @isMode('visual', 'blockwise')
       @getLastBlockwiseSelection().autoscroll()
 

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore-plus'
 {Emitter, Range, CompositeDisposable, Disposable} = require 'atom'
 Base = require './base'
-swrap = require './selection-wrapper'
 {moveCursorLeft} = require './utils'
 
 class ModeManager
@@ -59,7 +58,7 @@ class ModeManager
       @updateNarrowedState()
       @vimState.updatePreviousSelection()
     else
-      swrap.clearProperties(@editor)
+      @vimState.getProp('swrap')?.clearProperties(@editor)
 
     @editorElement.classList.add("#{@mode}-mode")
     @editorElement.classList.add(@submode) if @submode?
@@ -152,6 +151,7 @@ class ModeManager
   # - When selectRight at end position of normalized-selection, it become un-normalized selection
   #   which is the range in visual-mode.
   activateVisualMode: (submode) ->
+    swrap = @vimState.swrap
     for $selection in swrap.getSelections(@editor) when not $selection.hasProperties()
       $selection.saveProperties()
 
@@ -176,7 +176,7 @@ class ModeManager
       # [FIXME] why I need null guard here
       not @vimState.getLastBlockwiseSelection()?.isSingleRow()
     else
-      not swrap(@editor.getLastSelection()).isSingleRow()
+      not @vimState.swrap(@editor.getLastSelection()).isSingleRow()
 
   updateNarrowedState: (value=null) ->
     @editorElement.classList.toggle('is-narrowed', value ? @hasMultiLineSelection())

--- a/lib/mode-manager.coffee
+++ b/lib/mode-manager.coffee
@@ -55,6 +55,7 @@ class ModeManager
       @updateNarrowedState()
       @vimState.updatePreviousSelection()
     else
+      # Prevent swrap from loaded on initial mode-setup on startup.
       @vimState.getProp('swrap')?.clearProperties(@editor)
 
     @editorElement.classList.add("#{@mode}-mode")

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -4,8 +4,6 @@ _ = require 'underscore-plus'
 {
   moveCursorLeft, moveCursorRight
   moveCursorUpScreen, moveCursorDownScreen
-  moveCursorDownBuffer
-  moveCursorUpBuffer
   pointIsAtVimEndOfFile
   getFirstVisibleScreenRow, getLastVisibleScreenRow
   getValidVimScreenRow, getValidVimBufferRow
@@ -649,15 +647,19 @@ class MoveToFirstCharacterOfLineUp extends MoveToFirstCharacterOfLine
   wise: 'linewise'
   moveCursor: (cursor) ->
     @moveCursorCountTimes cursor, ->
-      moveCursorUpBuffer(cursor)
+      point = cursor.getBufferPosition()
+      unless point.row is 0
+        cursor.setBufferPosition(point.translate([-1, 0]))
     super
 
 class MoveToFirstCharacterOfLineDown extends MoveToFirstCharacterOfLine
   @extend()
   wise: 'linewise'
   moveCursor: (cursor) ->
-    @moveCursorCountTimes cursor, ->
-      moveCursorDownBuffer(cursor)
+    @moveCursorCountTimes cursor, =>
+      point = cursor.getBufferPosition()
+      unless @getVimLastBufferRow() is point.row
+        cursor.setBufferPosition(point.translate([+1, 0]))
     super
 
 class MoveToFirstCharacterOfLineAndDown extends MoveToFirstCharacterOfLineDown

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -30,7 +30,6 @@ _ = require 'underscore-plus'
   findRangeInBufferRow
 } = require './utils'
 
-swrap = require './selection-wrapper'
 Base = require './base'
 
 class Motion extends Base
@@ -94,7 +93,7 @@ class Motion extends Base
 
       succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
       if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
-        $selection = swrap(selection)
+        $selection = @swrap(selection)
         $selection.saveProperties(true) # save property of "already-normalized-selection"
         $selection.applyWise(@wise)
 
@@ -133,7 +132,7 @@ class CurrentSelection extends Motion
   moveCursor: (cursor) ->
     if @mode is 'visual'
       if @isBlockwise()
-        @blockwiseSelectionExtent = swrap(cursor.selection).getBlockwiseSelectionExtent()
+        @blockwiseSelectionExtent = @swrap(cursor.selection).getBlockwiseSelectionExtent()
       else
         @selectionExtent = @editor.getSelectedBufferRange().getExtent()
     else

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -1,5 +1,4 @@
 {Point} = require 'atom'
-{getFirstCharacterPositionForBufferRow, getVimLastBufferRow} = require './utils'
 
 module.exports =
 class MutationManager
@@ -80,11 +79,11 @@ class MutationManager
         else
           point = @clipPoint(mutation.startPositionOnDidSelect)
           if setToFirstCharacterOnLinewise and wise is 'linewise'
-            point = getFirstCharacterPositionForBufferRow(@editor, point.row)
+            point = @vimState.utils.getFirstCharacterPositionForBufferRow(@editor, point.row)
         selection.cursor.setBufferPosition(point)
 
   clipPoint: (point) ->
-    point.row = Math.min(getVimLastBufferRow(@editor), point.row)
+    point.row = Math.min(@vimState.utils.getVimLastBufferRow(@editor), point.row)
     @editor.clipBufferPosition(point)
 
 # Mutation information is created even if selection.isEmpty()

--- a/lib/mutation-manager.coffee
+++ b/lib/mutation-manager.coffee
@@ -1,6 +1,5 @@
 {Point} = require 'atom'
 {getFirstCharacterPositionForBufferRow, getVimLastBufferRow} = require './utils'
-# swrap = require './selection-wrapper'
 
 module.exports =
 class MutationManager

--- a/lib/occurrence-manager.coffee
+++ b/lib/occurrence-manager.coffee
@@ -1,7 +1,5 @@
 _ = require 'underscore-plus'
 {Emitter, CompositeDisposable} = require 'atom'
-swrap = require './selection-wrapper'
-
 {
   shrinkRangeEndToBeforeNewLine
   collectRangeInBufferRow
@@ -15,7 +13,7 @@ class OccurrenceManager
   markerOptions: {invalidate: 'inside'}
 
   constructor: (@vimState) ->
-    {@editor, @editorElement} = @vimState
+    {@editor, @editorElement, @swrap} = @vimState
     @disposables = new CompositeDisposable
     @disposables.add @vimState.onDidDestroy(@destroy.bind(this))
     @emitter = new Emitter
@@ -171,7 +169,7 @@ class OccurrenceManager
         @vimState.mutationManager.migrateMutation(selection, selections[index])
 
       @destroyMarkers(markersSelected)
-      for $selection in swrap.getSelections(@editor)
+      for $selection in @swrap.getSelections(@editor)
         $selection.saveProperties()
       true
     else

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -1,6 +1,5 @@
 {Disposable, CompositeDisposable} = require 'atom'
 Base = require './base'
-{moveCursorLeft, haveSomeNonEmptySelection, assertWithException} = require './utils'
 {OperationAbortedError} = require './errors'
 [Select, MoveToRelativeLine] = []
 
@@ -193,14 +192,14 @@ class OperationStack
     # We need to manually clear blockwiseSelection.
     # See #647
     @vimState.clearBlockwiseSelections() # FIXME, should be removed
-    if haveSomeNonEmptySelection(@editor)
+    if @vimState.haveSomeNonEmptySelection()
       if @vimState.getConfig('strictAssertion')
-        assertWithException(false, "Have some non-empty selection in normal-mode: #{operation.toString()}")
+        @vimState.utils.assertWithException(false, "Have some non-empty selection in normal-mode: #{operation.toString()}")
       @vimState.clearSelections()
 
   ensureAllCursorsAreNotAtEndOfLine: ->
     for cursor in @editor.getCursors() when cursor.isAtEndOfLine()
-      moveCursorLeft(cursor, preserveGoalColumn: true)
+      @vimState.utils.moveCursorLeft(cursor, preserveGoalColumn: true)
 
   addToClassList: (className) ->
     @editorElement.classList.add(className)

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -2,8 +2,6 @@
 Base = require './base'
 {moveCursorLeft, haveSomeNonEmptySelection, assertWithException} = require './utils'
 {OperationAbortedError} = require './errors'
-swrap = require './selection-wrapper'
-
 [Select, MoveToRelativeLine] = []
 
 # opration life in operationStack
@@ -21,7 +19,7 @@ class OperationStack
   Object.defineProperty @prototype, 'submode', get: -> @modeManager.submode
 
   constructor: (@vimState) ->
-    {@editor, @editorElement, @modeManager} = @vimState
+    {@editor, @editorElement, @modeManager, @swrap} = @vimState
 
     @subscriptions = new CompositeDisposable
     @subscriptions.add @vimState.onDidDestroy(@destroy.bind(this))
@@ -67,7 +65,7 @@ class OperationStack
   # -------------------------
   run: (klass, properties) ->
     if @mode is 'visual'
-      for $selection in swrap.getSelections(@editor) when not $selection.hasProperties()
+      for $selection in @swrap.getSelections(@editor) when not $selection.hasProperties()
         $selection.saveProperties()
 
     try

--- a/lib/operation-stack.coffee
+++ b/lib/operation-stack.coffee
@@ -184,7 +184,7 @@ class OperationStack
       @modeManager.updateNarrowedState()
       @vimState.updatePreviousSelection()
 
-    @vimState.updateCursorsVisibility()
+    @vimState.cursorStyleManager.refresh()
     @vimState.reset()
 
   ensureAllSelectionsAreEmpty: (operation) ->

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -7,7 +7,6 @@ _ = require 'underscore-plus'
   limitNumber
   isEmptyRow
 } = require './utils'
-swrap = require './selection-wrapper'
 Operator = require('./base').getClass('Operator')
 
 # Operator which start 'insert-mode'
@@ -226,7 +225,7 @@ class InsertByTarget extends ActivateInsertMode
       # vC: `I` and `A` behaves as shoft hand of `ctrl-v I` and `ctrl-v A`.
       # vL: `I` and `A` place cursors at each selected lines of start( or end ) of non-white-space char.
       if not @occurrenceSelected and @mode is 'visual' and @submode in ['characterwise', 'linewise']
-        for $selection in swrap.getSelections(@editor)
+        for $selection in @swrap.getSelections(@editor)
           $selection.normalize()
           $selection.applyWise('blockwise')
 
@@ -234,8 +233,8 @@ class InsertByTarget extends ActivateInsertMode
           for blockwiseSelection in @getBlockwiseSelections()
             blockwiseSelection.expandMemberSelectionsOverLineWithTrimRange()
 
-      for selection in @editor.getSelections()
-        swrap(selection).setBufferPositionTo(@which)
+      for $selection in @swrap.getSelections(@editor)
+        $selection.setBufferPositionTo(@which)
     super
 
 # key: 'I', Used in 'visual-mode.characterwise', visual-mode.blockwise
@@ -301,7 +300,7 @@ class Change extends ActivateInsertMode
     #   {
     #     a
     #   }
-    isLinewiseTarget = swrap.detectWise(@editor) is 'linewise'
+    isLinewiseTarget = @swrap.detectWise(@editor) is 'linewise'
     for selection in @editor.getSelections()
       @setTextToRegisterForSelection(selection) unless @getConfig('dontUpdateRegisterOnChangeOrSubstitute')
       if isLinewiseTarget

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -11,7 +11,6 @@ _ = require 'underscore-plus'
   getIndentLevelForBufferRow
   adjustIndentWithKeepingLayout
 } = require './utils'
-swrap = require './selection-wrapper'
 Base = require './base'
 Operator = Base.getClass('Operator')
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -1,6 +1,5 @@
 _ = require 'underscore-plus'
 {
-  haveSomeNonEmptySelection
   isEmptyRow
   getWordPatternAtBufferPosition
   getSubwordPatternAtBufferPosition
@@ -264,7 +263,7 @@ class Operator extends Base
         @occurrenceSelected = true
         @mutationManager.setCheckpoint('did-select-occurrence')
 
-    if @targetSelected = haveSomeNonEmptySelection(@editor) or @target.name is "Empty"
+    if @targetSelected = @vimState.haveSomeNonEmptySelection() or @target.name is "Empty"
       @emitDidSelectTarget()
       @flashChangeIfNecessary()
       @trackChangeIfNecessary()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -10,7 +10,6 @@ _ = require 'underscore-plus'
   ensureEndsWithNewLineForBufferRow
   adjustIndentWithKeepingLayout
 } = require './utils'
-swrap = require './selection-wrapper'
 Base = require './base'
 
 class Operator extends Base
@@ -130,7 +129,7 @@ class Operator extends Base
     if @selectPersistentSelectionIfNecessary()
       # [FIXME] selection-wise is not synched if it already visual-mode
       unless @mode is 'visual'
-        @vimState.modeManager.activate('visual', swrap.detectWise(@editor))
+        @vimState.modeManager.activate('visual', @swrap.detectWise(@editor))
 
     @target = 'CurrentSelection' if @mode is 'visual' and @requireTarget
     @setTarget(@new(@target)) if _.isString(@target)
@@ -166,7 +165,7 @@ class Operator extends Base
 
       @persistentSelection.select()
       @editor.mergeIntersectingSelections()
-      for $selection in swrap.getSelections(@editor) when not $selection.hasProperties()
+      for $selection in @swrap.getSelections(@editor) when not $selection.hasProperties()
         $selection.saveProperties()
       true
     else
@@ -199,7 +198,7 @@ class Operator extends Base
 
   normalizeSelectionsIfNecessary: ->
     if @target?.isMotion() and (@mode is 'visual')
-      swrap.normalize(@editor)
+      @swrap.normalize(@editor)
 
   startMutation: (fn) ->
     if @canEarlySelect()

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -9,7 +9,7 @@
   assertWithException
 } = require './utils'
 settings = require './settings'
-BlockwiseSelection = null
+BlockwiseSelection = require './blockwise-selection'
 
 propertyStore = new Map
 
@@ -114,7 +114,6 @@ class SelectionWrapper
         {start, end} = @getBufferRange()
         @setBufferRange(getBufferRangeForRowRange(@selection.editor, [start.row, end.row]))
       when 'blockwise'
-        BlockwiseSelection ?= require './blockwise-selection'
         new BlockwiseSelection(@selection)
 
   selectByProperties: ({head, tail}) ->
@@ -175,6 +174,19 @@ class SelectionWrapper
 swrap = (selection) ->
   new SelectionWrapper(selection)
 
+# BlockwiseSelection proxy
+swrap.getBlockwiseSelections = (editor) ->
+  BlockwiseSelection.getSelections(editor)
+
+swrap.getLastBlockwiseSelections = (editor) ->
+  BlockwiseSelection.getLastSelection(editor)
+
+swrap.getBlockwiseSelectionsOrderedByBufferPosition = (editor) ->
+  BlockwiseSelection.getSelectionsOrderedByBufferPosition(editor)
+
+swrap.clearBlockwiseSelections = (editor) ->
+  BlockwiseSelection.clearSelections(editor)
+
 swrap.getSelections = (editor) ->
   editor.getSelections(editor).map(swrap)
 
@@ -196,8 +208,7 @@ swrap.dumpProperties = (editor) ->
     console.log inspect($selection.getProperties())
 
 swrap.normalize = (editor) ->
-  BlockwiseSelection ?= require './blockwise-selection'
-  if BlockwiseSelection.has(editor)#blockwiseSelections =
+  if BlockwiseSelection.has(editor)
     for blockwiseSelection in BlockwiseSelection.getSelections(editor)
       blockwiseSelection.normalize()
     BlockwiseSelection.clearSelections(editor)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -64,9 +64,6 @@ isEndsWithNewLineForBufferRow = (editor, row) ->
   {start, end} = editor.bufferRangeForBufferRow(row, includeNewline: true)
   start.row isnt end.row
 
-haveSomeNonEmptySelection = (editor) ->
-  editor.getSelections().some(isNotEmpty)
-
 sortRanges = (collection) ->
   collection.sort (a, b) -> a.compare(b)
 
@@ -937,7 +934,6 @@ module.exports = {
   debug
   saveEditorState
   isLinewiseRange
-  haveSomeNonEmptySelection
   sortRanges
   getIndex
   getVisibleBufferRange

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -259,18 +259,6 @@ moveCursorDownScreen = (cursor, options={}) ->
     motion = (cursor) -> cursor.moveDown()
     moveCursor(cursor, options, motion)
 
-# FIXME
-moveCursorDownBuffer = (cursor) ->
-  point = cursor.getBufferPosition()
-  unless getVimLastBufferRow(cursor.editor) is point.row
-    cursor.setBufferPosition(point.translate([+1, 0]))
-
-# FIXME
-moveCursorUpBuffer = (cursor) ->
-  point = cursor.getBufferPosition()
-  unless point.row is 0
-    cursor.setBufferPosition(point.translate([-1, 0]))
-
 moveCursorToFirstCharacterAtRow = (cursor, row) ->
   cursor.setBufferPosition([row, 0])
   cursor.moveToFirstCharacterOfLine()
@@ -989,8 +977,6 @@ module.exports = {
   getBufferRows
   smartScrollToBufferPosition
   matchScopes
-  moveCursorDownBuffer
-  moveCursorUpBuffer
   isSingleLineText
   getWordBufferRangeAtBufferPosition
   getWordBufferRangeAndKindAtBufferPosition
@@ -1034,3 +1020,4 @@ module.exports = {
   rangeContainsPointWithEndExclusive
   traverseTextFromPoint
 }
+console.log "loaded", __filename

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -108,20 +108,16 @@ class VimState
   # BlockwiseSelections
   # -------------------------
   getBlockwiseSelections: ->
-    BlockwiseSelection ?= require './blockwise-selection'
-    BlockwiseSelection.getSelections(@editor)
+    @swrap.getBlockwiseSelections(@editor)
 
   getLastBlockwiseSelection: ->
-    BlockwiseSelection ?= require './blockwise-selection'
-    BlockwiseSelection.getLastSelection(@editor)
+    @swrap.getLastBlockwiseSelections(@editor)
 
   getBlockwiseSelectionsOrderedByBufferPosition: ->
-    BlockwiseSelection ?= require './blockwise-selection'
-    BlockwiseSelection.getSelectionsOrderedByBufferPosition(@editor)
+    @swrap.getBlockwiseSelectionsOrderedByBufferPosition(@editor)
 
   clearBlockwiseSelections: ->
-    BlockwiseSelection ?= require './blockwise-selection'
-    BlockwiseSelection.clearSelections(@editor)
+    @swrap.clearBlockwiseSelections(@editor)
 
   # Other
   # -------------------------

--- a/spec/performance-spec.coffee
+++ b/spec/performance-spec.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore-plus'
 
 {getVimState} = require './spec-helper'
-swrap = require '../lib/selection-wrapper'
 
 xdescribe "visual-mode performance", ->
   [set, ensure, keystroke, editor, editorElement, vimState] = []

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -2,7 +2,6 @@ _ = require 'underscore-plus'
 semver = require 'semver'
 {Range, Point, Disposable} = require 'atom'
 {inspect} = require 'util'
-swrap = require '../lib/selection-wrapper'
 settings = require '../lib/settings'
 globalState = require '../lib/global-state'
 
@@ -41,12 +40,6 @@ withMockPlatform = (target, platform, fn) ->
 
 buildKeydownEvent = (key, options) ->
   KeymapManager.buildKeydownEvent(key, options)
-
-getHeadProperty = (selection) ->
-  swrap(selection).getBufferPositionFor('head', from: ['property'])
-
-getTailProperty = (selection) ->
-  swrap(selection).getBufferPositionFor('tail', from: ['property'])
 
 buildKeydownEventFromKeystroke = (keystroke, target) ->
   modifier = ['ctrl', 'alt', 'shift', 'cmd']
@@ -417,10 +410,14 @@ class VimEditor
     expect(actual).toEqual(toArray(text))
 
   ensurePropertyHead: (points) ->
+    getHeadProperty = (selection) =>
+      @vimState.swrap(selection).getBufferPositionFor('head', from: ['property'])
     actual = (getHeadProperty(s) for s in @editor.getSelections())
     expect(actual).toEqual(toArrayOfPoint(points))
 
   ensurePropertyTail: (points) ->
+    getTailProperty = (selection) =>
+      @vimState.swrap(selection).getBufferPositionFor('tail', from: ['property'])
     actual = (getTailProperty(s) for s in @editor.getSelections())
     expect(actual).toEqual(toArrayOfPoint(points))
 


### PR DESCRIPTION
Continuation of #758.

I'm still observing what is happening in `activate` phase of vmp.
This PR is
- Make widely-used swrap available as vimState's prop.
- Which prop is lazy-required to avoid require at activate phase.

## CAUTION

- Currently selection propertyStore is maintained in `selection-wrapper.coffee`.
- If swrap is **directly-requied** but it's not correctly cleared because of lazy-prop is not propertized, it very bad situation, result in incorrect cursor-placement.
- So **all-vmp-code and vmp plugin should not directly require** swrap file. should access it via vimState.
