### PR TITLE
Fix mixed bracket percent motion search

### DIFF
--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -252,19 +252,15 @@ class AnyPairAllowForwarding extends AnyPair
   getRange: (selection) ->
     ranges = @getRanges(selection)
     from = selection.cursor.getBufferPosition()
-    [forwardingRanges, enclosingRanges] = _.partition ranges, (range) ->
-      range.start.isGreaterThanOrEqual(from)
-    enclosingRange = _.last(sortRanges(enclosingRanges))
-    forwardingRanges = sortRanges(forwardingRanges)
-
-    # When enclosingRange is exists,
-    # We don't go across enclosingRange.end.
-    # So choose from ranges contained in enclosingRange.
-    if enclosingRange
-      forwardingRanges = forwardingRanges.filter (range) ->
-        enclosingRange.containsRange(range)
-
-    forwardingRanges[0] or enclosingRange
+    for range in ranges when range.start.isGreaterThanOrEqual(from)
+      if !bestRange or bestRange.start.isGreaterThan(range.start)
+        bestRange = range
+    closest = if bestRange then bestRange.start else from
+    for range in ranges
+      if !bestRange or closest.isGreaterThanOrEqual(range.end)
+        bestRange = range
+        closest = bestRange.end
+    bestRange
 
 class AnyQuote extends AnyPair
   @extend(false)

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -253,11 +253,11 @@ class AnyPairAllowForwarding extends AnyPair
     ranges = @getRanges(selection)
     from = selection.cursor.getBufferPosition()
     for range in ranges when range.start.isGreaterThanOrEqual(from)
-      if !bestRange or bestRange.start.isGreaterThan(range.start)
+      if not bestRange or bestRange.start.isGreaterThan(range.start)
         bestRange = range
     closest = if bestRange then bestRange.start else from
     for range in ranges
-      if !bestRange or closest.isGreaterThanOrEqual(range.end)
+      if not bestRange or closest.isGreaterThanOrEqual(range.end)
         bestRange = range
         closest = bestRange.end
     bestRange

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -625,6 +625,36 @@ describe "Motion Search", ->
         set cursor: [0, 2]
         ensure '%', cursor: [0, 0]
 
+    describe "mixed brackets", ->
+      beforeEach ->
+        set
+          text: """
+          if (a < b) {
+            a->foo(b);
+          }
+          """
+      it 'move to matching parenthesis', ->
+        set cursor: [0, 7]
+        ensure '%', cursor: [0, 3]
+        ensure '%', cursor: [0, 9]
+        set cursor: [1, 5]
+        ensure '%', cursor: [1, 10]
+        ensure '%', cursor: [1, 8]
+      it 'move to matching angle brackets', ->
+        set cursor: [0, 4]
+        ensure '%', cursor: [1, 4]
+        ensure '%', cursor: [0, 6]
+        set cursor: [0, 6]
+        ensure '%', cursor: [1, 4]
+        ensure '%', cursor: [0, 6]
+        set cursor: [1, 0]
+        ensure '%', cursor: [0, 6]
+        ensure '%', cursor: [1, 4]
+      it 'move to matching curly brackets', ->
+        set cursor: [0, 10]
+        ensure '%', cursor: [2, 0]
+        ensure '%', cursor: [0, 11]
+
     describe "complex situation with html tag", ->
       beforeEach ->
         set


### PR DESCRIPTION
This fixes matching across different mixed bracket types. It mimics the behavior in Vim. It is a _partial_ fix for #700, as it fixes issues regarding mixed brackets, but it doesn't resolve the initial issue regarding matching XML-like element name matching.