### PR TITLE
Improve fold handling

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -6,6 +6,9 @@
   # 'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
 
+'atom-workspace .tree-view':
+  'cmd-enter': 'abort!'
+
 # all
 # -------------------------
 'atom-text-editor.vim-mode-plus':

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -258,7 +258,7 @@ class Base
   # -------------------------
   @writeCommandTableOnDisk: ->
     commandTable = @generateCommandTableByEagerLoad()
-    console.log commandTable # investigate why sometime this get empty?
+    console.warn commandTable # investigate why sometime this get empty?
     _ = _plus()
     if _.isEqual(@commandTable, commandTable)
       atom.notifications.addInfo("No change commandTable", dismissable: true)

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -206,6 +206,9 @@ class Base
   scanBackward: (args...) ->
     @utils.scanEditorInDirection(@editor, 'backward', args...)
 
+  getFoldEndRowForRow: (args...) ->
+    @utils.getFoldEndRowForRow(@editor, args...)
+
   instanceof: (klassName) ->
     this instanceof Base.getClass(klassName)
 
@@ -255,6 +258,7 @@ class Base
   # -------------------------
   @writeCommandTableOnDisk: ->
     commandTable = @generateCommandTableByEagerLoad()
+    console.log commandTable # investigate why sometime this get empty?
     _ = _plus()
     if _.isEqual(@commandTable, commandTable)
       atom.notifications.addInfo("No change commandTable", dismissable: true)

--- a/lib/cursor-style-manager.coffee
+++ b/lib/cursor-style-manager.coffee
@@ -103,7 +103,7 @@ class CursorStyleManager
   getCursorStyle: (cursor, visible) ->
     if visible
       bufferPosition = @getCursorBufferPositionToDisplay(cursor.selection)
-      if @submode is 'linewise' and @editor.isSoftWrapped()
+      if @submode is 'linewise' and (@editor.isSoftWrapped() or @editor.isFoldedAtBufferRow(bufferPosition.row))
         screenPosition = @editor.screenPositionForBufferPosition(bufferPosition)
         {row, column} = screenPosition.traversalFrom(cursor.getScreenPosition())
       else

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -700,18 +700,12 @@ class MoveToRelativeLine extends Motion
   wise: 'linewise'
   moveSuccessOnLinewise: true
 
-  getRow: (row) ->
-    if @editor.isFoldedAtBufferRow(row)
-      getLargestFoldRangeContainsBufferRow(@editor, row).end.row
-    else
-      row
-
   moveCursor: (cursor) ->
-    row = @getRow(cursor.getBufferRow())
+    row = @getFoldEndRowForRow(cursor.getBufferRow())
 
     count = @getCount(-1)
     while (count > 0)
-      row = @getRow(row + 1)
+      row = @getFoldEndRowForRow(row + 1)
       count--
 
     setBufferRow(cursor, row)

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -700,8 +700,21 @@ class MoveToRelativeLine extends Motion
   wise: 'linewise'
   moveSuccessOnLinewise: true
 
+  getRow: (row) ->
+    if @editor.isFoldedAtBufferRow(row)
+      getLargestFoldRangeContainsBufferRow(@editor, row).end.row
+    else
+      row
+
   moveCursor: (cursor) ->
-    setBufferRow(cursor, cursor.getBufferRow() + @getCount(-1))
+    row = @getRow(cursor.getBufferRow())
+
+    count = @getCount(-1)
+    while (count > 0)
+      row = @getRow(row + 1)
+      count--
+
+    setBufferRow(cursor, row)
 
 class MoveToRelativeLineMinimumOne extends MoveToRelativeLine
   @extend(false)

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -6,6 +6,7 @@ _ = require 'underscore-plus'
   moveCursorRight
   limitNumber
   isEmptyRow
+  setBufferRow
 } = require './utils'
 Operator = require('./base').getClass('Operator')
 
@@ -199,6 +200,9 @@ class InsertAboveWithNewline extends ActivateInsertMode
 class InsertBelowWithNewline extends InsertAboveWithNewline
   @extend()
   mutateText: ->
+    for cursor in @editor.getCursors() when cursorRow = cursor.getBufferRow()
+      setBufferRow(cursor, @getFoldEndRowForRow(cursorRow))
+
     @editor.insertNewlineBelow()
     @autoIndentEmptyRows() if @editor.autoIndent
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -606,8 +606,9 @@ class PutBefore extends Operator
         newRange = insertTextAtBufferPosition(@editor, [cursorRow, 0], text)
         setBufferRow(cursor, newRange.start.row)
       else if @location is 'after'
-        ensureEndsWithNewLineForBufferRow(@editor, cursorRow)
-        newRange = insertTextAtBufferPosition(@editor, [cursorRow + 1, 0], text)
+        targetRow = @getFoldEndRowForRow(cursorRow)
+        ensureEndsWithNewLineForBufferRow(@editor, targetRow)
+        newRange = insertTextAtBufferPosition(@editor, [targetRow + 1, 0], text)
     else
       selection.insertText("\n") unless @isMode('visual', 'linewise')
       newRange = selection.insertText(text)

--- a/lib/selection-wrapper.coffee
+++ b/lib/selection-wrapper.coffee
@@ -7,6 +7,7 @@
   limitNumber
   isLinewiseRange
   assertWithException
+  getFoldEndRowForRow
 } = require './utils'
 settings = require './settings'
 BlockwiseSelection = require './blockwise-selection'
@@ -112,7 +113,8 @@ class SelectionWrapper
       when 'linewise'
         # Even if end.column is 0, expand over that end.row( don't use selection.getRowRange() )
         {start, end} = @getBufferRange()
-        @setBufferRange(getBufferRangeForRowRange(@selection.editor, [start.row, end.row]))
+        endRow = getFoldEndRowForRow(@selection.editor, end.row) # cover folded rowRange
+        @setBufferRange(getBufferRangeForRowRange(@selection.editor, [start.row, endRow]))
       when 'blockwise'
         new BlockwiseSelection(@selection)
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -974,6 +974,15 @@ getTraversalForText = (text) ->
       column++
   [row, column]
 
+
+# Return endRow of fold if row was folded or just return passed row.
+getFoldEndRowForRow = (editor, row) ->
+  if editor.isFoldedAtBufferRow(row)
+    screenRow = editor.screenRowForBufferRow(row)
+    editor.bufferRowForScreenRow(screenRow + 1) - 1
+  else
+    row
+
 module.exports = {
   assertWithException
   getAncestors
@@ -1067,4 +1076,5 @@ module.exports = {
   adjustIndentWithKeepingLayout
   rangeContainsPointWithEndExclusive
   traverseTextFromPoint
+  getFoldEndRowForRow
 }

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -978,8 +978,7 @@ getTraversalForText = (text) ->
 # Return endRow of fold if row was folded or just return passed row.
 getFoldEndRowForRow = (editor, row) ->
   if editor.isFoldedAtBufferRow(row)
-    screenRow = editor.screenRowForBufferRow(row)
-    editor.bufferRowForScreenRow(screenRow + 1) - 1
+    getLargestFoldRangeContainsBufferRow(editor, row).end.row
   else
     row
 


### PR DESCRIPTION
Fix #458, #452 , #788


Here is the TODO I can come up with.
I don't think this is perfect. What other situation I should cover???

## TODO

- [x] Don't forget to correctly handle count.

- [x] MoveToRelativeLine respect folded row(affect `d d`, `y y`).
  - Old: delete/yank just firstline-of-fold.
  - New: delete/yank folded row ranges.
- [x] `o` on folded row
  - Old: start insert at next-line of firstline-of-fold.
  - New: start insert at next-line of endline-of-fold.
- [x] `V` on folded row
  - Old: select firstline-of-fold only.
  - New: select row ranges of fold. Fix cursor visibility reported in xxx
- [x] `p` on folded row
  - Old: paste to next line of firstline-of-fold.
  - New: paste to next line of endline-of-fold
