### PR TITLE
Implementation of *zm, zr* folding commands

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -270,11 +270,13 @@
   'z s': 'vim-mode-plus:scroll-cursor-to-left'
   'z e': 'vim-mode-plus:scroll-cursor-to-right'
 
-  'z M': 'editor:fold-all'
-  'z R': 'editor:unfold-all'
   'z c': 'editor:fold-current-row'
   'z o': 'editor:unfold-current-row'
   'z a': 'vim-mode-plus:toggle-fold'
+  'z M': 'vim-mode-plus:fold-all'
+  'z R': 'vim-mode-plus:unfold-all'
+  'z m': 'vim-mode-plus:fold-all-by-one-indent-level'
+  'z r': 'vim-mode-plus:unfold-all-by-one-indent-level'
 
 'atom-text-editor.vim-mode-plus-input-char-waiting':
   'enter': 'core:confirm'

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -1121,6 +1121,22 @@ ToggleFold:
   file: "./misc-command"
   commandName: "vim-mode-plus:toggle-fold"
   commandScope: "atom-text-editor"
+UnfoldAll:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:unfold-all"
+  commandScope: "atom-text-editor"
+FoldAll:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:fold-all"
+  commandScope: "atom-text-editor"
+UnfoldAllByOneIndentLevel:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:unfold-all-by-one-indent-level"
+  commandScope: "atom-text-editor"
+FoldAllByOneIndentLevel:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:fold-all-by-one-indent-level"
+  commandScope: "atom-text-editor"
 ReplaceModeBackspace:
   file: "./misc-command"
   commandName: "vim-mode-plus:replace-mode-backspace"

--- a/lib/fold-manager.coffee
+++ b/lib/fold-manager.coffee
@@ -1,0 +1,70 @@
+{CompositeDisposable} = require 'atom'
+
+# see `foldnestmax` in VIM help manual
+# TODO: Settings with this param
+FOLD_NEST_MAX = 20
+
+# A manager for memorizing fold level.
+module.exports =
+class FoldManager
+  constructor: (@vimState) ->
+    {@editor} = @vimState
+    {@buffer, @languageMode} = @editor
+
+    @disposables = new CompositeDisposable
+    @disposables.add @vimState.onDidDestroy(@destroy.bind(this))
+
+    @foldLevel = FOLD_NEST_MAX
+
+  destroy: ->
+    @disposables.dispose()
+
+  unfoldAll: ->
+    @editor.displayLayer.destroyAllFolds()
+    @foldLevel = FOLD_NEST_MAX
+
+  foldAll: ->
+    if FOLD_NEST_MAX > 0
+      @editor.foldAll()
+    @foldLevel = 0
+
+  # Internal use
+  foldAllAtIndentLevel: (indentLevel) ->
+    @editor.unfoldAll()
+    if indentLevel >= FOLD_NEST_MAX
+      @foldLevel = FOLD_NEST_MAX
+      return
+
+    foldedRowRanges = {}
+    folded = false
+
+    maxBufferIndentLevel = 0
+
+    for currentRow in [0..@buffer.getLastRow()] by 1
+      rowRange = [startRow, endRow] = @languageMode.rowRangeForFoldAtBufferRow(currentRow) ? []
+      continue unless startRow?
+      continue if foldedRowRanges[rowRange]
+
+      # assumption: startRow will always be the min indent level for the entire range
+      currentIndentLevel = @editor.indentationForBufferRow(startRow + 1)
+      if currentIndentLevel >= indentLevel + 1
+        @editor.foldBufferRowRange(startRow, endRow)
+        foldedRowRanges[rowRange] = true
+        @foldLevel = indentLevel
+        folded = true
+
+      # Store maximum of indent level in current buffer
+      maxBufferIndentLevel = Math.max(maxBufferIndentLevel, currentIndentLevel)
+
+    # Set foldLevel to maximum indent level
+    if not folded
+      @foldLevel = maxBufferIndentLevel
+      # automatically fold one level if not folded
+      if indentLevel is FOLD_NEST_MAX - 1
+        @foldAllAtIndentLevel(Math.max(@foldLevel - 1, 0))
+
+  unfoldAllByOneIndentLevel: ->
+    @foldAllAtIndentLevel(@foldLevel + 1)
+
+  foldAllByOneIndentLevel: ->
+    @foldAllAtIndentLevel(Math.max(@foldLevel - 1, 0))

--- a/lib/fold-manager.coffee
+++ b/lib/fold-manager.coffee
@@ -1,9 +1,5 @@
 {CompositeDisposable} = require 'atom'
 
-# see `foldnestmax` in VIM help manual
-# TODO: Settings with this param
-FOLD_NEST_MAX = 20
-
 # A manager for memorizing fold level.
 module.exports =
 class FoldManager
@@ -14,25 +10,28 @@ class FoldManager
     @disposables = new CompositeDisposable
     @disposables.add @vimState.onDidDestroy(@destroy.bind(this))
 
-    @foldLevel = FOLD_NEST_MAX
+    @foldLevel = @getFoldNestMax()
 
   destroy: ->
     @disposables.dispose()
 
+  getFoldNestMax: ->
+    @vimState.getConfig('maximumNestingOfFolds')
+
   unfoldAll: ->
     @editor.displayLayer.destroyAllFolds()
-    @foldLevel = FOLD_NEST_MAX
+    @foldLevel = @getFoldNestMax()
 
   foldAll: ->
-    if FOLD_NEST_MAX > 0
+    if @getFoldNestMax() > 0
       @editor.foldAll()
     @foldLevel = 0
 
   # Internal use
   foldAllAtIndentLevel: (indentLevel) ->
     @editor.unfoldAll()
-    if indentLevel >= FOLD_NEST_MAX
-      @foldLevel = FOLD_NEST_MAX
+    if indentLevel >= @getFoldNestMax()
+      @foldLevel = @getFoldNestMax()
       return
 
     foldedRowRanges = {}
@@ -60,7 +59,7 @@ class FoldManager
     if not folded
       @foldLevel = maxBufferIndentLevel
       # automatically fold one level if not folded
-      if indentLevel is FOLD_NEST_MAX - 1
+      if indentLevel is @getFoldNestMax() - 1
         @foldAllAtIndentLevel(Math.max(@foldLevel - 1, 0))
 
   unfoldAllByOneIndentLevel: ->

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -160,6 +160,26 @@ class ToggleFold extends MiscCommand
     point = @editor.getCursorBufferPosition()
     @editor.toggleFoldAtBufferRow(point.row)
 
+class UnfoldAll extends MiscCommand
+  @extend()
+  execute: ->
+    @vimState.foldManager.unfoldAll()
+
+class FoldAll extends MiscCommand
+  @extend()
+  execute: ->
+    @vimState.foldManager.foldAll()
+
+class UnfoldAllByOneIndentLevel extends MiscCommand
+  @extend()
+  execute: ->
+    @vimState.foldManager.unfoldAllByOneIndentLevel()
+
+class FoldAllByOneIndentLevel extends MiscCommand
+  @extend()
+  execute: ->
+    @vimState.foldManager.foldAllByOneIndentLevel()
+
 class ReplaceModeBackspace extends MiscCommand
   @commandScope: 'atom-text-editor.vim-mode-plus.insert-mode.replace'
   @extend()

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -243,6 +243,9 @@ module.exports = new Settings 'vim-mode-plus',
     description: 'Comma separated list of operator class name to disable flash e.g. "yank, auto-indent"'
   flashOnSearch: true
   flashScreenOnSearchHasNoMatch: true
+  maximumNestingOfFolds:
+    default: 20
+    description: 'Sets the maximum nesting of folds to avoid creating too many folds.'
   showHoverSearchCounter: false
   showHoverSearchCounterDuration:
     default: 700

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -62,6 +62,7 @@ class VimState
     searchInput: './search-input'
     operationStack: './operation-stack'
     cursorStyleManager: './cursor-style-manager'
+    foldManager: './fold-manager'
 
   for propName, fileToLoad of @lazyProperties
     @defineLazyProperty(propName, fileToLoad)


### PR DESCRIPTION
Implemented:  

- Fold/unfold by one level (`zm`, `zr` in VIM)
- Settings for maximum nesting level of folds (`foldnestmax` in VIM)
- Modify **fold-all** and **unfold-all** commands for adaptation of tracking fold levels. 

This feature lacks of suitable tests. I have no enough time to dive into the test structures. Sorry for this 😭 .