### PR TITLE
Clear flash marker on pane-item change to workaround keyframe anime being re-started

### DIFF
--- a/lib/flash-manager.js
+++ b/lib/flash-manager.js
@@ -73,7 +73,7 @@ function removeDemoSuffix(decoration) {
   replaceDecorationClassBy(text => text.replace(/-demo$/, ""), decoration)
 }
 
-module.exports = FlashManager = class FlashManager {
+module.exports = class FlashManager {
   constructor(vimState) {
     this.vimState = vimState
     this.editor = this.vimState.editor
@@ -83,8 +83,7 @@ module.exports = FlashManager = class FlashManager {
   }
 
   destroy() {
-    this.markersByType.forEach(markers => markers.map(marker => marker.destroy()))
-    this.markersByType.clear()
+    this.clearAllMarkers()
   }
 
   destroyDemoModeMarkers() {
@@ -106,12 +105,11 @@ module.exports = FlashManager = class FlashManager {
     const markerOptions = {invalidate: "touch"}
 
     const markers = ranges.map(range => this.editor.markBufferRange(range, markerOptions))
-    if (!allowMultiple) {
-      if (this.markersByType.has(type)) {
-        this.markersByType.get(type).forEach(marker => marker.destroy())
-      }
-      this.markersByType.set(type, markers)
+    if (!allowMultiple && this.markersByType.has(type)) {
+      this.markersByType.get(type).forEach(marker => marker.destroy())
     }
+    // hold as state to clear all markers onDidStopChangingActivePaneItem. t9md/vim-mode-plus#844.
+    this.markersByType.set(type, markers)
 
     const decorations = markers.map(marker => this.editor.decorateMarker(marker, decorationOptions))
 
@@ -124,5 +122,10 @@ module.exports = FlashManager = class FlashManager {
     } else {
       this.destroyMarkersAfter(markers, timeout)
     }
+  }
+
+  clearAllMarkers() {
+    this.markersByType.forEach(markers => markers.forEach(marker => marker.destroy()))
+    this.markersByType.clear()
   }
 }

--- a/lib/flash-manager.js
+++ b/lib/flash-manager.js
@@ -108,7 +108,7 @@ module.exports = class FlashManager {
     if (!allowMultiple && this.markersByType.has(type)) {
       this.markersByType.get(type).forEach(marker => marker.destroy())
     }
-    // hold as state to clear all markers onDidStopChangingActivePaneItem. t9md/vim-mode-plus#844.
+    // hold as state to clear all markers onDidStopChangingActivePaneItem. t9md/vim-mode-plus#846.
     this.markersByType.set(type, markers)
 
     const decorations = markers.map(marker => this.editor.decorateMarker(marker, decorationOptions))

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,8 @@ module.exports = {
         }
         if (item.isMini()) return
 
+        VimState.forEach(vimState => vimState.clearFlash())
+
         // Still there is possibility editor is destroyed and don't have corresponding
         // vimState #196.
         const vimState = this.getEditorState(item)

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,9 @@ module.exports = {
         }
         if (item.isMini()) return
 
+        // [FIXME] Clear existing flash markers for all vimState to avoid hide/show editor re-start flash animation.
+        // This is workaround for "the keyframe animation being restarted on re-activating editor"-issue.
+        // Ideally I want to remove this and keyframe animation state is mainained across hide/show editor item.
         VimState.forEach(vimState => vimState.clearFlash())
 
         // Still there is possibility editor is destroyed and don't have corresponding

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -63,6 +63,9 @@ module.exports = class VimState {
   flashScreenRange(...args) {
     this.flashManager.flashScreenRange(...args)
   }
+  clearFlash() {
+    this.__flashManager && this.flashManager.clearAllMarkers()
+  }
   // To OperationStack
   subscribe(...args) {
     return this.operationStack.subscribe(...args)


### PR DESCRIPTION
Workaround re-activating pane item re-start keyframe issue commented in https://github.com/t9md/atom-vim-mode-plus/issues/843#issuecomment-325100369.

Also reported to https://github.com/atom/atom/issues/15451.

By immediately clear all marker used for flash when active pane item changed.
This make sure user no longer see remaining flash-marker re-trigger keyframe animation on re-activating editor after tab switch/back.