### PR TITLE
[experiment] findAcrossLines options to find match in next-line

### DIFF
--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -939,14 +939,21 @@ class Find extends Motion
     offset = if @isBackwards() then @offset else -@offset
     unOffset = -offset * @repeated
     if @isBackwards()
+      if @getConfig("findAcrossLines")
+        start = Point.ZERO
       scanRange = [start, fromPoint.translate([0, unOffset])]
       method = 'backwardsScanInBufferRange'
     else
+      if @getConfig("findAcrossLines")
+        end = @editor.getEofBufferPosition()
       scanRange = [fromPoint.translate([0, 1 + unOffset]), end]
       method = 'scanInBufferRange'
 
     points = []
-    @editor[method] @getRegex(@input), scanRange, ({range}) -> points.push(range.start)
+    indexWantAcess = @getCount(-1)
+    @editor[method] @getRegex(@input), scanRange, ({range, stop}) ->
+      points.push(range.start)
+      stop() if points.length > indexWantAcess
 
     points[@getCount(-1)]?.translate([0, offset])
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -939,13 +939,11 @@ class Find extends Motion
     offset = if @isBackwards() then @offset else -@offset
     unOffset = -offset * @repeated
     if @isBackwards()
-      if @getConfig("findAcrossLines")
-        start = Point.ZERO
+      start = Point.ZERO if @getConfig("findAcrossLines")
       scanRange = [start, fromPoint.translate([0, unOffset])]
       method = 'backwardsScanInBufferRange'
     else
-      if @getConfig("findAcrossLines")
-        end = @editor.getEofBufferPosition()
+      end = @editor.getEofBufferPosition() if @getConfig("findAcrossLines")
       scanRange = [fromPoint.translate([0, 1 + unOffset]), end]
       method = 'scanInBufferRange'
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -284,7 +284,7 @@ module.exports = new Settings("vim-mode-plus", {
       "When `true`, find( `f` ) accept two chars<br>Greatly reduces the possible matches.<br>You now need to explicitly confirm for single-char input.<br>See also `keymap `;` to confirm `find` motion` configuratio0jn.)",
   },
   findAcrossLines: {
-    default: false
+    default: false,
     description:
       "By default `f` search current line only, when set `true`, `f` find match across lines.<br>Affects `f`, `F`, `t`, `T`.",
   },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -286,7 +286,7 @@ module.exports = new Settings("vim-mode-plus", {
   findAcrossLines: {
     default: false,
     description:
-      "By default `f` search current line only, when set `true`, `f` find match across lines.<br>Affects `f`, `F`, `t`, `T`.",
+      "When `true`, `f` searches over next lines.<br>Affects `f`, `F`, `t`, `T`.",
   },
   findByTwoCharsAutoConfirmTimeout: {
     default: 0,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -283,6 +283,11 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "When `true`, find( `f` ) accept two chars<br>Greatly reduces the possible matches.<br>You now need to explicitly confirm for single-char input.<br>See also `keymap `;` to confirm `find` motion` configuratio0jn.)",
   },
+  findAcrossLines: {
+    default: false
+    description:
+      "By default `f` search current line only, when set `true`, `f` find match across lines.<br>Affects `f`, `F`, `t`, `T`.",
+  },
   findByTwoCharsAutoConfirmTimeout: {
     default: 0,
     description:

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -334,6 +334,22 @@ describe "Motion Find", ->
         ensure "T",   textC: "    A    ab    a|    Ab    a"
         ensure "T",   textC: "    A    a|b    a    Ab    a"
 
+    describe "findAcrossLines", ->
+      beforeEach ->
+        settings.set("findAcrossLines", true)
+
+      it "searches across multiple lines", ->
+        set           textC: "|0:    a    a\n1:    a    a\n2:    a    a\n"
+        ensure "f a", textC: "0:    |a    a\n1:    a    a\n2:    a    a\n"
+        ensure ";",   textC: "0:    a    |a\n1:    a    a\n2:    a    a\n"
+        ensure ";",   textC: "0:    a    a\n1:    |a    a\n2:    a    a\n"
+        ensure ";",   textC: "0:    a    a\n1:    a    |a\n2:    a    a\n"
+        ensure ";",   textC: "0:    a    a\n1:    a    a\n2:    |a    a\n"
+        ensure "F a", textC: "0:    a    a\n1:    a    |a\n2:    a    a\n"
+        ensure "t a", textC: "0:    a    a\n1:    a    a\n2:   | a    a\n"
+        ensure "T a", textC: "0:    a    a\n1:    a    |a\n2:    a    a\n"
+        ensure "T a", textC: "0:    a    a\n1:    a|    a\n2:    a    a\n"
+
     describe "findByTwoChars", ->
       beforeEach ->
         settings.set("findByTwoChars", true)


### PR DESCRIPTION
Related #851 
clever-f have this feature.
I myself not sure this is really useful.
IMO, should use `/` for multi-lines search.
But I agree with that `f` is light-context-switch.

Will evaluate if it improve developer-efficiency if I use `f` in nearby line.