### PR TITLE
Better `f` as chimera of clever-f  and vim-seek.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# 1.1.0: [WIP] Tryout to make `f` better.
+
+- New: Now `f` is **tunable** to make it better, more efficient. #852.
+  - Inspired pure-vim's plugins: `clever-f`, `vim-seek`, `vim-sneak`.
+  - Highlighting find-char find-char help pre-determine consequence of repeat.
+  - Aiming to get both benefit of two-char find(`vim-seek`, `vim-sneak`) and one-char-find( vim's default ).
+  - Reuse `f`, `F` to repeat find like `clever-f`.
+- Config: Following configuration option is available to **tune** `f` motion.
+  - `keymapSemicolonToConfirmFind`: default `false`.
+    - See explanation for `findByTwoChars`.
+  - `ignoreCaseForFind`: default `false`
+  - `useSmartcaseForFind`: default `false`
+  - `highlightFindChar`: default `true`
+    - Highlight find char, fadeout automatically( this auto-disappearing behavior is not configurable ).
+  - `findByTwoChars`: default `false`
+    - When enabled, `f` accept TWO chars.
+      - Pros. Greatly reduces matches, less chance of retry by `;` or `,`.
+      - Cons. You need to **confirm** for single char-input. You might mitigate frustration by.
+        - Confirm by `;`( easier to type and well blend to forwarding repeat-find( `;` ))
+          - Enable "keymap `;` to confirm `find` motion"( `keymapSemicolonToConfirmFind` ) configuration.
+          - e.g. `f a ;` to move to `a`( better than `f a enter`?). `f a ; ;` to move to 2nd `a`(well blended to default repeat-find(`;`)).
+        - Enable auto confirm by timeout( See. `findByTwoCharsAutoConfirmTimeout` )
+  - `findByTwoCharsAutoConfirmTimeout`: default `0`.
+    - "When `findByTwoChars` was enabled, automatically confirm single-char input on timeout( msec ).
+    - `0` means no timeout.
+  - `reuseFindForRepeatFind`: default `false`
+    - When `true` you can repeat last-find by `f` and `F`(also `t` and `T`).
+    - You still can use `,` and `;`.
+    - e.g. `f a f` move cursor to 2nd `a`.
+  - My configuration( I'm still in-eval phase, don't take this as recommendation )
+    ```coffeescript
+    findByTwoChars: true
+    findByTwoCharsAutoConfirmTimeout: 200
+    reuseFindForRepeatFind: true
+    useSmartcaseForFind: true
+    ```
+
 # 1.0.0: New default `stayOn` all `true`.
 - Version: Decided to bump major version.
 - Breaking: Default config change/Renamed config name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,24 @@
-# 1.1.0: [WIP] Tryout to make `f` better.
-
-- New: Now `f` is **tunable** to make it better, more efficient. #852.
+# 1.1.0: This release is all for better `f` by making it tunable
+- New: [Summary] Now `f` is **tunable**. #852.
   - Inspired pure-vim's plugins: `clever-f`, `vim-seek`, `vim-sneak`.
-  - Highlighting find-char help you to pre-determine consequence of repeat by `;`, `,` and `.`.
-  - Aiming to get both benefit of two-char find(`vim-seek`, `vim-sneak`) and one-char-find( vim's default ).
-    - When two-char input was enabled, you still can auto-confirm single-char input by specified timeout.
-  - Can reuse `f`, `F` to repeat find like `clever-f`.
-- Config: Following configuration option is available to **tune** `f`.
+  - Highlighting find-char. It help you to pre-determine consequence of repeat by `;`, `,` and `.`.
+  - Aiming to get both benefit of two-char-find(`vim-seek`, `vim-sneak`) and one-char-find( vim's default ).
+    - Even after two-char-find was enabled, you can auto-confirm one-char input by specified timeout.
+  - Can reuse `f`, `F`, `t`, `T` as `repeat-find` like `clever-f`.
+- Config: [Detail] Following configuration option is available to **tune** `f`.
   - `keymapSemicolonToConfirmFind`: default `false`.
     - See explanation for `findByTwoChars`.
   - `ignoreCaseForFind`: default `false`
   - `useSmartcaseForFind`: default `false`
   - `highlightFindChar`: default `true`
-    - Highlight find char, fadeout automatically( this auto-disappearing behavior is not configurable ).
+    - Highlight find char, fadeout automatically( this auto-disappearing behavior/duration is not configurable ).
+      - Fadeout in 2 second when used as motion.
+      - Fadeout in 4 second when used as operator-target.
   - `findByTwoChars`: default `false`
     - When enabled, `f` accept TWO chars.
-      - Pros. Greatly reduces matches, less chance of retry by `;` or `,`.
-      - Cons. You need to **confirm** for single char-input. You might mitigate frustration by.
-        - Confirm by `;`( easier to type and well blend to forwarding repeat-find( `;` ))
+      - Pros. Greatly reduces possible matches, avoid being stopped at earlier spot than where you aimed.
+      - Cons. Require explicit **confirmation** by `enter` for single char-input. You might mitigate frustration by.
+        - Confirm by `;`, easier to type and well blend to forwarding `repeat-find`( `;` ).
           - Enable "keymap `;` to confirm `find` motion"( `keymapSemicolonToConfirmFind` ) configuration.
           - e.g. `f a ;` to move to `a`( better than `f a enter`?). `f a ; ;` to move to 2nd `a`(well blended to default repeat-find(`;`)).
         - Enable auto confirm by timeout( See. `findByTwoCharsAutoConfirmTimeout` )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@
     - When `true` you can repeat last-find by `f` and `F`(also `t` and `T`).
     - You still can use `,` and `;`.
     - e.g. `f a f` move cursor to 2nd `a`.
-  - My configuration( I'm still in-eval phase, don't take this as recommendation )
+  - My configuration( I'm still in-eval phase, don't take this as recommendation ).
     ```coffeescript
+    keymapSemicolonToConfirmFind: true
     findByTwoChars: true
-    findByTwoCharsAutoConfirmTimeout: 200
+    findByTwoCharsAutoConfirmTimeout: 500
     reuseFindForRepeatFind: true
     useSmartcaseForFind: true
     ```
@@ -41,7 +42,7 @@
 - Version: Decided to bump major version.
 - Breaking: Default config change/Renamed config name.
   - Summary:
-    - Now all `stayOn` prefixed configuration have new default `true`.
+    - Now all `stayOn` prefixed configuration have new default `false`.
     - New default behavior is NOT compatible with pure-Vim.
       - Set all `stayOn` prefixed configuration to `false` to revert to previous behavior.
     - Some configuration parameter name is renamed to have `stayOn` prefix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 - New: Now `f` is **tunable** to make it better, more efficient. #852.
   - Inspired pure-vim's plugins: `clever-f`, `vim-seek`, `vim-sneak`.
-  - Highlighting find-char find-char help pre-determine consequence of repeat.
+  - Highlighting find-char help you to pre-determine consequence of repeat by `;`, `,` and `.`.
   - Aiming to get both benefit of two-char find(`vim-seek`, `vim-sneak`) and one-char-find( vim's default ).
-  - Reuse `f`, `F` to repeat find like `clever-f`.
-- Config: Following configuration option is available to **tune** `f` motion.
+    - When two-char input was enabled, you still can auto-confirm single-char input by specified timeout.
+  - Can reuse `f`, `F` to repeat find like `clever-f`.
+- Config: Following configuration option is available to **tune** `f`.
   - `keymapSemicolonToConfirmFind`: default `false`.
     - See explanation for `findByTwoChars`.
   - `ignoreCaseForFind`: default `false`

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -282,12 +282,6 @@
   # 'g n': 'vim-mode-plus:move-to-next-number'
   # 'g N': 'vim-mode-plus:move-to-previous-number'
 
-'atom-text-editor.vim-mode-plus.has-highlight-find:not(.insert-mode)':
-  'f': 'vim-mode-plus:repeat-find'
-  'F': 'vim-mode-plus:repeat-find-reverse'
-  't': 'vim-mode-plus:repeat-find'
-  'T': 'vim-mode-plus:repeat-find-reverse'
-
 # macOS only
 '.platform-darwin atom-text-editor.vim-mode-plus:not(.insert-mode)':
   'ctrl-s': 'vim-mode-plus:transform-string-by-select-list'

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -105,7 +105,7 @@
   '-': 'vim-mode-plus:move-to-first-character-of-line-up'
   '+': 'vim-mode-plus:move-to-first-character-of-line-down'
   'enter': 'vim-mode-plus:move-to-first-character-of-line-down'
-  
+
   'g 0': 'vim-mode-plus:move-to-beginning-of-screen-line'
   'g ^': 'vim-mode-plus:move-to-first-character-of-screen-line'
   'g $': 'vim-mode-plus:move-to-last-character-of-screen-line'
@@ -282,6 +282,11 @@
   # 'g n': 'vim-mode-plus:move-to-next-number'
   # 'g N': 'vim-mode-plus:move-to-previous-number'
 
+'atom-text-editor.vim-mode-plus.has-highlight-find:not(.insert-mode)':
+  'f': 'vim-mode-plus:repeat-find'
+  'F': 'vim-mode-plus:repeat-find-reverse'
+  't': 'vim-mode-plus:repeat-find'
+  'T': 'vim-mode-plus:repeat-find-reverse'
 
 # macOS only
 '.platform-darwin atom-text-editor.vim-mode-plus:not(.insert-mode)':

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -660,7 +660,7 @@
   'O': 'vim-mode-plus:reverse-selections'
   'D': 'vim-mode-plus:delete-to-last-character-of-line' # To avoid overridden by delete-line in visual-mode
 
-# Input mini editor e.g. mark, surround.
+# Input mini editor e.g. mark, surround, find, till.
 # -------------------------
 'atom-text-editor.vim-mode-plus-input':
   'ctrl-c': 'core:cancel'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -166,13 +166,11 @@ class Base
     selectList.show(@vimState, options)
 
   input: null
-  focusInput: ({charsMax, hideCursor} = {}) ->
-    @vimState.focusInput
-      charsMax: charsMax
-      hideCursor: hideCursor
-      onConfirm: (@input) => @processOperation()
-      onCancel: => @cancelOperation()
-      onChange: (input) => @vimState.hover.set(input)
+  focusInput: (options = {}) ->
+    options.onConfirm ?= (@input) => @processOperation()
+    options.onCancel ?= => @cancelOperation()
+    options.onChange ?= (input) => @vimState.hover.set(input)
+    @vimState.focusInput(options)
 
   readChar: ->
     @vimState.readChar

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,14 +1,15 @@
 module.exports = function focusInput(
   vimState,
-  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm} = {}
+  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, classList = []} = {}
 ) {
-  vimState.editorElement.classList.add("vim-mode-plus-input-focused")
-  if (hideCursor) vimState.editorElement.classList.add("hide-cursor")
+  const classListToAdd = ["vim-mode-plus-input-focused"]
+  if (hideCursor) classListToAdd.push("hide-cursor")
+  vimState.editorElement.classList.add(...classListToAdd)
 
   const editor = atom.workspace.buildTextEditor({mini: true})
 
   vimState.inputEditor = editor // set ref for test
-  editor.element.classList.add("vim-mode-plus-input")
+  editor.element.classList.add("vim-mode-plus-input", ...classList)
   editor.element.setAttribute("mini", "")
 
   // So that I can skip jasmine.attachToDOM in test.
@@ -25,7 +26,7 @@ module.exports = function focusInput(
     clerAutoConfirmTimer()
     vimState.editorElement.focus() // focus
     vimState.inputEditor = null // unset ref for test
-    vimState.editorElement.classList.remove("vim-mode-plus-input-focused", "hide-cursor")
+    vimState.editorElement.classList.remove(...classListToAdd)
     editor.element.remove()
     editor.destroy()
   }

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,6 +1,6 @@
 module.exports = function focusInput(
   vimState,
-  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, classList = []} = {}
+  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, purpose} = {}
 ) {
   const classListToAdd = ["vim-mode-plus-input-focused"]
   if (hideCursor) classListToAdd.push("hide-cursor")
@@ -9,7 +9,8 @@ module.exports = function focusInput(
   const editor = atom.workspace.buildTextEditor({mini: true})
 
   vimState.inputEditor = editor // set ref for test
-  editor.element.classList.add("vim-mode-plus-input", ...classList)
+  editor.element.classList.add("vim-mode-plus-input")
+  if (purpose) editor.element.classList.add(purpose)
   editor.element.setAttribute("mini", "")
 
   // So that I can skip jasmine.attachToDOM in test.

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,4 +1,7 @@
-module.exports = function focusInput(vimState, {charsMax = 1, hideCursor, onChange, onCancel, onConfirm} = {}) {
+module.exports = function focusInput(
+  vimState,
+  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm} = {}
+) {
   vimState.editorElement.classList.add("vim-mode-plus-input-focused")
   if (hideCursor) vimState.editorElement.classList.add("hide-cursor")
 
@@ -8,10 +11,18 @@ module.exports = function focusInput(vimState, {charsMax = 1, hideCursor, onChan
   editor.element.classList.add("vim-mode-plus-input")
   editor.element.setAttribute("mini", "")
 
-  if (atom.inSpecMode()) atom.workspace.getElement().appendChild(editor.element) // I can skip jasmine.attachToDOM.
+  // So that I can skip jasmine.attachToDOM in test.
+  if (atom.inSpecMode()) atom.workspace.getElement().appendChild(editor.element)
   else vimState.editorElement.parentNode.appendChild(editor.element)
 
+  let autoConfirmTimeoutID
+  const clerAutoConfirmTimer = () => {
+    if (autoConfirmTimeoutID) clearTimeout(autoConfirmTimeoutID)
+    autoConfirmTimeoutID = null
+  }
+
   const unfocus = () => {
+    clerAutoConfirmTimer()
     vimState.editorElement.focus() // focus
     vimState.inputEditor = null // unset ref for test
     vimState.editorElement.classList.remove("vim-mode-plus-input-focused", "hide-cursor")
@@ -30,8 +41,23 @@ module.exports = function focusInput(vimState, {charsMax = 1, hideCursor, onChan
 
   vimState.onDidFailToPushToOperationStack(cancel)
 
-  if (charsMax === 1) editor.onDidChange(() => confirm(editor.getText()))
-  else if (onChange) editor.onDidChange(() => onChange(editor.getText()))
+  if (charsMax === 1) {
+    editor.onDidChange(() => confirm(editor.getText()))
+  } else {
+    editor.onDidChange(() => {
+      clerAutoConfirmTimer()
+
+      const text = editor.getText()
+      if (text.length >= charsMax) {
+        confirm(text)
+      } else {
+        if (onChange) onChange(text)
+        if (autoConfirmTimeout) {
+          autoConfirmTimeoutID = setTimeout(() => confirm(text), autoConfirmTimeout)
+        }
+      }
+    })
+  }
 
   atom.commands.add(editor.element, {
     "core:cancel": event => {

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -23,13 +23,17 @@ module.exports = class HighlightFind {
     this.markerLayer.destroy()
   }
 
+  clearMarkers() {
+    this.markerLayer.clear()
+  }
+
   highlightRanges(ranges, confirmed) {
     if (this.clearMarkerTimeoutID) {
       clearTimeout(this.clearMarkerTimeoutID)
       this.clearMarkerTimeoutID = null
     }
 
-    this.markerLayer.clear()
+    this.clearMarkers()
     this.decorationLayer.setProperties(DecorationProps.initial)
     // We need to force update here to reflect decoration props.confirmed being reset.
     this.vimState.editor.component.updateSync()
@@ -40,7 +44,7 @@ module.exports = class HighlightFind {
 
     if (confirmed) {
       this.decorationLayer.setProperties(DecorationProps.confirmed)
-      this.clearMarkerTimeoutID = setTimeout(() => this.markerLayer.clear(), 2000)
+      this.clearMarkerTimeoutID = setTimeout(() => this.clearMarkers(), 2000)
     }
   }
 }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,3 +1,5 @@
+const {Disposable} = require("atom")
+
 module.exports = class HighlightFind {
   constructor(vimState) {
     this.vimState = vimState
@@ -33,10 +35,38 @@ module.exports = class HighlightFind {
     this.updateEditorElement()
   }
 
+  addListner() {
+    const onKeydown = this.onKeydown.bind(this)
+    this.vimState.editorElement.addEventListener("keydown", onKeydown, true)
+    return new Disposable(() => {
+      console.log('remove listner');
+      this.vimState.editorElement.removeEventListener("keydown", onKeydown, true)
+    })
+  }
+
+  onKeydown(event) {
+    const currentFind = this.vimState.globalState.get('currentFind')
+    if (currentFind && currentFind.input === atom.keymaps.keystrokeForKeyboardEvent(event)) {
+      this.vimState.operationStack.runCurrentFind()
+      event.stopImmediatePropagation()
+    } else {
+      this.listnerDisposable.dispose()
+    }
+  }
+
   highlightRanges(ranges) {
+    clearTimeout(this.clearMarkersTimeout)
+    if (this.listnerDisposable) this.listnerDisposable.dispose()
+
     for (const range of ranges) {
       this.markerLayer.markBufferRange(range)
     }
+    this.listnerDisposable = this.addListner()
     this.updateEditorElement()
+
+    this.clearMarkersTimeout = setTimeout(() => {
+      this.clearMarkers()
+      this.listnerDisposable.dispose()
+    }, 800)
   }
 }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,20 +1,13 @@
-const {Disposable} = require("atom")
-
 module.exports = class HighlightFind {
   constructor(vimState) {
     this.vimState = vimState
-    const {editor} = vimState
     vimState.onDidDestroy(() => this.destroy())
 
-    this.markerLayer = editor.addMarkerLayer()
-    this.decorationLayer = editor.decorateMarkerLayer(this.markerLayer, {
+    this.markerLayer = vimState.editor.addMarkerLayer()
+    this.decorationLayer = vimState.editor.decorateMarkerLayer(this.markerLayer, {
       type: "highlight",
       class: "vim-mode-plus-find-char",
     })
-  }
-
-  updateEditorElement() {
-    this.vimState.editorElement.classList.toggle("has-highlight-find", this.hasMarkers())
   }
 
   destroy() {
@@ -22,51 +15,14 @@ module.exports = class HighlightFind {
     this.markerLayer.destroy()
   }
 
-  hasMarkers() {
-    return this.markerLayer.getMarkerCount() > 0
-  }
-
-  getMarkers() {
-    return this.markerLayer.getMarkers()
-  }
-
   clearMarkers() {
     this.markerLayer.clear()
-    this.updateEditorElement()
   }
 
-  addListner() {
-    const onKeydown = this.onKeydown.bind(this)
-    this.vimState.editorElement.addEventListener("keydown", onKeydown, true)
-    return new Disposable(() => {
-      console.log('remove listner');
-      this.vimState.editorElement.removeEventListener("keydown", onKeydown, true)
-    })
-  }
-
-  onKeydown(event) {
-    const currentFind = this.vimState.globalState.get('currentFind')
-    if (currentFind && currentFind.input === atom.keymaps.keystrokeForKeyboardEvent(event)) {
-      this.vimState.operationStack.runCurrentFind()
-      event.stopImmediatePropagation()
-    } else {
-      this.listnerDisposable.dispose()
-    }
-  }
-
-  highlightRanges(ranges) {
-    clearTimeout(this.clearMarkersTimeout)
-    if (this.listnerDisposable) this.listnerDisposable.dispose()
-
+  highlightRanges(ranges, confirmed) {
+    this.clearMarkers()
     for (const range of ranges) {
       this.markerLayer.markBufferRange(range)
     }
-    this.listnerDisposable = this.addListner()
-    this.updateEditorElement()
-
-    this.clearMarkersTimeout = setTimeout(() => {
-      this.clearMarkers()
-      this.listnerDisposable.dispose()
-    }, 800)
   }
 }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,11 +1,23 @@
-const DecorationProps = {
-  initial: {
-    type: "highlight",
-    class: "vim-mode-plus-find-char",
+const DecorationTypes = {
+  "pre-confirm": {
+    decorationProps: {
+      type: "highlight",
+      class: "vim-mode-plus-find-char pre-confirm",
+    },
   },
-  confirmed: {
-    type: "highlight",
-    class: "vim-mode-plus-find-char confirmed",
+  "post-confirm": {
+    timeout: 2000,
+    decorationProps: {
+      type: "highlight",
+      class: "vim-mode-plus-find-char post-confirm",
+    },
+  },
+  "post-confirm-long": {
+    timeout: 4000,
+    decorationProps: {
+      type: "highlight",
+      class: "vim-mode-plus-find-char post-confirm-long",
+    },
   },
 }
 
@@ -14,8 +26,9 @@ module.exports = class HighlightFind {
     this.vimState = vimState
     vimState.onDidDestroy(() => this.destroy())
 
-    this.markerLayer = vimState.editor.addMarkerLayer()
-    this.decorationLayer = vimState.editor.decorateMarkerLayer(this.markerLayer, DecorationProps.initial)
+    const {editor} = vimState
+    this.markerLayer = editor.addMarkerLayer()
+    this.decorationLayer = editor.decorateMarkerLayer(this.markerLayer, {})
   }
 
   destroy() {
@@ -27,24 +40,24 @@ module.exports = class HighlightFind {
     this.markerLayer.clear()
   }
 
-  highlightRanges(ranges, confirmed) {
+  highlightRanges(ranges, decorationType) {
     if (this.clearMarkerTimeoutID) {
       clearTimeout(this.clearMarkerTimeoutID)
       this.clearMarkerTimeoutID = null
     }
 
     this.clearMarkers()
-    this.decorationLayer.setProperties(DecorationProps.initial)
-    // We need to force update here to reflect decoration props.confirmed being reset.
+    // We need to force update here to restart(re-trigger) keyframe animation.
     this.vimState.editor.component.updateSync()
 
     for (const range of ranges) {
       this.markerLayer.markBufferRange(range)
     }
 
-    if (confirmed) {
-      this.decorationLayer.setProperties(DecorationProps.confirmed)
-      this.clearMarkerTimeoutID = setTimeout(() => this.clearMarkers(), 2000)
+    const {timeout, decorationProps} = DecorationTypes[decorationType]
+    this.decorationLayer.setProperties(decorationProps)
+    if (timeout) {
+      this.clearMarkerTimeoutID = setTimeout(() => this.clearMarkers(), timeout)
     }
   }
 }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,0 +1,42 @@
+module.exports = class HighlightFind {
+  constructor(vimState) {
+    this.vimState = vimState
+    const {editor} = vimState
+    vimState.onDidDestroy(() => this.destroy())
+
+    this.markerLayer = editor.addMarkerLayer()
+    this.decorationLayer = editor.decorateMarkerLayer(this.markerLayer, {
+      type: "highlight",
+      class: "vim-mode-plus-find-char",
+    })
+  }
+
+  updateEditorElement() {
+    this.vimState.editorElement.classList.toggle("has-highlight-find", this.hasMarkers())
+  }
+
+  destroy() {
+    this.decorationLayer.destroy()
+    this.markerLayer.destroy()
+  }
+
+  hasMarkers() {
+    return this.markerLayer.getMarkerCount() > 0
+  }
+
+  getMarkers() {
+    return this.markerLayer.getMarkers()
+  }
+
+  clearMarkers() {
+    this.markerLayer.clear()
+    this.updateEditorElement()
+  }
+
+  highlightRanges(ranges) {
+    for (const range of ranges) {
+      this.markerLayer.markBufferRange(range)
+    }
+    this.updateEditorElement()
+  }
+}

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,13 +1,21 @@
+const DecorationProps = {
+  initial: {
+    type: "highlight",
+    class: "vim-mode-plus-find-char",
+  },
+  confirmed: {
+    type: "highlight",
+    class: "vim-mode-plus-find-char confirmed",
+  },
+}
+
 module.exports = class HighlightFind {
   constructor(vimState) {
     this.vimState = vimState
     vimState.onDidDestroy(() => this.destroy())
 
     this.markerLayer = vimState.editor.addMarkerLayer()
-    this.decorationLayer = vimState.editor.decorateMarkerLayer(this.markerLayer, {
-      type: "highlight",
-      class: "vim-mode-plus-find-char",
-    })
+    this.decorationLayer = vimState.editor.decorateMarkerLayer(this.markerLayer, DecorationProps.initial)
   }
 
   destroy() {
@@ -15,14 +23,24 @@ module.exports = class HighlightFind {
     this.markerLayer.destroy()
   }
 
-  clearMarkers() {
-    this.markerLayer.clear()
-  }
-
   highlightRanges(ranges, confirmed) {
-    this.clearMarkers()
+    if (this.clearMarkerTimeoutID) {
+      clearTimeout(this.clearMarkerTimeoutID)
+      this.clearMarkerTimeoutID = null
+    }
+
+    this.markerLayer.clear()
+    this.decorationLayer.setProperties(DecorationProps.initial)
+    // We need to force update here to reflect decoration props.confirmed being reset.
+    this.vimState.editor.component.updateSync()
+
     for (const range of ranges) {
       this.markerLayer.markBufferRange(range)
+    }
+
+    if (confirmed) {
+      this.decorationLayer.setProperties(DecorationProps.confirmed)
+      this.clearMarkerTimeoutID = setTimeout(() => this.markerLayer.clear(), 2000)
     }
   }
 }

--- a/lib/motion-search.coffee
+++ b/lib/motion-search.coffee
@@ -9,7 +9,7 @@ class SearchBase extends Motion
   jump: true
   backwards: false
   useRegexp: true
-  configScope: null
+  caseSensitivityKind: null
   landingPoint: null # ['start' or 'end']
   defaultLandingPoint: 'start' # ['start' or 'end']
   relativeIndex: null
@@ -32,20 +32,6 @@ class SearchBase extends Motion
       -count
     else
       count
-
-  getCaseSensitivity: ->
-    if @getConfig("useSmartcaseFor#{@configScope}")
-      'smartcase'
-    else if @getConfig("ignoreCaseFor#{@configScope}")
-      'insensitive'
-    else
-      'sensitive'
-
-  isCaseSensitive: (term) ->
-    switch @getCaseSensitivity()
-      when 'smartcase' then term.search('[A-Z]') isnt -1
-      when 'insensitive' then false
-      when 'sensitive' then true
 
   finish: ->
     if @isIncrementalSearch() and @getConfig('showHoverSearchCounter')
@@ -101,7 +87,7 @@ class SearchBase extends Motion
 # -------------------------
 class Search extends SearchBase
   @extend()
-  configScope: "Search"
+  caseSensitivityKind: "Search"
   requireInput: true
 
   initialize: ->
@@ -206,7 +192,7 @@ class SearchBackwards extends Search
 # -------------------------
 class SearchCurrentWord extends SearchBase
   @extend()
-  configScope: "SearchCurrentWord"
+  caseSensitivityKind: "SearchCurrentWord"
 
   moveCursor: (cursor) ->
     @input ?= (

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -911,13 +911,14 @@ class Find extends Motion
       method = 'scanInBufferRange'
 
     points = []
-    rangesToHighlight = []
     @editor[method] ///#{_.escapeRegExp(@input)}///g, scanRange, ({range}) ->
-      rangesToHighlight.push(range)
       points.push(range.start)
 
-    if @getConfig('highlightFind') and not @vimState.highlightFind.hasMarkers()
-      @vimState.highlightFind.highlightRanges(rangesToHighlight)
+    rangesToHighlight = []
+    rangeForCurrentRow = @editor.bufferRangeForBufferRow(fromPoint.row)
+    @editor[method] ///#{_.escapeRegExp(@input)}///g, rangeForCurrentRow, ({range}) ->
+      rangesToHighlight.push(range)
+    @vimState.highlightFind.highlightRanges(rangesToHighlight)
 
     points[@getCount(-1)]?.translate([0, offset])
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -929,7 +929,6 @@ class Find extends Motion
 
   execute: ->
     super
-
     @highlightTextCursorRows(@input, true)
 
   getPoint: (fromPoint) ->

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -909,6 +909,10 @@ class Find extends Motion
         charsMax: 2
         autoConfirmTimeout: @getConfig("findByTwoCharsAutoConfirmTimeout")
         onChange: (char) => @highlightTextInRow(char, @editor.getCursorBufferPosition().row)
+        onCancel: =>
+          @vimState.highlightFind.clearMarkers()
+          @cancelOperation()
+
     options ?= {}
     options.classList = ["find"]
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -908,7 +908,7 @@ class Find extends Motion
       options =
         charsMax: 2
         autoConfirmTimeout: @getConfig("findByTwoCharsAutoConfirmTimeout")
-        onChange: (char) => @highlightTextCursorRows(char)
+        onChange: (char) => @highlightTextInCursorRows(char, "pre-confirm")
         onCancel: =>
           @vimState.highlightFind.clearMarkers()
           @cancelOperation()
@@ -929,7 +929,9 @@ class Find extends Motion
 
   execute: ->
     super
-    @highlightTextCursorRows(@input, true)
+    decorationType = "post-confirm"
+    decorationType += "-long" if @isAsTargetExceptSelect()
+    @highlightTextInCursorRows(@input, decorationType)
 
   getPoint: (fromPoint) ->
     {start, end} = @editor.bufferRangeForBufferRow(fromPoint.row)
@@ -948,13 +950,13 @@ class Find extends Motion
 
     points[@getCount(-1)]?.translate([0, offset])
 
-  highlightTextCursorRows: (text, confirmed) ->
+  highlightTextInCursorRows: (text, decorationType) ->
     return unless @getConfig("highlightFindChar")
     ranges = []
     for cursor in @editor.getCursors()
       scanRange = cursor.getCurrentLineBufferRange()
       @editor.scanInBufferRange(@getRegex(text), scanRange, ({range}) -> ranges.push(range))
-    @vimState.highlightFind.highlightRanges(ranges, confirmed)
+    @vimState.highlightFind.highlightRanges(ranges, decorationType)
 
   moveCursor: (cursor) ->
     point = @getPoint(cursor.getBufferPosition())

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -911,8 +911,14 @@ class Find extends Motion
       method = 'scanInBufferRange'
 
     points = []
+    rangesToHighlight = []
     @editor[method] ///#{_.escapeRegExp(@input)}///g, scanRange, ({range}) ->
+      rangesToHighlight.push(range)
       points.push(range.start)
+
+    if @getConfig('highlightFind') and not @vimState.highlightFind.hasMarkers()
+      @vimState.highlightFind.highlightRanges(rangesToHighlight)
+
     points[@getCount(-1)]?.translate([0, offset])
 
   moveCursor: (cursor) ->

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -914,7 +914,7 @@ class Find extends Motion
           @cancelOperation()
 
     options ?= {}
-    options.classList = ["find"]
+    options.purpose = "find"
 
     @focusInput(options)
 

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -103,7 +103,7 @@ module.exports = class OperationStack {
       }
 
       // FIXME: dont do this kind of operator specic work here.
-      if (this.vimState.__highlightFind && !operation.instanceof("Find")) {
+      if (this.vimState.__highlightFind) {
         this.vimState.__highlightFind.clearMarkers()
       }
 

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -102,6 +102,11 @@ module.exports = class OperationStack {
         }
       }
 
+      // FIXME: dont do this kind of operator specic work here.
+      if (this.vimState.__highlightFind && !operation.instanceof("Find")) {
+        this.vimState.__highlightFind.clearMarkers()
+      }
+
       if (this.isEmpty()) {
         if ((this.mode === "visual" && operation.isMotion()) || operation.isTextObject()) {
           operation = this.newSelectWithTarget(operation)

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -38,6 +38,10 @@ module.exports = class OperationStack {
     return handler // DONT REMOVE
   }
 
+  getLastCommandName() {
+    return this.lastCommandName
+  }
+
   reset() {
     this.resetCount()
     this.stack = []
@@ -100,11 +104,6 @@ module.exports = class OperationStack {
         } else {
           operation = new klass(this.vimState, properties)
         }
-      }
-
-      // FIXME: dont do this kind of operator specic work here.
-      if (this.vimState.__highlightFind) {
-        this.vimState.__highlightFind.clearMarkers()
       }
 
       if (this.isEmpty()) {
@@ -227,7 +226,10 @@ module.exports = class OperationStack {
   }
 
   finish(operation) {
-    if (operation && operation.recordable) this.recordedOperation = operation
+    if (operation) {
+      if (operation.recordable) this.recordedOperation = operation
+      this.lastCommandName = operation.name
+    }
 
     this.vimState.emitDidFinishOperation()
     if (operation && operation.isOperator()) operation.resetState()

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -427,15 +427,10 @@ class SurroundBase extends TransformString
   supportEarlySelect: true # Experimental
 
   focusInputForSurroundChar: ->
-    @vimState.focusInput
-      hideCursor: true
-      onConfirm: (@input) => @processOperation()
-      onCancel: => @cancelOperation()
+    @focusInput(hideCursor: true)
 
   focusInputForTargetPairChar: ->
-    @vimState.focusInput
-      onConfirm: (char) => @onConfirmTargetPairChar(char)
-      onCancel: => @cancelOperation()
+    @focusInput(onConfirm: (char) => @onConfirmTargetPairChar(char))
 
   getPair: (char) ->
     pair = @pairsByAlias[char]

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -258,6 +258,11 @@ module.exports = new Settings("vim-mode-plus", {
   lazyFind:{
     default: false,
   },
+  highlightFind:{
+    default: true,
+    description:
+      "highlight finding char( `f{char}` ). Affects `f`, `F`, `t`, `T`",
+  },
   ignoreCaseForSearch: {
     default: false,
     description: "For `/` and `?`",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -143,6 +143,11 @@ class Settings {
           "/": "vim-mode-plus:inner-comment-or-paragraph",
         },
       },
+      keymapSemicolonToConfirmFind: {
+        "atom-text-editor.vim-mode-plus-input.find": {
+          ";": "core:confirm",
+        },
+      },
     }
 
     const observeConditionalKeymap = param => {
@@ -209,6 +214,12 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Can: `g / /` to comment-in commented region, `g / /` to comment-out paragraph.<br>\nConflicts: `g / /`( `toggle-line-comments` by `search` motion )",
   },
+  keymapSemicolonToConfirmFind: {
+    title: "keymap `;` to confirm `find` motion",
+    default: false,
+    description:
+      "Can: When `findByTwoChars` was enabled, you can confirm single-char input by `;`. `f a ;` instead of `f a enter`.<br>Conflicts: You cannot search `;` by `f`, `F`, `t` and `T`.",
+  },
   setCursorToStartOfChangeOnUndoRedo: true,
   setCursorToStartOfChangeOnUndoRedoStrategy: {
     default: "smart",
@@ -255,13 +266,23 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Comma separated list of character, which add space around surrounded text.<br>\nFor vim-surround compatible behavior, set `(, {, [, <`.",
   },
-  lazyFind:{
-    default: false,
-  },
-  highlightFind:{
+  highlightFindChar: {
     default: true,
+    description: "highlight finding char( `f{char}` ). Affects `f`, `F`, `t`, `T`",
+  },
+  findByTwoChars: {
+    default: false,
+    description: "When `true`, find( `f` ) accept two chars<br>Reduces number of matches.<br>You now need to explicitly confirm for single-char input(Try `keymap \`;\` to confirm \`find\` motion`.)",
+  },
+  findByTwoCharsAutoConfirmTimeout: {
+    default: 0,
     description:
-      "highlight finding char( `f{char}` ). Affects `f`, `F`, `t`, `T`",
+      "When `findByTwoChars` was enabled, automatically confirm single-char input on timeout( msec )<br>Set `0` to disable.",
+  },
+  reuseFindForRepeatFind: {
+    default: false,
+    description:
+      "When `true`, can repeat last-find by `f` and `F`( backwards ), you still can use normal `,` and `;`.<br>e.g. `f a f` move cursor to 2nd `a`.<br>Affects to: `f`, `F`, `t`, `T`.",
   },
   ignoreCaseForSearch: {
     default: false,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -266,13 +266,22 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Comma separated list of character, which add space around surrounded text.<br>\nFor vim-surround compatible behavior, set `(, {, [, <`.",
   },
+  ignoreCaseForFind: {
+    default: false,
+    description: "For `f`, `F`, `t`, and `T`",
+  },
+  useSmartcaseForFind: {
+    default: false,
+    description: "For `f`, `F`, `t`, and `T`, `ignoreCaseForFind`",
+  },
   highlightFindChar: {
     default: true,
     description: "highlight finding char( `f{char}` ). Affects `f`, `F`, `t`, `T`",
   },
   findByTwoChars: {
     default: false,
-    description: "When `true`, find( `f` ) accept two chars<br>Reduces number of matches.<br>You now need to explicitly confirm for single-char input(Try `keymap \`;\` to confirm \`find\` motion`.)",
+    description:
+      "When `true`, find( `f` ) accept two chars<br>Reduces number of matches.<br>You now need to explicitly confirm for single-char input(Try `keymap `;` to confirm `find` motion`.)",
   },
   findByTwoCharsAutoConfirmTimeout: {
     default: 0,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -255,6 +255,9 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Comma separated list of character, which add space around surrounded text.<br>\nFor vim-surround compatible behavior, set `(, {, [, <`.",
   },
+  lazyFind:{
+    default: false,
+  },
   ignoreCaseForSearch: {
     default: false,
     description: "For `/` and `?`",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -276,12 +276,12 @@ module.exports = new Settings("vim-mode-plus", {
   },
   highlightFindChar: {
     default: true,
-    description: "highlight finding char( `f{char}` ). Affects `f`, `F`, `t`, `T`",
+    description: "highlight finding char. Affects `f`, `F`, `t`, `T`",
   },
   findByTwoChars: {
     default: false,
     description:
-      "When `true`, find( `f` ) accept two chars<br>Reduces number of matches.<br>You now need to explicitly confirm for single-char input(Try `keymap `;` to confirm `find` motion`.)",
+      "When `true`, find( `f` ) accept two chars<br>Greatly reduces the possible matches.<br>You now need to explicitly confirm for single-char input.<br>See also `keymap `;` to confirm `find` motion` configuratio0jn.)",
   },
   findByTwoCharsAutoConfirmTimeout: {
     default: 0,

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -499,6 +499,8 @@ module.exports = class VimState {
     this.clearBlockwiseSelections()
 
     if (userInvocation) {
+      this.operationStack.lastCommandName = null
+
       if (this.editor.hasMultipleCursors()) {
         this.clearSelections()
       } else if (this.hasPersistentSelections() && this.getConfig("clearPersistentSelectionOnResetNormalMode")) {

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -103,6 +103,9 @@ module.exports = class VimState {
   get highlightSearch() {
     return this.__highlightSearch || (this.__highlightSearch = this.load("./highlight-search-manager"))
   }
+  get highlightFind() {
+    return this.__highlightFind || (this.__highlightFind = this.load("./highlight-find-manager"))
+  }
   get persistentSelection() {
     return this.__persistentSelection || (this.__persistentSelection = this.load("./persistent-selection-manager"))
   }

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -304,6 +304,14 @@ atom-text-editor {
     z-index: 1;
     border-color: @syntax-color-modified;
   }
+
+  .vim-mode-plus-find-char .region {
+    border-color: @syntax-color-function;
+    box-sizing: border-box;
+    border-width: 0px;
+    border-bottom-width: 2px;
+    border-style: solid;
+  }
 }
 
 // Maximize Pane

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -312,14 +312,19 @@ atom-text-editor {
 
   .vim-mode-plus-find-char {
     .region {
-      border-color: @syntax-color-function;
       box-sizing: border-box;
       border-width: 0px;
       border-bottom-width: 2px;
       border-style: solid;
     }
-    &.confirmed .region {
+    &.pre-confirm .region {
+      border-color: @syntax-color-function;
+    }
+    &.post-confirm .region {
       .flash(vim-mode-plus-flash-find-char, 2.0s);
+    }
+    &.post-confirm-long .region {
+      .flash(vim-mode-plus-flash-find-char, 4.0s);
     }
   }
 }

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -270,6 +270,11 @@ atom-text-editor:not(.silent) {
   }
 }
 
+@keyframes vim-mode-plus-flash-find-char {
+  from { border-color: @syntax-color-function; }
+  to { border-color: transparent; }
+}
+
 atom-text-editor {
   .vim-mode-plus-search-match {
     .region {
@@ -305,12 +310,29 @@ atom-text-editor {
     border-color: @syntax-color-modified;
   }
 
-  .vim-mode-plus-find-char .region {
-    border-color: @syntax-color-function;
-    box-sizing: border-box;
-    border-width: 0px;
-    border-bottom-width: 2px;
-    border-style: solid;
+  .vim-mode-plus-find-char {
+    .region {
+      border-color: @syntax-color-function;
+      box-sizing: border-box;
+      border-width: 0px;
+      border-bottom-width: 2px;
+      border-style: solid;
+    }
+    &.confirmed .region {
+      .flash(vim-mode-plus-flash-find-char, 2.0s);
+    }
+  }
+}
+
+atom-text-editor {
+  &.find-pending,
+  &.find-backwards-pending,
+  &.till-pending,
+  &.till-backwards-pending,
+  {
+    .vim-mode-plus-find-char .region {
+      border-color: @syntax-color-constant;
+    }
   }
 }
 

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -318,25 +318,13 @@ atom-text-editor {
       border-style: solid;
     }
     &.pre-confirm .region {
-      border-color: @syntax-color-function;
+      border-color: @syntax-color-constant;
     }
     &.post-confirm .region {
       .flash(vim-mode-plus-flash-find-char, 2.0s);
     }
     &.post-confirm-long .region {
       .flash(vim-mode-plus-flash-find-char, 4.0s);
-    }
-  }
-}
-
-atom-text-editor {
-  &.find-pending,
-  &.find-backwards-pending,
-  &.till-pending,
-  &.till-backwards-pending,
-  {
-    .vim-mode-plus-find-char .region {
-      border-color: @syntax-color-constant;
     }
   }
 }


### PR DESCRIPTION
#851
#366 is Previous attempt to improve `f`, `F`, but removed because I didn't use it.
Now I also want re-evaluate #366.

# TODO

- [x] highlight f char in current line.
  - [x] Automatically clear highlight.
- [ ] ~~Allow `f` to find next line's char~~ [CHANGED MIND]
- [x] `repeat-find` on sequential `f`.
- [x] allow smartcase/ignorecase for `f`
- [x] Can find both `one-char`(auto confirm by timeout), `two-char`.
  - [x] Change find-char highlight color when auto-confirmed.
- [x] Configurable timeout
  - [ ] ~~Provide timeout for smart-cased situation?(to use longer timeout when shift- modifier involved)~~

# Note for experiment I did

I stopped optimistically going "let's introduce clever-f int vmp" mood.
Instead, I'm now experimenting several ideas to find best/better `f`.


- Treat 2nd char as `repeat-find`
  - When move to `a` char, `f a f` allow 2nd `a` since 2nd `f` work as `repeat-find`.
  - I enhanced this idea to make 2nd any-char work as `repeat-find`.
    - So, `f a a` to move 2nd `a`, since 2nd `a` work as `repeat-find`, `f b b` to 2nd `b` and so on.
    - This require user-key-input intercept and compare key-input is equals to find-char.
    - If char was equal, invoke `repeat-find`.

- Two char input to reduce possible matches(like vim-seek, vim-sneak).
  - Find by two char, and also allow 2nd-char-as-repeat-find
  - So `f a b` move cursor to `ab`, next `b` within timeout move cursor to 2nd `ab`
  - [Frustration] Sometime I want to jump by single char.
    - e.g. when try to move to `a` in `(a)` and `a` is enough, but require two char force me to type `a)`.
    - Auto confirm by timeout?
    - Auto confirm if there is single match in line?

# [current status] lazy-find

- Command name is `lazy-find`.
- Compromise two-char find and one char-find
  - `f` by TWO like vim-seek, vim-sneak
  - `f` by ONE-char by auto confirming on timeout(configurable)
  - Reuse `f`, `F` to repeat-find like clever-f.
- highlighting find-char help pre-determine consequence of repeat.
  - After `d f a`, pre-determine text deleted by next `.`.
- [Changed mind] I won't introduce treat-2nd-char-as-repeat-find feature for simplicity.
