### PR TITLE
add  allowMoveToOffScreenColumnOnScreenLineMotion config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.99.0:
+- New: Screen line based column motion commands `g 0`, `g ^` and `g $`.
+  Commands:
+    - `move-to-beginning-of-screen-line`( keymap `g 0` )
+    - `move-to-first-character-of-screen-line`( keymap `g ^` )
+    - `move-to-last-character-of-screen-line`( keymap `g $` )
+  Config: `allowMoveToOffScreenColumnOnScreenLineMotion`( vim-mode-plus original ).
+    - Affects how `g 0`, `g ^` and `g $` find destination position.
+    - When a line is wider than the screen width(no-wrapped line a)
+      - `true`(default): move to off-screen column.
+      - `false`: move to on-screen(visible) column( = Vim default ).
+    - Behavioral difference appears only when
+      - Line is not wrapped.
+      - Destination column is off-screen(invisible because of the line is wider than screen width).
+        - for `g 0`: column-0 is off-screen
+          - `true`: move to column-0.
+          - `false`: move to first-visible-column.
+        - for `g ^`: first-char-column is off-screen
+          - `true`: move to first-char-column.
+          - `false`: move to first-visible-char-column.
+        - for `g $`: last-char-column is off-screen
+          - `true`: move to last-char-column.
+          - `false`: move to last-visible-char-column.
+
 # 0.98.0:
 - Improve: Now `r`, `f`, `F`, `t`, `T` and `surround` use mini-editor to read user-input. #838
   - Benefit?

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -607,18 +607,6 @@ MoveToLastCharacterOfLine:
   file: "./motion"
   commandName: "vim-mode-plus:move-to-last-character-of-line"
   commandScope: "atom-text-editor"
-MoveToBeginningOfScreenLine:
-  file: "./motion"
-  commandName: "vim-mode-plus:move-to-beginning-of-screen-line"
-  commandScope: "atom-text-editor"
-MoveToFirstCharacterOfScreenLine:
-  file: "./motion"
-  commandName: "vim-mode-plus:move-to-first-character-of-screen-line"
-  commandScope: "atom-text-editor"
-MoveToLastCharacterOfScreenLine:
-  file: "./motion"
-  commandName: "vim-mode-plus:move-to-last-character-of-screen-line"
-  commandScope: "atom-text-editor"
 MoveToLastNonblankCharacterOfLineAndDown:
   file: "./motion"
   commandName: "vim-mode-plus:move-to-last-nonblank-character-of-line-and-down"
@@ -642,6 +630,20 @@ MoveToFirstCharacterOfLineAndDown:
 MoveToFirstLine:
   file: "./motion"
   commandName: "vim-mode-plus:move-to-first-line"
+  commandScope: "atom-text-editor"
+MoveToScreenColumn:
+  file: "./motion"
+MoveToBeginningOfScreenLine:
+  file: "./motion"
+  commandName: "vim-mode-plus:move-to-beginning-of-screen-line"
+  commandScope: "atom-text-editor"
+MoveToFirstCharacterOfScreenLine:
+  file: "./motion"
+  commandName: "vim-mode-plus:move-to-first-character-of-screen-line"
+  commandScope: "atom-text-editor"
+MoveToLastCharacterOfScreenLine:
+  file: "./motion"
+  commandName: "vim-mode-plus:move-to-last-character-of-screen-line"
   commandScope: "atom-text-editor"
 MoveToLastLine:
   file: "./motion"

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -684,35 +684,27 @@ class MoveToFirstLine extends Motion
   getRow: ->
     @getCount(-1)
 
-# keymap: g 0
-class MoveToBeginningOfScreenLine extends Motion
-  @extend()
+class MoveToScreenColumn extends Motion
+  @extend(false)
   moveCursor: (cursor) ->
-    row = cursor.getScreenRow()
-    column = @editor.getFirstVisibleScreenColumn()
-    cursor.setScreenPosition([row, column])
+    allowOffScreenPosition = @getConfig("allowMoveToOffScreenColumnOnScreenLineMotion")
+    point = @vimState.utils.getScreenPositionForScreenRow(@editor, cursor.getScreenRow(), @which, {allowOffScreenPosition})
+    @setScreenPositionSafely(cursor, point)
+
+# keymap: g 0
+class MoveToBeginningOfScreenLine extends MoveToScreenColumn
+  @extend()
+  which: "beginning"
 
 # g ^: `move-to-first-character-of-screen-line`
-class MoveToFirstCharacterOfScreenLine extends Motion
+class MoveToFirstCharacterOfScreenLine extends MoveToScreenColumn
   @extend()
-  moveCursor: (cursor) ->
-    row = cursor.getScreenRow()
-    startColumn = @editor.getFirstVisibleScreenColumn()
-    scanRange = @editor.bufferRangeForScreenRange([[row, startColumn], [row, Infinity]])
-
-    firstCharacterPosition = null
-    @editor.scanInBufferRange /\S/, scanRange, ({range}) =>
-      firstCharacterPosition = range.start
-    if firstCharacterPosition
-      cursor.setBufferPosition(firstCharacterPosition)
+  which: "first-character"
 
 # keymap: g $
-class MoveToLastCharacterOfScreenLine extends Motion
+class MoveToLastCharacterOfScreenLine extends MoveToScreenColumn
   @extend()
-  moveCursor: (cursor) ->
-    row = cursor.getScreenRow()
-    column = @editor.getFirstVisibleScreenColumn() + @editor.getEditorWidthInChars()
-    cursor.setScreenPosition([row, column])
+  which: "last-character"
 
 # keymap: G
 class MoveToLastLine extends MoveToFirstLine

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -267,7 +267,7 @@ module.exports = new Settings("vim-mode-plus", {
   allowMoveToOffScreenColumnOnScreenLineMotion: {
     default: true,
     description:
-      "Affects how `g 0`, `g ^` and `g $` find destnation position<br>When a line is wider than the screen width(no-wrapped line)<br> - `false`: move to on-screen column(Vim default)<br> - `true`: move to off-screen column of same screen-line",
+      "Affects how `g 0`, `g ^` and `g $` find destination position<br>When a line is wider than the screen width(no-wrapped line)<br> - `false`: move to on-screen( visible ) column( Vim default )<br> - `true`: move to off-screen column of same screen-line",
   },
   flashOnUndoRedo: true,
   flashOnMoveToOccurrence: {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -264,6 +264,11 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Almost equivalent to `startofline` pure-Vim option. When true, move cursor to first char.<br>\nAffects to `ctrl-f, b, d, u`, `G`, `H`, `M`, `L`, `gg`<br>\nUnlike pure-Vim, `d`, `<<`, `>>` are not affected by this option, use independent `stayOn` options.",
   },
+  allowMoveToOffScreenColumnOnScreenLineMotion: {
+    default: true,
+    description:
+      "Affects how `g 0`, `g ^` and `g $` find destnation position<br>When a line is wider than the screen width(no-wrapped line)<br> - `false`: move to on-screen column(Vim default)<br> - `true`: move to off-screen column of same screen-line",
+  },
   flashOnUndoRedo: true,
   flashOnMoveToOccurrence: {
     default: false,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -205,6 +205,30 @@ function getFirstCharacterPositionForBufferRow(editor, row) {
   return range ? range.start : new Point(row, 0)
 }
 
+function getScreenPositionForScreenRow(editor, row, which, {allowOffScreenPosition = false} = {}) {
+  if (which === "beginning") {
+    const column = allowOffScreenPosition ? 0 : editor.getFirstVisibleScreenColumn()
+    return new Point(row, column)
+  } else if (which === "last-character") {
+    const column = allowOffScreenPosition
+      ? Infinity
+      : editor.getFirstVisibleScreenColumn() + editor.getEditorWidthInChars()
+    return new Point(row, column)
+  } else if (which === "first-character") {
+    let point
+
+    const column = allowOffScreenPosition
+      ? editor.clipScreenPosition([row, 0], {skipSoftWrapIndentation: true}).column
+      : editor.getFirstVisibleScreenColumn()
+
+    const scanRange = editor.bufferRangeForScreenRange([[row, column], [row, Infinity]])
+    editor.scanInBufferRange(/\S/, scanRange, ({range}) => {
+      point = editor.screenPositionForBufferPosition(range.start)
+    })
+    return point
+  }
+}
+
 function trimRange(editor, rangeToTrim) {
   let start, end
   const regex = /\S/
@@ -1103,6 +1127,7 @@ module.exports = {
   getBufferRangeForRowRange,
   trimRange,
   getFirstCharacterPositionForBufferRow,
+  getScreenPositionForScreenRow,
   isIncludeFunctionScopeForRow,
   detectScopeStartPositionForScope,
   getBufferRows,

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -13,7 +13,7 @@ describe "Motion Find", ->
       {editor, editorElement} = vimState
       {set, ensure, keystroke} = _vim
 
-  describe 'the f performance', ->
+  xdescribe 'the f performance', ->
     timesToExecute = 500
     # timesToExecute = 1
     measureWithTimeEnd = (fn) ->

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -1131,7 +1131,7 @@ describe "Motion general", ->
         beforeEach -> settings.set('allowMoveToOffScreenColumnOnScreenLineMotion', true)
 
         describe "softwrap = false, firstColumnIsVisible = true", ->
-          beforeEach -> set cursor: [0, 3];
+          beforeEach -> set cursor: [0, 3]
           it "move to column 0 of screen line", -> ensure "g 0", cursor: [0, 0]
 
         describe "softwrap = false, firstColumnIsVisible = false", ->
@@ -1195,7 +1195,6 @@ describe "Motion general", ->
           it "move to first-char of screen line", ->
             set cursorScreen: [0, 3]; ensure "g ^", cursorScreen: [0, 1]
             set cursorScreen: [1, 3]; ensure "g ^", cursorScreen: [1, 1] # skip softwrap indentation.
-
     describe "the g $ keybinding", ->
       describe "allowMoveToOffScreenColumnOnScreenLineMotion = true(default)", ->
         beforeEach -> settings.set('allowMoveToOffScreenColumnOnScreenLineMotion', true)

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -1095,7 +1095,7 @@ describe "Motion general", ->
 
   describe "the 0 keybinding", ->
     beforeEach ->
-      set text: "  abcde", cursor: [0, 4]
+      set textC: "  ab|cde"
 
     describe "as a motion", ->
       it "moves the cursor to the first column", ->
@@ -1154,14 +1154,6 @@ describe "Motion general", ->
         ensure 'd $',
           text: "  ab\n\n1234567890"
           cursor: [0, 3]
-
-  describe "the 0 keybinding", ->
-    beforeEach ->
-      set text: "  a\n", cursor: [0, 2],
-
-    describe "as a motion", ->
-      it "moves the cursor to the beginning of the line", ->
-        ensure '0', cursor: [0, 0]
 
   describe "the - keybinding", ->
     beforeEach ->


### PR DESCRIPTION
Continuation of 302f5291c5c8a707ae4a5159996c8b5d3e226712
related #724


Add config option to tweak behavior:
Pure-vim's `g 0`, `g ^`, `g $` find destination column within visible screen column.
But for non-wrapped line, I want to move to find from same screen-line including off-screen position of same screen line.
