### PR TITLE
support new editor Rendering code where cursor.setVisible is no longer available

### DIFF
--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -22,43 +22,26 @@ class CursorStyleManager
     @styleDisposables?.dispose()
     @disposables.dispose()
 
-  refresh: =>
-    # Intentionally skip in spec mode, since not all spec have DOM attached( and don't want to ).
-    return if atom.inSpecMode()
-    @lineHeight = @editor.getLineHeightInPixels()
-
+  updateCursorStyleOld: ->
     # We must dispose previous style modification for non-visual-mode
     @styleDisposables?.dispose()
+    @styleDisposables = new CompositeDisposable
     return unless @mode is 'visual'
 
-    @styleDisposables = new CompositeDisposable
     if @submode is 'blockwise'
       cursorsToShow = @vimState.getBlockwiseSelections().map (bs) -> bs.getHeadSelection().cursor
     else
       cursorsToShow = @editor.getCursors()
 
-    if SupportCursorSetVisible
-      # FIXME: In visual-mode or in occurrence operation, cursor are added during operation but selection is added asynchronously.
-      # We have to make sure that corresponding cursor's domNode is available at this point to directly modify it's style.
-      @editorElement.component.updateSync()
-
+    # In visual-mode or in occurrence operation, cursor are added during operation but selection is added asynchronously.
+    # We have to make sure that corresponding cursor's domNode is available at this point to directly modify it's style.
+    @editorElement.component.updateSync()
     for cursor in @editor.getCursors()
-      # In blockwise, show only blockwise-head cursor
       cursorIsVisible = cursor in cursorsToShow
-      if SupportCursorSetVisible
-        cursor.setVisible(cursor, cursorIsVisible)
-      else
-        visibility = if cursorIsVisible then 'visible' else 'hidden'
-        @editor.decorateMarker(cursor.getMarker(), type: 'cursor', style: {visibility})
-      continue unless cursorIsVisible
+      cursor.setVisible(cursorIsVisible)
 
-      traversal = @getCursorTraversal(cursor)
-      cursorStyle = {
-        top: @lineHeight * traversal.row + 'px'
-        left: traversal.column + 'ch'
-      }
-
-      if SupportCursorSetVisible
+      if cursorIsVisible
+        cursorStyle = @getCursorStyle(cursor, cursorIsVisible)
         # [NOTE] Using non-public API
         cursorNode = @editorElement.component.linesComponent.cursorsComponent.cursorNodesById[cursor.id]
         cursorNode.style.setProperty('top', cursorStyle.top)
@@ -66,14 +49,40 @@ class CursorStyleManager
         @styleDisposables.add new Disposable ->
           cursorNode.style.removeProperty('top')
           cursorNode.style.removeProperty('left')
-      else
-        # @editorElement.component.getNextUpdatePromise().then =>
-        #   for cursorNode in @editorElement.querySelectorAll('.cursor')
-        #     console.log [cursorNode.style.top, cursorNode.style.left]
-        cursorMarker = cursor.getMarker()
-        @editor.decorateMarker(cursorMarker, type: 'cursor', style: cursorStyle)
-        @styleDisposables.add new Disposable =>
-          @editor.decorateMarker(cursorMarker, type: 'cursor', style: {top: '0px', left: '0ch'})
+
+  updateCursorStyleNew: ->
+    # We must dispose previous style modification for non-visual-mode
+    # Intentionally collect all decorations from editor instead of managing
+    # decorations we created explicitly.
+    # Why? when intersecting multiple selections are auto-merged, it's got wired
+    # state where decoration cannot be disposable(not investigated well).
+    # And I want to assure ALL cursor style modification done by vmp is cleared.
+    for decoration in @editor.getDecorations(type: 'cursor', class: 'vim-mode-plus')
+      decoration.destroy()
+
+    return unless @mode is 'visual'
+
+    if @submode is 'blockwise'
+      cursorsToShow = @vimState.getBlockwiseSelections().map (bs) -> bs.getHeadSelection().cursor
+    else
+      cursorsToShow = @editor.getCursors()
+
+    for cursor in @editor.getCursors()
+      @editor.decorateMarker cursor.getMarker(),
+        type: 'cursor'
+        class: 'vim-mode-plus'
+        style: @getCursorStyle(cursor, cursor in cursorsToShow)
+
+  refresh: =>
+    # Intentionally skip in spec mode, since not all spec have DOM attached( and don't want to ).
+    return if atom.inSpecMode()
+
+    @lineHeight = @editor.getLineHeightInPixels()
+
+    if SupportCursorSetVisible
+      @updateCursorStyleOld()
+    else
+      @updateCursorStyleNew()
 
   getCursorBufferPositionToDisplay: (selection) ->
     bufferPosition = @vimState.swrap(selection).getBufferPositionFor('head', from: ['property'])
@@ -85,14 +94,21 @@ class CursorStyleManager
 
     @editor.clipBufferPosition(bufferPosition)
 
-  getCursorTraversal: (cursor) ->
-    selection = cursor.selection
-    bufferPosition = @getCursorBufferPositionToDisplay(selection)
+  getCursorStyle: (cursor, visible) ->
+    if visible
+      bufferPosition = @getCursorBufferPositionToDisplay(cursor.selection)
+      if @submode is 'linewise' and @editor.isSoftWrapped()
+        screenPosition = @editor.screenPositionForBufferPosition(bufferPosition)
+        {row, column} = screenPosition.traversalFrom(cursor.getScreenPosition())
+      else
+        {row, column} = bufferPosition.traversalFrom(cursor.getBufferPosition())
 
-    if @submode is 'linewise' and @editor.isSoftWrapped()
-      screenPosition = @editor.screenPositionForBufferPosition(bufferPosition)
-      screenPosition.traversalFrom(cursor.getScreenPosition())
+      return {
+        top: @lineHeight * row + 'px'
+        left: column + 'ch'
+        visibility: 'visible'
+      }
     else
-      bufferPosition.traversalFrom(cursor.getBufferPosition())
+      return {visibility: 'hidden'}
 
 module.exports = CursorStyleManager

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -12,6 +12,7 @@ class CursorStyleManager
 
   constructor: (@vimState) ->
     {@editorElement, @editor} = @vimState
+    SupportCursorSetVisible ?= @editor.getLastCursor().setVisible?
     @disposables = new CompositeDisposable
     @disposables.add atom.config.observe('editor.lineHeight', @refresh)
     @disposables.add atom.config.observe('editor.fontSize', @refresh)
@@ -35,8 +36,6 @@ class CursorStyleManager
       cursorsToShow = @vimState.getBlockwiseSelections().map (bs) -> bs.getHeadSelection().cursor
     else
       cursorsToShow = @editor.getCursors()
-
-    SupportCursorSetVisible ?= @editor.getLastCursor().setVisible?
 
     if SupportCursorSetVisible
       # FIXME: In visual-mode or in occurrence operation, cursor are added during operation but selection is added asynchronously.

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -4,6 +4,7 @@ SupportCursorSetVisible = null
 
 # Display cursor in visual-mode
 # ----------------------------------
+module.exports =
 class CursorStyleManager
   lineHeight: null
 
@@ -110,5 +111,3 @@ class CursorStyleManager
       }
     else
       return {visibility: 'hidden'}
-
-module.exports = CursorStyleManager


### PR DESCRIPTION
refs atom/atom#13880

To support both old-rendering and new-rendering way.
- old: where `cursor.setVisible` is available
- new: where `cursor.setVisible` is no longer available