### PR TITLE
maximize-pane-toggle-centered

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -207,7 +207,9 @@
   'ctrl-w s': 'pane:split-down-and-copy-active-item'
 
   'ctrl-w z': 'vim-mode-plus:maximize-pane'
+  'ctrl-w Z': 'vim-mode-plus:maximize-pane-toggle-centered'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
+  # 'cmd-shift-enter': 'vim-mode-plus:maximize-pane-toggle-centered'
 
   'ctrl-w =': 'vim-mode-plus:equalize-panes'
 

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -207,9 +207,9 @@
   'ctrl-w s': 'pane:split-down-and-copy-active-item'
 
   'ctrl-w z': 'vim-mode-plus:maximize-pane'
-  'ctrl-w Z': 'vim-mode-plus:maximize-pane-toggle-centered'
+  'ctrl-w Z': 'vim-mode-plus:maximize-pane-without-center'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
-  # 'cmd-shift-enter': 'vim-mode-plus:maximize-pane-toggle-centered'
+  'cmd-shift-enter': 'vim-mode-plus:maximize-pane-without-center'
 
   'ctrl-w =': 'vim-mode-plus:equalize-panes'
 

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -209,7 +209,7 @@
   'ctrl-w z': 'vim-mode-plus:maximize-pane'
   'ctrl-w Z': 'vim-mode-plus:maximize-pane-without-center'
   'cmd-enter': 'vim-mode-plus:maximize-pane'
-  'cmd-shift-enter': 'vim-mode-plus:maximize-pane-without-center'
+  # 'cmd-shift-enter': 'vim-mode-plus:maximize-pane-without-center'
 
   'ctrl-w =': 'vim-mode-plus:equalize-panes'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -137,7 +137,7 @@ module.exports = {
       }),
       atom.commands.add("atom-workspace", {
         "vim-mode-plus:maximize-pane": () => this.getPaneUtils().maximizePane(),
-        "vim-mode-plus:maximize-pane-toggle-centered": () => this.getPaneUtils().toggleCentered(),
+        "vim-mode-plus:maximize-pane-without-center": () => this.getPaneUtils().maximizePane(false),
         "vim-mode-plus:equalize-panes": () => this.getPaneUtils().equalizePanes(),
         "vim-mode-plus:exchange-pane": () => this.getPaneUtils().exchangePane(),
         "vim-mode-plus:move-pane-to-very-top": () => this.getPaneUtils().movePaneToVery("top"),

--- a/lib/main.js
+++ b/lib/main.js
@@ -137,6 +137,7 @@ module.exports = {
       }),
       atom.commands.add("atom-workspace", {
         "vim-mode-plus:maximize-pane": () => this.getPaneUtils().maximizePane(),
+        "vim-mode-plus:maximize-pane-toggle-centered": () => this.getPaneUtils().toggleCentered(),
         "vim-mode-plus:equalize-panes": () => this.getPaneUtils().equalizePanes(),
         "vim-mode-plus:exchange-pane": () => this.getPaneUtils().exchangePane(),
         "vim-mode-plus:move-pane-to-very-top": () => this.getPaneUtils().movePaneToVery("top"),

--- a/lib/pane-utils.js
+++ b/lib/pane-utils.js
@@ -118,25 +118,23 @@ module.exports = class PaneUtils {
     movePaneToVery(direction)
   }
 
-  toggleCentered() {
-    if (this.isMaximized()) atom.workspace.getElement().classList.toggle("vim-mode-plus--pane-centered")
-  }
-
   isMaximized() {
     return atom.workspace.getElement().classList.contains("vim-mode-plus--pane-maximized")
   }
 
-  maximizePane() {
+  maximizePane(centerPane) {
     if (this.isMaximized()) {
       this.demaximizePane()
       return
     }
 
+    if (centerPane == null) centerPane = settings.get("centerPaneOnMaximizePane")
+
     const workspaceClassList = [
       "vim-mode-plus--pane-maximized",
       settings.get("hideTabBarOnMaximizePane") && "vim-mode-plus--hide-tab-bar",
       settings.get("hideStatusBarOnMaximizePane") && "vim-mode-plus--hide-status-bar",
-      settings.get("centerPaneOnMaximizePane") && "vim-mode-plus--pane-centered",
+      centerPane && "vim-mode-plus--pane-centered",
     ].filter(v => v)
     atom.workspace.getElement().classList.add(...workspaceClassList)
 

--- a/lib/pane-utils.js
+++ b/lib/pane-utils.js
@@ -118,49 +118,52 @@ module.exports = class PaneUtils {
     movePaneToVery(direction)
   }
 
+  toggleCentered() {
+    if (this.isMaximized()) atom.workspace.getElement().classList.toggle("vim-mode-plus--pane-centered")
+  }
+
+  isMaximized() {
+    return atom.workspace.getElement().classList.contains("vim-mode-plus--pane-maximized")
+  }
+
   maximizePane() {
-    if (this.maximizePaneDisposable) {
+    if (this.isMaximized()) {
       this.demaximizePane()
       return
     }
 
-    this.maximizePaneDisposable = new CompositeDisposable()
+    const workspaceClassList = [
+      "vim-mode-plus--pane-maximized",
+      settings.get("hideTabBarOnMaximizePane") && "vim-mode-plus--hide-tab-bar",
+      settings.get("hideStatusBarOnMaximizePane") && "vim-mode-plus--hide-status-bar",
+      settings.get("centerPaneOnMaximizePane") && "vim-mode-plus--pane-centered",
+    ].filter(v => v)
+    atom.workspace.getElement().classList.add(...workspaceClassList)
 
-    const addClassList = (element, classList) => {
-      classList = classList.map(className => `vim-mode-plus--${className}`)
-      element.classList.add(...classList)
-      this.maximizePaneDisposable.add(new Disposable(() => element.classList.remove(...classList)))
-    }
-
-    const workspaceClassList = ["pane-maximized"]
-    if (settings.get("hideTabBarOnMaximizePane")) {
-      workspaceClassList.push("hide-tab-bar")
-    }
-    if (settings.get("hideStatusBarOnMaximizePane")) {
-      workspaceClassList.push("hide-status-bar")
-    }
-    if (settings.get("centerPaneOnMaximizePane")) {
-      workspaceClassList.push("pane-centered")
-    }
-    addClassList(atom.workspace.getElement(), workspaceClassList)
-
-    const activePane = atom.workspace.getActivePane()
-    const activePaneElement = activePane.getElement()
-    addClassList(activePaneElement, ["active-pane"])
-
-    const root = activePane.getContainer().getRoot()
-    forEachPaneAxis(root, paneAxis => {
-      const element = paneAxis.getElement()
+    const activePaneElement = atom.workspace.getActivePane().getElement()
+    activePaneElement.classList.add("vim-mode-plus--active-pane")
+    for (const element of atom.workspace.getElement().getElementsByTagName("atom-pane-axis")) {
       if (element.contains(activePaneElement)) {
-        addClassList(element, ["active-pane-axis"])
+        element.classList.add("vim-mode-plus--active-pane-axis")
       }
-    })
+    }
   }
 
   demaximizePane() {
-    if (this.maximizePaneDisposable) {
-      this.maximizePaneDisposable.dispose()
-      this.maximizePaneDisposable = null
+    if (this.isMaximized()) {
+      const workspaceElement = atom.workspace.getElement()
+      workspaceElement.classList.remove(
+        "vim-mode-plus--pane-maximized",
+        "vim-mode-plus--hide-tab-bar",
+        "vim-mode-plus--hide-status-bar",
+        "vim-mode-plus--pane-centered"
+      )
+      for (const element of workspaceElement.getElementsByTagName("atom-pane-axis")) {
+        element.classList.remove("vim-mode-plus--active-pane-axis")
+      }
+      for (const element of workspaceElement.getElementsByTagName("atom-pane")) {
+        element.classList.remove("vim-mode-plus--active-pane")
+      }
     }
   }
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -296,6 +296,8 @@ module.exports = new Settings("vim-mode-plus", {
   },
   centerPaneOnMaximizePane: {
     default: true,
+    description:
+      "Set to `false`, if you never need centering effect.<br>If you usually want centering but **occasionally** don't, leave this setting to `true` and use `vim-mode-plus:maximize-pane`(`cmd-enter` or `ctrl-w z`) and `vim-mode-plus:maximize-pane-without-center`(`ctrl-w Z`) command respectively.",
   },
   smoothScrollOnFullScrollMotion: {
     default: false,


### PR DESCRIPTION
somewhat continuation of #828.

- For my usecase, centering effect is always preferable( I use 1920x1080 resolution monitor ).
- But I also admit for some text, I want to de-center when maximized.
- So I want explicitly use different command for maximize without centering.

This pr add `vim-mode-plus:maximize-pane-without-center` command.
Which maximize without centering effect.

## keymap

`ctrl-w Z` on text-editor scope
not `cmd-enter` corresponding keymap(I wanted but I can't find safe keymap).

Example keymap to use `cmd-shift-enter`

```coffeescript
'atom-text-editor.vim-mode-plus:not(.insert-mode)':
  'cmd-shift-enter': 'vim-mode-plus:maximize-pane-without-center'
````

## Along with above enhancement, this PR include following code simplification.

- Remove `maximizePaneDisposable` state.
- DOM classList hold state, and we can stupidly(I like this stupidity) remove CSS class by find and remove on demaximize.
