### PR TITLE
:gift: keymap config helper for Y as y $

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.99.0:
-- New: Conditional keymap config `keymapYToYankToLastCharacterOfLine`.
+- New: Conditional keymap config `keymapYToYankToLastCharacterOfLine`(default `false`).
   - By default `Y` behaves as `y y`.
   - This is not consistent with `C` and `D` which behaves `c $` and `d $`.
   - By enabling this `Y` behaves as `y $`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 0.99.0:
+- New: Conditional keymap config `keymapYToYankToLastCharacterOfLine`.
+  - By default `Y` behaves as `y y`.
+  - This is not consistent with `C` and `D` which behaves `c $` and `d $`.
+  - By enabling this `Y` behaves as `y $`.
 - Fix: Incorrect mouse selection when editor was soft-wrapped.
 - New: Screen line based column motion commands `g 0`, `g ^` and `g $`.
   Commands:

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -79,6 +79,11 @@ class Settings {
 
   observeConditionalKeymaps() {
     const conditionalKeymaps = {
+      keymapYToYankToLastCharacterOfLine: {
+        "atom-text-editor.vim-mode-plus:not(.insert-mode)": {
+          Y: "vim-mode-plus:yank-to-last-character-of-line",
+        },
+      },
       keymapUnderscoreToReplaceWithRegister: {
         "atom-text-editor.vim-mode-plus:not(.insert-mode)": {
           _: "vim-mode-plus:replace-with-register",
@@ -134,6 +139,11 @@ class Settings {
 }
 
 module.exports = new Settings("vim-mode-plus", {
+  keymapYToYankToLastCharacterOfLine: {
+    default: false,
+    description:
+      "Make `Y` behave as `y $` instead of default `y y`, This make `Y` consistent with `C`(works as `c $`) and `D`(works as `d $`)"
+  },
   keymapUnderscoreToReplaceWithRegister: {
     default: false,
     description:

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -1132,7 +1132,6 @@ describe "Motion general", ->
       _123456789B123456789C123456789
       """
       jasmine.attachToDOM(getView(atom.workspace))
-      # jasmine.attachToDOM(edit)
       waitsForPromise ->
         setEditorWidthInCharacters(editor, 10)
 


### PR DESCRIPTION
Ideas from discussion with @calebmeyer in https://github.com/t9md/atom-vim-mode-plus/issues/728#issuecomment-325071863.

- New: Conditional keymap config `keymapYToYankToLastCharacterOfLine`(default `false`).
  - By default `Y` behaves as `y y`.
  - This is not consistent with `C` and `D` which behaves `c $` and `d $`.
  - By enabling this `Y` behaves as `y $`.
