### PR TITLE
[highlight-find] change appearance for current match to give hint to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.3.3:
-- Improve: highlight-find-char now highlight differently( with thicker border ) if there is single match in VISIBLE screen range,
-  - If you see this thick border while typing, it means you don't need extra typing to move that target.
+- Improve: highlight-find-char now highlight unconfirmed-current-match differently( with thicker border ).
+  - You now visually notified "no extra keytype is required to land this position" while typing.
 
 # 1.3.2:
 - Improve: highlight-find-char now highlight all chars in next lines when `findAcrossLines` was set.

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -5,12 +5,6 @@ const DecorationTypes = {
       class: "vim-mode-plus-find-char pre-confirm",
     },
   },
-  "pre-confirm single-match": {
-    decorationProps: {
-      type: "highlight",
-      class: "vim-mode-plus-find-char pre-confirm single-match",
-    },
-  },
   "post-confirm": {
     timeout: 2000,
     decorationProps: {
@@ -46,7 +40,7 @@ module.exports = class HighlightFind {
     this.markerLayer.clear()
   }
 
-  highlightRanges(ranges, decorationType) {
+  highlightRanges(ranges, decorationType, currentRange) {
     if (this.clearMarkerTimeoutID) {
       clearTimeout(this.clearMarkerTimeoutID)
       this.clearMarkerTimeoutID = null
@@ -62,6 +56,15 @@ module.exports = class HighlightFind {
 
     const {timeout, decorationProps} = DecorationTypes[decorationType]
     this.decorationLayer.setProperties(decorationProps)
+
+    if (currentRange) {
+      const currentMarker = this.markerLayer.getMarkers().find(marker => marker.getBufferRange().isEqual(currentRange))
+      this.decorationLayer.setPropertiesForMarker(currentMarker, {
+        type: "highlight",
+        class: "vim-mode-plus-find-char pre-confirm current",
+      })
+    }
+
     if (timeout) {
       this.clearMarkerTimeoutID = setTimeout(() => this.clearMarkers(), timeout)
     }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -40,13 +40,51 @@ module.exports = class HighlightFind {
     this.markerLayer.clear()
   }
 
+  highlightCursorRows(regex, decorationType, backwards, currentIndex) {
+    this.clearMarkers()
+
+    const vimState = this.vimState
+    const editor = this.vimState.editor
+    const visibleRange = this.vimState.utils.getVisibleBufferRange(editor)
+
+    const cursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
+    if (!cursors.length) return
+
+    let scanRanges
+    if (vimState.getConfig("findAcrossLines")) {
+      const cursorsOrdered = this.vimState.utils.sortCursors(cursors)
+      scanRanges = backwards
+        ? [[visibleRange.start, cursorsOrdered.pop().getBufferPosition()]]
+        : [[cursorsOrdered.shift().getBufferPosition(), visibleRange.end]]
+    } else {
+      scanRanges = backwards
+        ? cursors.map(cursor => [cursor.getCurrentLineBufferRange().start, cursor.getBufferPosition()])
+        : cursors.map(cursor => [cursor.getBufferPosition(), cursor.getCurrentLineBufferRange().end])
+    }
+
+    const ranges = []
+    for (const scanRange of scanRanges) {
+      editor.scanInBufferRange(regex, scanRange, ({range}) => ranges.push(range))
+    }
+    if (!ranges.length) return
+
+    let currentRange
+    if (decorationType === "pre-confirm") {
+      const cursorPosition = editor.getCursorBufferPosition()
+      const candidates = backwards
+        ? ranges.slice().reverse().filter(range => range.start.isLessThan(cursorPosition))
+        : ranges.filter(range => range.start.isGreaterThan(cursorPosition))
+      currentRange = candidates[currentIndex]
+    }
+    this.highlightRanges(ranges, decorationType, currentRange)
+  }
+
   highlightRanges(ranges, decorationType, currentRange) {
     if (this.clearMarkerTimeoutID) {
       clearTimeout(this.clearMarkerTimeoutID)
       this.clearMarkerTimeoutID = null
     }
 
-    this.clearMarkers()
     // We need to force update here to restart(re-trigger) keyframe animation.
     this.vimState.editor.component.updateSync()
 

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -46,6 +46,7 @@ module.exports = class HighlightFind {
     const vimState = this.vimState
     const editor = this.vimState.editor
     const visibleRange = this.vimState.utils.getVisibleBufferRange(editor)
+    if (!visibleRange) return
 
     const cursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
     if (!cursors.length) return

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -965,42 +965,7 @@ class Find extends Motion
 
   highlightTextInCursorRows: (text, decorationType) ->
     return unless @getConfig("highlightFindChar")
-    @vimState.highlightFind.clearMarkers()
-
-    visibleRange = @vimState.utils.getVisibleBufferRange(@editor)
-    cursors = @editor.getCursors().filter (cursor) ->
-      visibleRange.containsPoint(cursor.getBufferPosition())
-    cursors = @vimState.utils.sortCursors(cursors ? [])
-    return unless cursors.length
-
-    if @getConfig("findAcrossLines")
-      if @isBackwards()
-        scanRanges = [[visibleRange.start, cursors.pop().getBufferPosition()]]
-      else
-        scanRanges = [[cursors.shift().getBufferPosition(), visibleRange.end]]
-    else
-      if @isBackwards()
-        scanRanges = cursors.map (cursor) ->
-          [cursor.getCurrentLineBufferRange().start, cursor.getBufferPosition()]
-      else
-        scanRanges = cursors.map (cursor) ->
-          [cursor.getBufferPosition(), cursor.getCurrentLineBufferRange().end]
-
-    regex = @getRegex(text)
-    ranges = []
-    for scanRange in scanRanges
-      @editor.scanInBufferRange(regex, scanRange, ({range}) -> ranges.push(range))
-
-    return unless ranges.length
-
-    if (decorationType is "pre-confirm")
-      cursorPosition = @editor.getCursorBufferPosition()
-      if @isBackwards()
-        candidates = ranges.reverse().filter (range) -> range.start.isLessThan(cursorPosition)
-      else
-        candidates = ranges.filter (range) -> range.start.isGreaterThan(cursorPosition)
-      currentRange = candidates[@getCount(-1)]
-    @vimState.highlightFind.highlightRanges(ranges, decorationType, currentRange)
+    @vimState.highlightFind.highlightCursorRows(@getRegex(text), decorationType, @isBackwards(), @getCount(-1))
 
   moveCursor: (cursor) ->
     point = @getPoint(cursor.getBufferPosition())

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -965,6 +965,7 @@ class Find extends Motion
 
   highlightTextInCursorRows: (text, decorationType) ->
     return unless @getConfig("highlightFindChar")
+    @vimState.highlightFind.clearMarkers()
 
     visibleRange = @vimState.utils.getVisibleBufferRange(@editor)
     cursors = @editor.getCursors().filter (cursor) ->
@@ -974,11 +975,16 @@ class Find extends Motion
 
     if @getConfig("findAcrossLines")
       if @isBackwards()
-        scanRanges = [[visibleRange.start, [cursors.pop().getBufferRow(), Infinity]]]
+        scanRanges = [[visibleRange.start, cursors.pop().getBufferPosition()]]
       else
-        scanRanges = [[[cursors.shift().getBufferRow(), 0], visibleRange.end]]
+        scanRanges = [[cursors.shift().getBufferPosition(), visibleRange.end]]
     else
-      scanRanges = cursors.map (cursor) -> cursor.getCurrentLineBufferRange()
+      if @isBackwards()
+        scanRanges = cursors.map (cursor) ->
+          [cursor.getCurrentLineBufferRange().start, cursor.getBufferPosition()]
+      else
+        scanRanges = cursors.map (cursor) ->
+          [cursor.getBufferPosition(), cursor.getCurrentLineBufferRange().end]
 
     regex = @getRegex(text)
     ranges = []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,8 +72,12 @@ function isEndsWithNewLineForBufferRow(editor, row) {
   return start.row !== end.row
 }
 
-function sortRanges(collection) {
-  return collection.sort((a, b) => a.compare(b))
+function sortRanges(ranges) {
+  return ranges.sort((a, b) => a.compare(b))
+}
+
+function sortCursors(cursors) {
+  return cursors.sort((a, b) => a.compare(b))
 }
 
 // Return adjusted index fit whitin given list's length
@@ -1095,6 +1099,7 @@ module.exports = {
   saveEditorState,
   isLinewiseRange,
   sortRanges,
+  sortCursors,
   getIndex,
   getVisibleBufferRange,
   getVisibleEditors,

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -351,6 +351,9 @@ describe "Motion Find", ->
         ensure "T a", textC: "0:    a    a\n1:    a|    a\n2:    a    a\n"
 
     describe "findCharsMax", ->
+      beforeEach ->
+        # To pass hlFind logic it require "visible" screen range.
+        jasmine.attachToDOM(atom.workspace.getElement())
 
       describe "with 2 length", ->
         beforeEach ->

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -319,7 +319,7 @@ atom-text-editor {
     }
     &.pre-confirm .region {
       border-color: @syntax-color-modified;
-      &.single-match { border-bottom-width: 5px; }
+      &.current { border-bottom-width: 5px; }
     }
     &.post-confirm .region {
       .flash(vim-mode-plus-flash-find-char, 2.0s);


### PR DESCRIPTION
Related #851 

- If you see this thick border while typing, it means you don't need extra typing to move that target.
- This is useful when you set `findCharsMax` greater than `1`.
- You can know "no repeat or no extra keytype is required to land this position" while typing.
