### PR TITLE
support count for gt

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -200,8 +200,8 @@
   'ctrl-w c': 'pane:close'
   'ctrl-w ctrl-q': 'core:close'
   'ctrl-w q': 'core:close'
-  'g t': 'pane:show-next-item'
-  'g T': 'pane:show-previous-item'
+  'g t': 'vim-mode-plus:next-tab'
+  'g T': 'vim-mode-plus:previous-tab'
 
   'f': 'vim-mode-plus:find'
   'F': 'vim-mode-plus:find-backwards'

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -1205,3 +1205,11 @@ CopyFromLineBelow:
   file: "./misc-command"
   commandName: "vim-mode-plus:copy-from-line-below"
   commandScope: "atom-text-editor.vim-mode-plus.insert-mode"
+NextTab:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:next-tab"
+  commandScope: "atom-text-editor"
+PreviousTab:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:previous-tab"
+  commandScope: "atom-text-editor"

--- a/lib/misc-command.coffee
+++ b/lib/misc-command.coffee
@@ -418,3 +418,20 @@ class CopyFromLineBelow extends CopyFromLineAbove
   Equivalent to *i_CTRL-E* of pure Vim
   """
   rowDelta: +1
+
+class NextTab extends MiscCommand
+  @extend()
+  defaultCount: 0
+  execute: ->
+    count = @getCount()
+    pane = atom.workspace.paneForItem(@editor)
+    if count
+      pane.activateItemAtIndex(count - 1)
+    else
+      pane.activateNextItem()
+
+class PreviousTab extends MiscCommand
+  @extend()
+  execute: ->
+    pane = atom.workspace.paneForItem(@editor)
+    pane.activatePreviousItem()


### PR DESCRIPTION
Fix #759

This PR add support `<count>gt` to move activate numbered tab item.

- `3 g t` activate 3rd tab( = pane Item ).
- `7 g t` activate 7th tab.
- When tab( = pane item ) was not exist, do nothing.
- Limitation is vim-mode-plus's command works only for normal text-editor.
  - So when you activated 3rd tab by `3 g t`, then that 3rd tab was setting-view item, you can't use `g t` on this pane item.

For `gT`, I won't implement the feature described in vim-help with this PR( postpone ).

```
{count}gT	Go {count} tab pages back.  Wraps around from the first one
		to the last one.
```

