### PR TITLE
Improve mouse handling

### DIFF
--- a/lib/blockwise-selection.js
+++ b/lib/blockwise-selection.js
@@ -213,7 +213,6 @@ module.exports = class BlockwiseSelection {
 
   normalize() {
     if (this.needSkipNormalization) return
-    if (this.getSelections().every(selection => selection.isEmpty())) return
 
     // CAUTION: Save prop BEFORE removing member selections.
     const properties = this.getProperties()

--- a/lib/selection-wrapper.js
+++ b/lib/selection-wrapper.js
@@ -93,13 +93,9 @@ class SelectionWrapper {
   getTailBufferRange() {
     const {editor} = this.selection
     const tailPoint = this.selection.getTailBufferPosition()
-    if (this.selection.isReversed()) {
-      const point = translatePointAndClip(editor, tailPoint, "backward")
-      return new Range(point, tailPoint)
-    } else {
-      const point = translatePointAndClip(editor, tailPoint, "forward")
-      return new Range(tailPoint, point)
-    }
+    return this.selection.isReversed()
+      ? new Range(translatePointAndClip(editor, tailPoint, "backward"), tailPoint)
+      : new Range(tailPoint, translatePointAndClip(editor, tailPoint, "forward"))
   }
 
   saveProperties(isNormalized) {

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -376,6 +376,9 @@ module.exports = class VimState {
         this.activate("visual", wise)
       }
     } else if (this.mode === "visual") {
+      if (this.submode === "blockwise") {
+        this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
+      }
       this.activate("normal")
     }
   }

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -370,7 +370,7 @@ module.exports = class VimState {
         this.editorElement.component.updateSync()
         const wise = this.swrap.detectWise(this.editor)
         if (this.isMode("visual", wise)) {
-          this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
+          this.swrap.getSelections(this.editor).forEach($s => $s.saveProperties())
           this.cursorStyleManager.refresh()
         } else {
           this.activate("visual", wise)

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -137,7 +137,11 @@ module.exports = class VimState {
     this.modeManager = new ModeManager(this)
     this.previousSelection = {}
     this.scrollAnimationEffect = null
-    this.observeSelections()
+
+    this.subscriptions.add(
+      this.observeMouse(),
+      atom.commands.onDidDispatch(event => this.checkSelectionOnDidDispatch(event))
+    )
 
     this.editorElement.classList.add("vim-mode-plus")
 
@@ -353,7 +357,7 @@ module.exports = class VimState {
     return this.editor.getSelections().some(selection => !selection.isEmpty())
   }
 
-  checkSelection(event) {
+  checkSelectionOnDidDispatch(event) {
     if (atom.workspace.getActiveTextEditor() !== this.editor) return
     if (this.withProp("operationStack", p => p.isProcessing())) return // Don't populate lazy-prop on startup
     if (this.mode === "insert") return
@@ -364,6 +368,10 @@ module.exports = class VimState {
     if (!(target && target.closest && target.closest("atom-text-editor") === this.editorElement)) return
     if (event.type.startsWith("vim-mode-plus")) return // to match vim-mode-plus: and vim-mode-plus-user:
 
+    this.updateModeWithCurrentSelection()
+  }
+
+  updateModeWithCurrentSelection() {
     if (this.haveSomeNonEmptySelection()) {
       this.editorElement.component.updateSync()
       const wise = this.swrap.detectWise(this.editor)
@@ -383,26 +391,59 @@ module.exports = class VimState {
     }
   }
 
-  observeSelections() {
-    const checkSelection = this.checkSelection.bind(this)
-    const handleMouseDown = () => {
-      this.editorElement.addEventListener("mousemove", checkSelection)
-      this.editorElement.addEventListener("mouseup", handleMouseUp)
+  observeMouse() {
+    let selectionChangeObserver, ignoreSelectionChange
+    const editor = this.editor
+
+    const onChangeSelectionRange = () => {
+      if (ignoreSelectionChange || this.mode === "insert" || this.withProp("operationStack", p => p.isProcessing())) {
+        return
+      }
+
+      if (this.mode === "visual") {
+        this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
+        this.cursorStyleManager.refresh()
+      } else if (this.haveSomeNonEmptySelection()) {
+        ignoreSelectionChange = true
+        this.activate("visual", this.swrap.detectWise(editor))
+        ignoreSelectionChange = false
+      }
     }
-    const handleMouseUp = event => {
-      this.editorElement.removeEventListener("mousemove", checkSelection)
+
+    const handleMouseDown = () => {
+      if (this.mode === "visual" && !this.haveSomeNonEmptySelection()) {
+        if (this.submode === "blockwise") {
+          this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
+        }
+        this.activate("normal")
+      }
+
+      for (const selection of editor.getSelections()) {
+        selection.initialScreenRange = selection.cursor.getScreenRange()
+      }
+      selectionChangeObserver = editor.onDidChangeSelectionRange(onChangeSelectionRange)
+    }
+
+    const handleMouseUp = () => {
+      selectionChangeObserver.dispose()
+      // if (this.mode === "visual") {
+      //   this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
+      //   this.cursorStyleManager.refresh()
+      // } else if (this.haveSomeNonEmptySelection()) {
+      //   // ignoreSelectionChange = true
+      //   this.activate("visual", this.swrap.detectWise(editor))
+      //   // ignoreSelectionChange = false
+      // }
+
     }
 
     this.editorElement.addEventListener("mousedown", handleMouseDown)
-    this.editorElement.addEventListener("focus", checkSelection)
+    this.editorElement.addEventListener("mouseup", handleMouseUp)
 
-    this.subscriptions.add(
-      new Disposable(() => {
-        this.editorElement.removeEventListener("mousedown", handleMouseDown)
-        this.editorElement.removeEventListener("focus", checkSelection)
-      }),
-      atom.commands.onDidDispatch(checkSelection)
-    )
+    return new Disposable(() => {
+      this.editorElement.removeEventListener("mousedown", handleMouseDown)
+      this.editorElement.removeEventListener("mouseup", handleMouseUp)
+    })
   }
 
   // What's this?

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -39,12 +39,13 @@ module.exports = class VimState {
   }
 
   // To modeManager
-  // prettier-ignore
-  get mode() { return this.modeManager.mode }
+  get mode() {
+    return this.modeManager.mode
+  }
   get submode() {
     return this.modeManager.submode
   }
-  // FIXME: REMOVE THIS
+  // FIXME: REMOVE THIS; DONT directly update submode just for skip normalization
   set submode(submode) {
     this.modeManager.submode = submode
   }
@@ -385,14 +386,13 @@ module.exports = class VimState {
   }
 
   observeMouse() {
-    let selectionChangeObserver, ignoreSelectionChange
-    const editor = this.editor
+    let selectionChangeObserver,
+      activateNormalOnMouseUp,
+      ignoreSelectionChange = false
 
-    const onChangeSelectionRange = () => {
-      if (ignoreSelectionChange || this.mode === "insert" || this.withProp("operationStack", p => p.isProcessing())) {
-        return
-      }
+    const {editor} = this
 
+    const updateVisualModeWithCurrentSelection = () => {
       if (this.mode === "visual") {
         this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
         this.cursorStyleManager.refresh()
@@ -403,37 +403,57 @@ module.exports = class VimState {
       }
     }
 
-    const handleMouseDown = () => {
+    const shouldIgnoreMouse = () => {
+      return ignoreSelectionChange || this.mode === "insert" || this.withProp("operationStack", p => p.isProcessing())
+    }
+
+    // To keep original cursor screen range(tail range of selection) keep selected on `shift+click`
+    // At this phase, cursor position is NOT yet updated, so we interact with original before-clicked cursor position.
+    const handleMouseDownCapture = () => {
+      if (shouldIgnoreMouse()) return
+      for (const selection of editor.getSelections()) {
+        selection.initialScreenRange = this.swrap(selection).getTailBufferRange()
+      }
+    }
+
+    const handleMouseDownBubble = () => {
+      activateNormalOnMouseUp = false
+      if (shouldIgnoreMouse()) return
+
       if (this.mode === "visual" && !this.haveSomeNonEmptySelection()) {
         if (this.submode === "blockwise") {
           this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
         }
-        this.activate("normal")
+        // We can't switch to normal mode here since selection might be modified by mousemove(drag).
+        activateNormalOnMouseUp = true
       }
 
-      for (const selection of editor.getSelections()) {
-        selection.initialScreenRange = selection.cursor.getScreenRange()
+      for (const selection of editor.getSelections().filter(s => s.isEmpty())) {
+        selection.initialScreenRange = this.swrap(selection).getTailBufferRange()
       }
-      selectionChangeObserver = editor.onDidChangeSelectionRange(onChangeSelectionRange)
+
+      // For shilft+click which not involve mousemove event.
+      updateVisualModeWithCurrentSelection()
+
+      selectionChangeObserver = editor.onDidChangeSelectionRange(() => {
+        if (ignoreSelectionChange) return
+        activateNormalOnMouseUp = false
+        updateVisualModeWithCurrentSelection()
+      })
     }
 
     const handleMouseUp = () => {
       selectionChangeObserver.dispose()
-      // if (this.mode === "visual") {
-      //   this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
-      //   this.cursorStyleManager.refresh()
-      // } else if (this.haveSomeNonEmptySelection()) {
-      //   // ignoreSelectionChange = true
-      //   this.activate("visual", this.swrap.detectWise(editor))
-      //   // ignoreSelectionChange = false
-      // }
+      if (activateNormalOnMouseUp) this.activate("normal")
     }
 
-    this.editorElement.addEventListener("mousedown", handleMouseDown)
+    this.editorElement.addEventListener("mousedown", handleMouseDownCapture, true)
+    this.editorElement.addEventListener("mousedown", handleMouseDownBubble, false)
     this.editorElement.addEventListener("mouseup", handleMouseUp)
 
     return new Disposable(() => {
-      this.editorElement.removeEventListener("mousedown", handleMouseDown)
+      this.editorElement.removeEventListener("mousedown", handleMouseDownCapture, true)
+      this.editorElement.removeEventListener("mousedown", handleMouseDownBubble, false)
       this.editorElement.removeEventListener("mouseup", handleMouseUp)
     })
   }

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -138,10 +138,7 @@ module.exports = class VimState {
     this.previousSelection = {}
     this.scrollAnimationEffect = null
 
-    this.subscriptions.add(
-      this.observeMouse(),
-      atom.commands.onDidDispatch(event => this.checkSelectionOnDidDispatch(event))
-    )
+    this.subscriptions.add(this.observeMouse(), this.observeCommandDispatch())
 
     this.editorElement.classList.add("vim-mode-plus")
 
@@ -357,38 +354,34 @@ module.exports = class VimState {
     return this.editor.getSelections().some(selection => !selection.isEmpty())
   }
 
-  checkSelectionOnDidDispatch(event) {
-    if (atom.workspace.getActiveTextEditor() !== this.editor) return
-    if (this.withProp("operationStack", p => p.isProcessing())) return // Don't populate lazy-prop on startup
-    if (this.mode === "insert") return
+  observeCommandDispatch() {
+    return atom.commands.onDidDispatch(event => {
+      if (atom.workspace.getActiveTextEditor() !== this.editor) return
+      if (this.withProp("operationStack", p => p.isProcessing())) return
+      if (this.mode === "insert") return
 
-    // Intentionally using target.closest('atom-text-editor')
-    // Don't use target.getModel() which is work for CustomEvent(=command) but not work for mouse event.
-    const {target} = event
-    if (!(target && target.closest && target.closest("atom-text-editor") === this.editorElement)) return
-    if (event.type.startsWith("vim-mode-plus")) return // to match vim-mode-plus: and vim-mode-plus-user:
+      // Intentionally using target.closest('atom-text-editor')
+      // Don't use target.getModel() which is work for CustomEvent(=command) but not work for mouse event.
+      const {target} = event
+      if (!(target && target.closest && target.closest("atom-text-editor") === this.editorElement)) return
+      if (event.type.startsWith("vim-mode-plus")) return // to match vim-mode-plus: and vim-mode-plus-user:
 
-    this.updateModeWithCurrentSelection()
-  }
-
-  updateModeWithCurrentSelection() {
-    if (this.haveSomeNonEmptySelection()) {
-      this.editorElement.component.updateSync()
-      const wise = this.swrap.detectWise(this.editor)
-      if (this.isMode("visual", wise)) {
-        for (const $selection of this.swrap.getSelections(this.editor)) {
-          $selection.saveProperties()
+      if (this.haveSomeNonEmptySelection()) {
+        this.editorElement.component.updateSync()
+        const wise = this.swrap.detectWise(this.editor)
+        if (this.isMode("visual", wise)) {
+          this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
+          this.cursorStyleManager.refresh()
+        } else {
+          this.activate("visual", wise)
         }
-        this.cursorStyleManager.refresh()
-      } else {
-        this.activate("visual", wise)
+      } else if (this.mode === "visual") {
+        if (this.submode === "blockwise") {
+          this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
+        }
+        this.activate("normal")
       }
-    } else if (this.mode === "visual") {
-      if (this.submode === "blockwise") {
-        this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
-      }
-      this.activate("normal")
-    }
+    })
   }
 
   observeMouse() {
@@ -434,7 +427,6 @@ module.exports = class VimState {
       //   this.activate("visual", this.swrap.detectWise(editor))
       //   // ignoreSelectionChange = false
       // }
-
     }
 
     this.editorElement.addEventListener("mousedown", handleMouseDown)


### PR DESCRIPTION
Fix #794

### Improvement summary

Works properly modify selection and shift to visual-mode if necessary, and keep original tail range kept selected while modifying selection by shift+click or mouse drag


- `shift+click` from empty selection
- `shift+click` with selection already exists situation(in-visual-mode).
- `mouse click and move(drag)` from empty selection
- `mouse click and move(drag)` with selection already exists situation(in-visual-mode). 
- `mouse click only` from empty selection (nothing to do)
- `mouse click only` shift to normal-mode.

### Why need to handle mousdown at capture phase?

- When selection is created by "shilft+click", it create selection from original cursor position to new cursor position.
- We need to keep original cursor screen range selected as like pure Vim way.
- I call this selection behavior that "keep selection tail range always selected" behavior.
- Tail range is 1 column width range of tail of selection.
- Atom's selection support this concept with `initialScreenRange` prop.
- `initialScreenRange` is kept "selected" while modifying selection with mouse.
