### PR TITLE
Find confirm by arbitrary  chars length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
   - New, Rename: `findCharsMax`: default `1`.
     - If `find`'s input reaches this length, confirm without waiting explicit `enter`.
     - So default `f a`(move to `a` char) is behavior when `findCharsMax` is `1`.
-    - By setting bigger number(such as `100`) and enabling `findConfirmByTimeout`, you can expect FIXED timing of confirmation agains your input.
+    - By setting bigger number(such as `100`) with also enabling `findConfirmByTimeout`, you can expect FIXED timing of confirmation against your input.
+      - FIXED-timing-gap for "f > chars-input > wait > land(always by timeout)" flow.
     - Old `findByTwoChars = true` is equals to `findCharsMax = 2`, and migrated on first time activation.
   - Rename: `findByTwoCharsAutoConfirmTimeout` to `findConfirmByTimeout`( generalize naming )
 
@@ -67,8 +68,8 @@
   - My configuration( I'm still in-eval phase, don't take this as recommendation ).
     ```coffeescript
     keymapSemicolonToConfirmFind: true
-    findByTwoChars: true
-    findByTwoCharsAutoConfirmTimeout: 500
+    findByTwoChars: true # [converted] to `findCharsMax = 2`
+    findByTwoCharsAutoConfirmTimeout: 500 # [converted] to `findConfirmByTimeout = 500`
     reuseFindForRepeatFind: true
     useSmartcaseForFind: true
     ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.3.0:
+- Breaking, New: `findCharsMax` options to find arbitrary length of chars by `f`.
+  - Involves renaming, auto-value-conversion of existing configuration introduced in v1.1.0( yesterday ).
+  - New, Rename: `findCharsMax`: default `1`.
+    - If `find`'s input reaches this length, confirm without waiting explicit `enter`.
+    - So default `f a`(move to `a` char) is behavior when `findCharsMax` is `1`.
+    - By setting bigger number(such as `100`) and enabling `findConfirmByTimeout`, you can expect FIXED timing of confirmation agains your input.
+    - Old `findByTwoChars = true` is equals to `findCharsMax = 2`, and migrated on first time activation.
+  - Rename: `findByTwoCharsAutoConfirmTimeout` to `findConfirmByTimeout`( generalize naming )
+
 # 1.2.0:
 - New, Experimental: `findAcrossLines`: default `false`
   - When `true`, `f` searches over next lines. Affects `f`, `F`, `t`, `T`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@
 - Fix: Fix confusing description in setting, no behavioral diff.
 
 # 1.1.0: This release is all for better `f` by making it tunable
+
+- [CAUTION: added at release of v1.3.0]: Config option name changed.
+  - I basically don't want update old CHANGELOG, but this is for reducing confusion.
+  - Because of short release timing gap with braking config params change.
+    - v1.1.0: 2017.9.1
+    - v1.3.0: 2017.9.2
+  - When you read this below, keep in mind, change in available config params.
+    - Parameterized: `findByTwoChars = true` to `findCharsMax = 2`
+    - Renamed: `findByTwoCharsAutoConfirmTimeout` to `findConfirmByTimeout`
+
 - New: [Summary] Now `f` is **tunable**. #852.
   - Inspired pure-vim's plugins: `clever-f`, `vim-seek`, `vim-sneak`.
   - Highlighting find-char. It help you to pre-determine consequence of repeat by `;`, `,` and `.`.

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -904,10 +904,11 @@ class Find extends Motion
     @repeatIfNecessary()
     return if @isComplete()
 
-    if @getConfig("findByTwoChars")
+    charsMax = @getConfig("findCharsMax")
+
+    if (charsMax > 1)
       options =
-        charsMax: 2
-        autoConfirmTimeout: @getConfig("findByTwoCharsAutoConfirmTimeout")
+        autoConfirmTimeout: @getConfig("findConfirmByTimeout")
         onChange: (char) => @highlightTextInCursorRows(char, "pre-confirm")
         onCancel: =>
           @vimState.highlightFind.clearMarkers()
@@ -915,6 +916,7 @@ class Find extends Motion
 
     options ?= {}
     options.purpose = "find"
+    options.charsMax = charsMax
 
     @focusInput(options)
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -8,9 +8,16 @@ function inferType(value) {
 }
 
 const DEPRECATED_PARAMS = ["showCursorInVisualMode"]
+
+function invertValue(value) {
+  return !value
+}
+
 const RENAMED_PARAMS = [
+  {oldName: "findByTwoChars", newName: "findCharsMax", setValueBy: enabled => (enabled ? 2 : undefined)},
+  {oldName: "findByTwoCharsAutoConfirmTimeout", newName: "findConfirmByTimeout"},
   {oldName: "keepColumnOnSelectTextObject", newName: "stayOnSelectTextObject"},
-  {oldName: "moveToFirstCharacterOnVerticalMotion", newName: "stayOnVerticalMotion", invertValue: true},
+  {oldName: "moveToFirstCharacterOnVerticalMotion", newName: "stayOnVerticalMotion", setValueBy: invertValue},
 ]
 
 class Settings {
@@ -41,17 +48,19 @@ class Settings {
   migrateRenamedParams() {
     const messages = []
 
-    for (const {oldName, newName, invertValue} of RENAMED_PARAMS) {
+    for (const {oldName, newName, setValueBy} of RENAMED_PARAMS) {
       const oldValue = this.get(oldName)
       if (oldValue != null) {
-        const newValue = invertValue ? !oldValue : oldValue
+        const newValue = setValueBy != null ? setValueBy(oldValue) : oldValue
 
         // Set only if newValue isnt default.
-        if (this.get(newName) !== newValue) this.set(newName, newValue)
+        if (newValue != null && this.get(newName) !== newValue) {
+          this.set(newName, newValue)
+        }
         this.delete(oldName)
 
         let s = `- |${oldName}| was renamed to |${newName}|`.replace(/\|/g, "`")
-        if (invertValue) s += " with meaning **inverted**"
+        if (setValueBy === invertValue) s += " with meaning **inverted**"
         messages.push(s)
       }
     }
@@ -218,7 +227,7 @@ module.exports = new Settings("vim-mode-plus", {
     title: "keymap `;` to confirm `find` motion",
     default: false,
     description:
-      "Can: When `findByTwoChars` was enabled, you can confirm single-char input by `;`. `f a ;` instead of `f a enter`.<br>Conflicts: You cannot search `;` by `f`, `F`, `t` and `T`.",
+      "Can: You can confirm find( `f` ) input by `;`.<br>e.g. `f a ;` instead of `f a enter`.<br>Conflicts: You cannot search `;` by `f`, `F`, `t` and `T`.",
   },
   setCursorToStartOfChangeOnUndoRedo: true,
   setCursorToStartOfChangeOnUndoRedoStrategy: {
@@ -266,6 +275,17 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "Comma separated list of character, which add space around surrounded text.<br>\nFor vim-surround compatible behavior, set `(, {, [, <`.",
   },
+  findCharsMax: {
+    default: 1,
+    minimum: 1,
+    description:
+      "Auto confirm when find( `f` )'s input reaches this lenth.<br>Increasing this number greatly reduces the possible matches, but you now need confirm( `enter` ) for shorter input.<br>See also `keymap `;` to confirm `find` motion` configuration.",
+  },
+  findConfirmByTimeout: {
+    default: 0,
+    description:
+      "Automatically confirm find( `f` ) when no input change happenend in timeout( msec )<br>Set `0` to disable.",
+  },
   ignoreCaseForFind: {
     default: false,
     description: "For `f`, `F`, `t`, and `T`",
@@ -278,25 +298,14 @@ module.exports = new Settings("vim-mode-plus", {
     default: true,
     description: "highlight finding char. Affects `f`, `F`, `t`, `T`",
   },
-  findByTwoChars: {
-    default: false,
-    description:
-      "When `true`, find( `f` ) accept two chars<br>Greatly reduces the possible matches.<br>You now need to explicitly confirm for single-char input.<br>See also `keymap `;` to confirm `find` motion` configuratio0jn.)",
-  },
-  findAcrossLines: {
-    default: false,
-    description:
-      "[EXPERIMENTAL] When `true`, `f` searches over next lines.<br>Affects `f`, `F`, `t`, `T`.",
-  },
-  findByTwoCharsAutoConfirmTimeout: {
-    default: 0,
-    description:
-      "When `findByTwoChars` was enabled, automatically confirm single-char input on timeout( msec )<br>Set `0` to disable.",
-  },
   reuseFindForRepeatFind: {
     default: false,
     description:
       "When `true`, can repeat last-find by `f` and `F`( backwards ), you still can use normal `,` and `;`.<br>e.g. `f a f` move cursor to 2nd `a`.<br>Affects to: `f`, `F`, `t`, `T`.",
+  },
+  findAcrossLines: {
+    default: false,
+    description: "[EXPERIMENTAL] When `true`, `f` searches over next lines.<br>Affects `f`, `F`, `t`, `T`.",
   },
   ignoreCaseForSearch: {
     default: false,
@@ -361,7 +370,8 @@ module.exports = new Settings("vim-mode-plus", {
   flashOnUndoRedo: true,
   flashOnMoveToOccurrence: {
     default: true,
-    description: "When preset-occurrence( `g o` ) is exist on editor, you can move between occurrences by `tab` and `shift-tab`<br>When set to `true`, flash occurrence under cursor after move",
+    description:
+      "When preset-occurrence( `g o` ) is exist on editor, you can move between occurrences by `tab` and `shift-tab`<br>When set to `true`, flash occurrence under cursor after move",
   },
   flashOnOperate: true,
   flashOnOperateBlacklist: {

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -350,23 +350,40 @@ describe "Motion Find", ->
         ensure "T a", textC: "0:    a    a\n1:    a    |a\n2:    a    a\n"
         ensure "T a", textC: "0:    a    a\n1:    a|    a\n2:    a    a\n"
 
-    describe "findByTwoChars", ->
-      beforeEach ->
-        settings.set("findByTwoChars", true)
+    describe "findCharsMax", ->
 
-      describe "can find one or two char", ->
-        it "can find by two char", ->
-          set             textC: "|    a    ab    a    cd    a"
-          ensure "f a b", textC: "    a    |ab    a    cd    a"
-          ensure "f c d", textC: "    a    ab    a    |cd    a"
+      describe "with 2 length", ->
+        beforeEach ->
+          settings.set("findCharsMax", 2)
 
-        it "can find by one-char by confirming explicitly", ->
-          set                 textC: "|    a    ab    a    cd    a"
-          ensure "f a enter", textC: "    |a    ab    a    cd    a"
-          ensure "f c enter", textC: "    a    ab    a    |cd    a"
+        describe "can find one or two char", ->
+          it "can find by two char", ->
+            set             textC: "|    a    ab    a    cd    a"
+            ensure "f a b", textC: "    a    |ab    a    cd    a"
+            ensure "f c d", textC: "    a    ab    a    |cd    a"
+
+          it "can find by one-char by confirming explicitly", ->
+            set                 textC: "|    a    ab    a    cd    a"
+            ensure "f a enter", textC: "    |a    ab    a    cd    a"
+            ensure "f c enter", textC: "    a    ab    a    |cd    a"
+
+      describe "with 3 length", ->
+        beforeEach ->
+          settings.set("findCharsMax", 3)
+
+        describe "can find 3 at maximum", ->
+          it "can find by one or two or three char", ->
+            set                   textC: "|    a    ab    a    cd    efg"
+            ensure "f a b enter", textC: "    a    |ab    a    cd    efg"
+            ensure "f a enter",   textC: "    a    ab    |a    cd    efg"
+            ensure "f c d enter", textC: "    a    ab    a    |cd    efg"
+            ensure "f e f g",     textC: "    a    ab    a    cd    |efg"
 
       describe "autoConfirmTimeout", ->
-        beforeEach -> settings.set("findByTwoCharsAutoConfirmTimeout", 500)
+        beforeEach ->
+          settings.set("findCharsMax", 2)
+          settings.set("findConfirmByTimeout", 500)
+
         it "auto-confirm single-char input on timeout", ->
           set             textC: "|    a    ab    a    cd    a"
 


### PR DESCRIPTION
User can set arbitrary max char length for `f`.

- `findCharsMax`: `1` by default.

Aside from flexibility with this new configuration.

Usecase I'm considering is bellow.

**By setting bigger number(such as `100`) with enabling `findConfirmByTimeout`, you can expect FIXED gap timing of confirmation against your input.**(FIXED gap on "input > wait > land" flow)

Feedback collecting Issue #851 

Continuation of work done in #852, #854 for "tunable-f"