### PR TITLE
[default change] `stayOn` default true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,20 @@
-# 1.0.0: [WIP]
+# 1.0.0: [WIP] Big change on default config value.
 - Breaking: Renamed config parameter name, changed default value.
-  - Automatically migrate existing config on activation of vmp.
-  - By renaming, we have member of `stayOn` prefixed config which shares same purpose.
-    - Purpose of renaming is to have `stayOn` shared prefix since it's purpose is same.
+  - Summary:
+    - Some configuration parameter name is renamed to have `stayOn` prefix.
+      - Automatically migrate existing config on activation of vmp.
+    - Now all `stayOn` prefixed configuration have new default value `true`( was `false` ).
+    - What is `stayOnXXX` configuration?
       - Respect original cursor position as much as possible after operation( select, move, operate ).
       - It keep both cursor's row and column or column only( if vertical move was necessary ).
   - Config params renamed and changed default value
-    - Param: `keepColumnOnSelectTextObject`
-      - Renamed to `stayOnSelectTextObject`
-      - New default `true`
-        - `true`: keep original cursor column when selecting text object(e.g. `v i p`).
-        - `false`: cursor moved to end of selection.
-    - Param: `incrementalSearch`
-      - New default: `true`
-        - `true`, visit matched position as you type search term.
-        - `false`, move to matched position after you confirmed by `enter`.
-    - Param: `moveToFirstCharacterOnVerticalMotion`
-      - Renamed to `stayOnVerticalMotion` with meaning **inverted**
-      - New default: `true`
-        - `true`, keep cursor column on vertical motion(e.g. `ctrl-f, b, d, u`, `G`, `g g` etc.)
-        - `false`, Move to first non-blank char after vertical move.
-      - What's "meaning **inverted**"?
-        - `(stayOnVerticalMotion = true) === (moveToFirstCharacterOnVerticalMotion = false)`
+    - New default: `incrementalSearch` = `true`
+    - New default: `stayOnTransformString` = `true`
+    - New default: `stayOnYank` = `true`
+    - New default: `stayOnDelete` = `true`
+    - Renamed/New default: `keepColumnOnSelectTextObject` > `stayOnSelectTextObject` = `true`
+    - Renamed/New default: `moveToFirstCharacterOnVerticalMotion` !> `stayOnVerticalMotion` = `true`
+      - Renamed with meaning inverted: `(stayOnVerticalMotion = true) === (moveToFirstCharacterOnVerticalMotion = false)`
 
 # 0.99.1:
 - Fix: Attempt to user non-yet-supported register( such as `" 0 y` ) no longer throw exception.

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -284,15 +284,15 @@ module.exports = new Settings("vim-mode-plus", {
     description: "When `relative`, `tab`, and `shift-tab` respect search direction('/' or '?')",
   },
   stayOnTransformString: {
-    default: false,
+    default: true,
     description: "Don't move cursor after TransformString e.g upper-case, surround",
   },
   stayOnYank: {
-    default: false,
+    default: true,
     description: "Don't move cursor after yank",
   },
   stayOnDelete: {
-    default: false,
+    default: true,
     description: "Don't move cursor after delete",
   },
   stayOnOccurrence: {

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -992,36 +992,38 @@ describe "Motion general", ->
 
   describe "the b keybinding", ->
     beforeEach ->
-      set text: " ab cde1+- \n xyz\n\nzip }\n last"
+      set
+        textC_: """
+        _ab cde1+-_
+        _xyz
+
+        zip }
+        _|last
+        """
 
     describe "as a motion", ->
-      beforeEach ->
-        set cursor: [4, 1]
-
       it "moves the cursor to the beginning of the previous word", ->
-        ensure 'b', cursor: [3, 4]
-        ensure 'b', cursor: [3, 0]
-        ensure 'b', cursor: [2, 0]
-        ensure 'b', cursor: [1, 1]
-        ensure 'b', cursor: [0, 8]
-        ensure 'b', cursor: [0, 4]
-        ensure 'b', cursor: [0, 1]
+        ensure 'b', textC: " ab cde1+- \n xyz\n\nzip |}\n last"
+        ensure 'b', textC: " ab cde1+- \n xyz\n\n|zip }\n last"
+        ensure 'b', textC: " ab cde1+- \n xyz\n|\nzip }\n last"
+        ensure 'b', textC: " ab cde1+- \n |xyz\n\nzip }\n last"
+        ensure 'b', textC: " ab cde1|+- \n xyz\n\nzip }\n last"
+        ensure 'b', textC: " ab |cde1+- \n xyz\n\nzip }\n last"
+        ensure 'b', textC: " |ab cde1+- \n xyz\n\nzip }\n last"
 
         # Go to start of the file, after moving past the first word
-        ensure 'b', cursor: [0, 0]
-        # Stay at the start of the file
-        ensure 'b', cursor: [0, 0]
+        ensure 'b', textC: "| ab cde1+- \n xyz\n\nzip }\n last"
+        # Do nothing
+        ensure 'b', textC: "| ab cde1+- \n xyz\n\nzip }\n last"
 
     describe "as a selection", ->
       describe "within a word", ->
         it "selects to the beginning of the current word", ->
-          set cursor: [0, 2]
-          ensure 'y b', cursor: [0, 1], register: '"': text: 'a'
+          set textC: " a|b cd"; ensure 'y b', textC: " |ab cd", register: '"': text: 'a'
 
       describe "between words", ->
         it "selects to the beginning of the last word", ->
-          set cursor: [0, 4]
-          ensure 'y b', cursor: [0, 1], register: '"': text: 'ab '
+          set textC: " ab |cd"; ensure 'y b', textC: " |ab cd", register: '"': text: 'ab '
 
   describe "the B keybinding", ->
     beforeEach ->
@@ -1301,7 +1303,6 @@ describe "Motion general", ->
     describe "from the middle of a line", ->
       beforeEach ->
         set cursor: [1, 3]
-
       describe "as a motion", ->
         it "moves the cursor to the last character of the previous line", ->
           ensure '-', cursor: [0, 0]
@@ -1321,8 +1322,8 @@ describe "Motion general", ->
       describe "as a selection", ->
         it "selects to the first character of the previous line (directly above)", ->
           ensure 'd -', text: "abcdefg\n"
-          # commented out because the column is wrong due to a bug in `k`; re-enable when `k` is fixed
-          #expect(editor.getCursorScreenPosition()).toEqual [0, 2]
+          # FIXME commented out because the column is wrong due to a bug in `k`; re-enable when `k` is fixed
+          # ensure cursor: [0, 2]
 
     describe "from the beginning of a line preceded by an indented line", ->
       beforeEach ->

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -149,14 +149,12 @@ describe "Operator general", ->
 
       it "leaves the cursor on the first nonblank character", ->
         set
-          text: """
-          12345
+          textC: """
+          1234|5
             abcde\n
           """
-          cursor: [0, 4]
         ensure 'd d',
-          text: "  abcde\n"
-          cursor: [0, 2]
+          textC: "  |abcde\n"
 
     describe "undo behavior", ->
       [originalText, initialTextC] = []
@@ -542,9 +540,8 @@ describe "Operator general", ->
   describe "the y keybinding", ->
     beforeEach ->
       set
-        cursor: [0, 4]
-        text: """
-        012 345
+        textC: """
+        012 |345
         abc\n
         """
 
@@ -563,9 +560,8 @@ describe "Operator general", ->
     describe "visual-mode.linewise", ->
       beforeEach ->
         set
-          cursor: [0, 4]
-          text: """
-            000000
+          textC: """
+            0000|00
             111111
             222222\n
             """

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -3,6 +3,7 @@ semver = require 'semver'
 {Range, Point, Disposable} = require 'atom'
 {inspect} = require 'util'
 globalState = require '../lib/global-state'
+settings = require '../lib/settings'
 
 KeymapManager = atom.keymaps.constructor
 {normalizeKeystrokes} = require(atom.config.resourcePath + "/node_modules/atom-keymap/lib/helpers")
@@ -21,6 +22,9 @@ supportedModeClass = [
 # -------------------------
 beforeEach ->
   globalState.reset()
+  settings.set("stayOnTransformString", false)
+  settings.set("stayOnYank", false)
+  settings.set("stayOnDelete", false)
 
 # Utils
 # -------------------------


### PR DESCRIPTION
Part of #728 

- Make following `stayOn` config `true`
  - `stayOnTransformString`
  - `stayOnDelete`
  - `stayOnYank`

- In test-spec keep it's default to `false`( old default value ).
  - To avoid verbose switching( also can easily reverted )
  - `stayOn = true` test already have dedicated section
  - basically `stayOn = false` is more behavioral variation depending on targets. Worthwhile to test in more scenarios.
