### PR TITLE
[better-find] allow adjust target before confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,26 @@
 # 1.4.0: WIP
-- Maintenance: Remove `[EXPERIMENTAL]` tag from description of `findAcrossLines` settings, since we found it useful.
+- Improve: `f` family related
+  - Improve: Restore original scrollTop when `findAcrossLines` enabled and cancelled after scroll.
+  - Rename config: `keymapSemicolonToConfirmFind` to `keymapSemicolonToConfirmOnFindInput`(auto-migrate)
+  - Improve: Empty confirm no longer move cursor when `findCharsMax` > 1.
+  - New: Commands `find-next-pre-confirmed` and `find-previous-pre-confirmed`.
+    - Scope: Available when `f` family waiting for input(`atom-text-editor.vim-mode-plus-input.find`).
+    - Keymap: `tab`, and `shift-tab` is mapped by default.
+    - Why?
+      - Allow you to adjust landing target BEFORE confirm to skip un-aimed stop interactively.
+      - In most case, using `;` or `,` after `f` finished is OK.
+      - But when `f` is used with operator, such as `c t f "` and `"` matched earlier spot than you aimed.
+      - This situation is not recoverable/retry-able by `.` repeat, but manually avoid-able by new commands.
+  - New, Experimental: Conditional keymap `keymapSemicolonAndCommaToFindPreConfirmedOnFindInput`(default `false`).
+    - When enabled, `;` and `,` is mapped to new `find-next-pre-confirmed` and `find-previous-pre-confirmed`.
+  - Maintenance: Remove `[EXPERIMENTAL]` tag from description of `findAcrossLines` settings, since we found it useful.
+  - Improve: Fix several highlight inconsistencies.
 - Fix: Incorrect cursor rendering when `automaticallyEscapeInsertModeOnActivePaneItemChange` is enabled. #855
   - When `automaticallyEscapeInsertModeOnActivePaneItemChange` is set and active-tab change and back.
   - Cursor rendered odd way.
   - This is started from Atom v1.19.0 with new editor-rendering change.
   - To workaround issue, now use more appropriate `onDidStopChangingActivePaneItem` hook.
-- New, Experimental: Conditional keymap config `keymapIAndAToInsertAtTargetWhenHasOccurrence`(default `false`). #862
+- New, Experimental: Conditional keymap `keymapIAndAToInsertAtTargetWhenHasOccurrence`(default `false`). #862
   - This is revival of old default keymap which is removed because it was too aggressive, confusing as default-keymap.
   - When enabled and edigtor has `preset-occurrence` marker, `I` and `A` behave as operator which take `target`.
   - e.g. `I p`, `A p` to insert at start or end of `preset-occurrence` in paragraph(`p`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
   - Following behavioral change is noticeable only when user create multiple `preset-occurrence` for different word.
     - old: `tab`, `shift-tab` visit `preset-occurrence` in created order.
     - new: `tab`, `shift-tab` visit `preset-occurrence` in ordered by buffer position.
-- Style: Tweak boldness from 5px to 4px for pre-confirmed-current-match of highlight-find-char.
 
 # 1.3.3:
 - Improve: highlight-find-char now highlight unconfirmed-current-match differently( with thicker border ).

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -666,6 +666,11 @@
   'ctrl-c': 'core:cancel'
   'ctrl-[': 'core:cancel'
 
+# Find editor
+"atom-text-editor.vim-mode-plus-input.find":
+  "tab": "vim-mode-plus:find-next-pre-confirmed"
+  "shift-tab": "vim-mode-plus:find-previous-pre-confirmed"
+
 # Search mini editor
 # -------------------------
 'atom-text-editor.vim-mode-plus-search':

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,6 +1,6 @@
 module.exports = function focusInput(
   vimState,
-  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, purpose} = {}
+  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, purpose, commands} = {}
 ) {
   const classListToAdd = ["vim-mode-plus-input-focused"]
   if (hideCursor) classListToAdd.push("hide-cursor")
@@ -36,6 +36,12 @@ module.exports = function focusInput(
     unfocus()
     onConfirm(text)
   }
+  const confirmAfter = (text, timeout) => {
+    if (text) {
+      clerAutoConfirmTimer()
+      autoConfirmTimeoutID = setTimeout(() => confirm(text), timeout)
+    }
+  }
   const cancel = () => {
     unfocus()
     onCancel()
@@ -47,16 +53,12 @@ module.exports = function focusInput(
     editor.onDidChange(() => confirm(editor.getText()))
   } else {
     editor.onDidChange(() => {
-      clerAutoConfirmTimer()
-
       const text = editor.getText()
       if (text.length >= charsMax) {
         confirm(text)
       } else {
         if (onChange) onChange(text)
-        if (autoConfirmTimeout) {
-          autoConfirmTimeoutID = setTimeout(() => confirm(text), autoConfirmTimeout)
-        }
+        if (autoConfirmTimeout) confirmAfter(text, autoConfirmTimeout)
       }
     })
   }
@@ -71,5 +73,18 @@ module.exports = function focusInput(
       confirm(editor.getText())
     },
   })
+  if (commands) {
+    const wrappedCommands = {}
+    for (const name of Object.keys(commands)) {
+      wrappedCommands[name] = function(event) {
+        commands[name].call(editor.element, event)
+        if (autoConfirmTimeout) {
+          confirmAfter(editor.getText(), autoConfirmTimeout)
+        }
+      }
+    }
+    atom.commands.add(editor.element, wrappedCommands)
+  }
+
   editor.element.focus()
 }

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -36,12 +36,12 @@ module.exports = function focusInput(
     unfocus()
     onConfirm(text)
   }
+
   const confirmAfter = (text, timeout) => {
-    if (text) {
-      clerAutoConfirmTimer()
-      autoConfirmTimeoutID = setTimeout(() => confirm(text), timeout)
-    }
+    clerAutoConfirmTimer()
+    if (text) autoConfirmTimeoutID = setTimeout(() => confirm(text), timeout)
   }
+
   const cancel = () => {
     unfocus()
     onCancel()

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,6 +1,16 @@
 module.exports = function focusInput(
   vimState,
-  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, purpose, commands} = {}
+  {
+    charsMax = 1,
+    autoConfirmTimeout,
+    hideCursor,
+    onChange,
+    onCancel,
+    onConfirm,
+    purpose,
+    commands,
+    onWillInsertText,
+  } = {}
 ) {
   const classListToAdd = ["vim-mode-plus-input-focused"]
   if (hideCursor) classListToAdd.push("hide-cursor")
@@ -52,6 +62,19 @@ module.exports = function focusInput(
   if (charsMax === 1) {
     editor.onDidChange(() => confirm(editor.getText()))
   } else {
+    if (onWillInsertText) {
+      editor.onWillInsertText(event => {
+        const text = editor.getText()
+        onWillInsertText({
+          text: event.text,
+          cancel: () => {
+            // Wrap original cancel to reset auto-confirm countdown.
+            if (autoConfirmTimeout) confirmAfter(text, autoConfirmTimeout)
+            event.cancel()
+          },
+        })
+      })
+    }
     editor.onDidChange(() => {
       const text = editor.getText()
       if (text.length >= charsMax) {
@@ -87,4 +110,5 @@ module.exports = function focusInput(
   }
 
   editor.element.focus()
+  return editor
 }

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -1,16 +1,6 @@
 module.exports = function focusInput(
   vimState,
-  {
-    charsMax = 1,
-    autoConfirmTimeout,
-    hideCursor,
-    onChange,
-    onCancel,
-    onConfirm,
-    purpose,
-    commands,
-    onWillInsertText,
-  } = {}
+  {charsMax = 1, autoConfirmTimeout, hideCursor, onChange, onCancel, onConfirm, purpose, commands} = {}
 ) {
   const classListToAdd = ["vim-mode-plus-input-focused"]
   if (hideCursor) classListToAdd.push("hide-cursor")
@@ -62,21 +52,9 @@ module.exports = function focusInput(
   if (charsMax === 1) {
     editor.onDidChange(() => confirm(editor.getText()))
   } else {
-    if (onWillInsertText) {
-      editor.onWillInsertText(event => {
-        const text = editor.getText()
-        onWillInsertText({
-          text: event.text,
-          cancel: () => {
-            // Wrap original cancel to reset auto-confirm countdown.
-            if (autoConfirmTimeout) confirmAfter(text, autoConfirmTimeout)
-            event.cancel()
-          },
-        })
-      })
-    }
     editor.onDidChange(() => {
       const text = editor.getText()
+      editor.element.classList.toggle("has-text", text.length)
       if (text.length >= charsMax) {
         confirm(text)
       } else {
@@ -110,5 +88,4 @@ module.exports = function focusInput(
   }
 
   editor.element.focus()
-  return editor
 }

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -101,12 +101,13 @@ module.exports = class HighlightFind {
       const rangesToHighlight = ranges.filter(range => visibleRange.containsRange(range))
       this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
       return currentIndex
-
     } else {
       let landingRanges = []
       const rangesToHighlight = []
 
-      const visibleCursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
+      const visibleCursors = editor
+        .getCursors()
+        .filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
       for (const cursor of visibleCursors) {
         const scanRange = cursor.getCurrentLineBufferRange()
         const ranges = collectRanges(regex, scanRange, cursor.getBufferPosition())
@@ -125,7 +126,6 @@ module.exports = class HighlightFind {
       if (!rangesToHighlight.length) return
       this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
       return currentIndex
-
     }
   }
 
@@ -138,16 +138,18 @@ module.exports = class HighlightFind {
     // We need to force update here to restart(re-trigger) keyframe animation.
     this.vimState.editor.component.updateSync()
 
+    const landingMarkers = []
     for (const range of ranges) {
-      this.markerLayer.markBufferRange(range, {invalidate: "touch"})
+      const marker = this.markerLayer.markBufferRange(range, {invalidate: "touch"})
+      if (landingRanges.includes(range)) {
+        landingMarkers.push(marker)
+      }
     }
 
     const {timeout, decorationProps} = DecorationTypes[decorationType]
     this.decorationLayer.setProperties(decorationProps)
 
-    for (const landingRange of landingRanges) {
-      const marker = this.markerLayer.getMarkers().find(marker => marker.getBufferRange().isEqual(landingRange))
-      if (!marker) continue
+    for (const marker of landingMarkers) {
       this.decorationLayer.setPropertiesForMarker(marker, {
         type: "highlight",
         class: "vim-mode-plus-find-char pre-confirm current",

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -80,6 +80,7 @@ module.exports = class HighlightFind {
         currentIndex = this.vimState.utils.limitNumber(currentIndex, {min: 0, max: ranges.length - 1})
       }
       currentRange = candidates[currentIndex]
+      if (currentRange) editor.scrollToBufferPosition(currentRange.start)
     }
     this.highlightRanges(ranges, decorationType, currentRange)
 

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,3 +1,4 @@
+const {Point} = require("atom")
 const DecorationTypes = {
   "pre-confirm": {
     decorationProps: {
@@ -41,47 +42,64 @@ module.exports = class HighlightFind {
   }
 
   // Return adjusted currentIndex
-  highlightCursorRows(regex, decorationType, backwards, currentIndex, adjustIndex) {
+  highlightCursorRows(regex, decorationType, backwards, offset, currentIndex, adjustIndex) {
     this.clearMarkers()
 
+    const isPreConfirm = decorationType === "pre-confirm"
     const vimState = this.vimState
     const editor = this.vimState.editor
     const visibleRange = this.vimState.utils.getVisibleBufferRange(editor)
     if (!visibleRange) return
 
-    const cursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
-    if (!cursors.length) return
+    const collectMethod = backwards
+      ? isPreConfirm || offset ? "isLessThan" : "isLessThanOrEqual"
+      : isPreConfirm || offset ? "isGreaterThan" : "isGreaterThanOrEqual"
 
-    let scanRanges
-    if (vimState.getConfig("findAcrossLines")) {
-      const cursorsOrdered = this.vimState.utils.sortCursors(cursors)
-      scanRanges = backwards
-        ? [[visibleRange.start, cursorsOrdered.pop().getBufferPosition()]]
-        : [[cursorsOrdered.shift().getBufferPosition(), visibleRange.end]]
-    } else {
-      scanRanges = backwards
-        ? cursors.map(cursor => [cursor.getCurrentLineBufferRange().start, cursor.getBufferPosition()])
-        : cursors.map(cursor => [cursor.getBufferPosition(), cursor.getCurrentLineBufferRange().end])
+    const collectRanges = (regex, scanRange, backwards, point) => {
+      const ranges = []
+      const needHighlight = range => range.start[collectMethod](point)
+      const collect = ({range}) => needHighlight(range) && ranges.push(range)
+      editor.scanInBufferRange(regex, scanRange, collect)
+      return ranges
     }
 
     const ranges = []
-    for (const scanRange of scanRanges) {
-      editor.scanInBufferRange(regex, scanRange, ({range}) => ranges.push(range))
+    let currentRange
+    if (vimState.getConfig("findAcrossLines")) {
+      const cursorsOrdered = this.vimState.utils.sortCursors(editor.getCursors())
+      const scanRange = visibleRange
+
+      if (backwards) {
+        const bottomCursor = cursorsOrdered.pop()
+        const cursorPosition = bottomCursor.getBufferPosition()
+        scanRange.end = Point.min(scanRange.end, bottomCursor.getCurrentLineBufferRange().end)
+        ranges.push(...collectRanges(regex, scanRange, true, cursorPosition))
+      } else {
+        const topCursor = cursorsOrdered.shift()
+        const cursorPosition = topCursor.getBufferPosition()
+        scanRange.start = Point.max(scanRange.start, topCursor.getCurrentLineBufferRange().start)
+        ranges.push(...collectRanges(regex, scanRange, false, cursorPosition))
+      }
+      // ranges.filter
+    } else {
+      const cursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
+      for (const cursor of cursors) {
+        const scanRange = cursor.getCurrentLineBufferRange()
+        const _ranges = collectRanges(regex, scanRange, backwards, cursor.getBufferPosition())
+
+        if (cursor.isLastCursor() && isPreConfirm) {
+          if (adjustIndex) {
+            currentIndex = this.vimState.utils.limitNumber(currentIndex, {min: 0, max: _ranges.length - 1})
+          }
+          currentRange = _ranges[currentIndex]
+          if (currentRange) editor.scrollToBufferPosition(currentRange.start)
+        }
+
+        ranges.push(..._ranges)
+      }
     }
     if (!ranges.length) return
 
-    let currentRange
-    if (decorationType === "pre-confirm") {
-      const cursorPosition = editor.getCursorBufferPosition()
-      const candidates = backwards
-        ? ranges.slice().reverse().filter(range => range.start.isLessThan(cursorPosition))
-        : ranges.filter(range => range.start.isGreaterThan(cursorPosition))
-      if (adjustIndex) {
-        currentIndex = this.vimState.utils.limitNumber(currentIndex, {min: 0, max: ranges.length - 1})
-      }
-      currentRange = candidates[currentIndex]
-      if (currentRange) editor.scrollToBufferPosition(currentRange.start)
-    }
     this.highlightRanges(ranges, decorationType, currentRange)
 
     return currentIndex

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -47,11 +47,11 @@ module.exports = class HighlightFind {
   highlightCursorRows(regex, decorationType, backwards, offset, currentIndex, adjustIndex) {
     this.clearMarkers()
 
-    const isPreConfirm = decorationType === "pre-confirm"
     const editor = this.vimState.editor
     const visibleRange = getVisibleBufferRange(editor)
     if (!visibleRange) return
 
+    const isPreConfirm = decorationType === "pre-confirm"
     const scanMethodName = backwards ? "backwardsScanInBufferRange" : "scanInBufferRange"
     const compareMethodName = backwards
       ? isPreConfirm || offset ? "isLessThan" : "isLessThanOrEqual"
@@ -65,28 +65,27 @@ module.exports = class HighlightFind {
       return ranges
     }
 
-    const rangesToHighlight = []
-
-    let landingRanges = []
     if (this.vimState.getConfig("findAcrossLines")) {
       const cursorsOrdered = editor.getCursorsOrderedByBufferPosition()
 
-      let scanRange, cursorPosition
+      let ranges
       if (backwards) {
         const bottomCursor = cursorsOrdered.slice().pop()
-        cursorPosition = bottomCursor.getBufferPosition()
-        scanRange = [Point.ZERO, [cursorPosition.row, Infinity]]
+        const cursorPosition = bottomCursor.getBufferPosition()
+        const scanRange = [Point.ZERO, [cursorPosition.row, Infinity]]
+        ranges = collectRanges(regex, scanRange, cursorPosition)
       } else {
         const topCursor = cursorsOrdered.slice().shift()
-        cursorPosition = topCursor.getBufferPosition()
-        scanRange = [[cursorPosition.row, 0], editor.getEofBufferPosition()]
+        const cursorPosition = topCursor.getBufferPosition()
+        const scanRange = [[cursorPosition.row, 0], editor.getEofBufferPosition()]
+        ranges = collectRanges(regex, scanRange, cursorPosition)
       }
-      const ranges = collectRanges(regex, scanRange, cursorPosition)
-      rangesToHighlight.push(...ranges.filter(range => visibleRange.containsRange(range)))
 
+      if (!ranges.length) return
+
+      let landingRanges = []
       if (isPreConfirm) {
         for (const cursor of cursorsOrdered) {
-
           const point = cursor.getBufferPosition()
           const index = ranges.findIndex(range => range.start[compareMethodName](point))
           if (index >= 0) {
@@ -99,7 +98,13 @@ module.exports = class HighlightFind {
           }
         }
       }
+      const rangesToHighlight = ranges.filter(range => visibleRange.containsRange(range))
+      this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
+      return currentIndex
+
     } else {
+      let landingRanges = []
+      const rangesToHighlight = []
 
       const visibleCursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
       for (const cursor of visibleCursors) {
@@ -117,12 +122,11 @@ module.exports = class HighlightFind {
           }
         }
       }
+      if (!rangesToHighlight.length) return
+      this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
+      return currentIndex
+
     }
-    if (!rangesToHighlight.length) return
-
-    this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
-
-    return currentIndex
   }
 
   highlightRanges(ranges, decorationType, landingRanges) {
@@ -143,6 +147,7 @@ module.exports = class HighlightFind {
 
     for (const landingRange of landingRanges) {
       const marker = this.markerLayer.getMarkers().find(marker => marker.getBufferRange().isEqual(landingRange))
+      if (!marker) continue
       this.decorationLayer.setPropertiesForMarker(marker, {
         type: "highlight",
         class: "vim-mode-plus-find-char pre-confirm current",

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,5 +1,5 @@
 const {Point} = require("atom")
-const {limitNumber} = require("./utils")
+const {limitNumber, getVisibleBufferRange} = require("./utils")
 
 const DecorationTypes = {
   "pre-confirm": {
@@ -49,7 +49,7 @@ module.exports = class HighlightFind {
 
     const isPreConfirm = decorationType === "pre-confirm"
     const editor = this.vimState.editor
-    const visibleRange = this.vimState.utils.getVisibleBufferRange(editor)
+    const visibleRange = getVisibleBufferRange(editor)
     if (!visibleRange) return
 
     const scanMethodName = backwards ? "backwardsScanInBufferRange" : "scanInBufferRange"
@@ -83,11 +83,14 @@ module.exports = class HighlightFind {
       }
       const ranges = collectRanges(regex, scanRange, cursorPosition)
       rangesToHighlight.push(...ranges.filter(range => visibleRange.containsRange(range)))
+
       if (isPreConfirm) {
         for (const cursor of cursorsOrdered) {
+
           const point = cursor.getBufferPosition()
           const index = ranges.findIndex(range => range.start[compareMethodName](point))
           if (index >= 0) {
+            if (adjustIndex) currentIndex = limitNumber(currentIndex, {min: 0, max: ranges.length - 1 - index})
             const range = ranges[index + currentIndex]
             if (range) {
               landingRanges.push(range)
@@ -96,8 +99,8 @@ module.exports = class HighlightFind {
           }
         }
       }
-      // ranges.filter
     } else {
+
       const visibleCursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
       for (const cursor of visibleCursors) {
         const scanRange = cursor.getCurrentLineBufferRange()

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -1,4 +1,6 @@
 const {Point} = require("atom")
+const {limitNumber} = require("./utils")
+
 const DecorationTypes = {
   "pre-confirm": {
     decorationProps: {
@@ -46,66 +48,81 @@ module.exports = class HighlightFind {
     this.clearMarkers()
 
     const isPreConfirm = decorationType === "pre-confirm"
-    const vimState = this.vimState
     const editor = this.vimState.editor
     const visibleRange = this.vimState.utils.getVisibleBufferRange(editor)
     if (!visibleRange) return
 
-    const collectMethod = backwards
+    const scanMethodName = backwards ? "backwardsScanInBufferRange" : "scanInBufferRange"
+    const compareMethodName = backwards
       ? isPreConfirm || offset ? "isLessThan" : "isLessThanOrEqual"
       : isPreConfirm || offset ? "isGreaterThan" : "isGreaterThanOrEqual"
 
-    const collectRanges = (regex, scanRange, backwards, point) => {
+    const collectRanges = (regex, scanRange, point) => {
       const ranges = []
-      const needHighlight = range => range.start[collectMethod](point)
-      const collect = ({range}) => needHighlight(range) && ranges.push(range)
-      editor.scanInBufferRange(regex, scanRange, collect)
+      editor[scanMethodName](regex, scanRange, ({range}) => {
+        if (range.start[compareMethodName](point)) ranges.push(range)
+      })
       return ranges
     }
 
-    const ranges = []
-    let currentRange
-    if (vimState.getConfig("findAcrossLines")) {
-      const cursorsOrdered = this.vimState.utils.sortCursors(editor.getCursors())
-      const scanRange = visibleRange
+    const rangesToHighlight = []
 
+    let landingRanges = []
+    if (this.vimState.getConfig("findAcrossLines")) {
+      const cursorsOrdered = editor.getCursorsOrderedByBufferPosition()
+
+      let scanRange, cursorPosition
       if (backwards) {
-        const bottomCursor = cursorsOrdered.pop()
-        const cursorPosition = bottomCursor.getBufferPosition()
-        scanRange.end = Point.min(scanRange.end, bottomCursor.getCurrentLineBufferRange().end)
-        ranges.push(...collectRanges(regex, scanRange, true, cursorPosition))
+        const bottomCursor = cursorsOrdered.slice().pop()
+        cursorPosition = bottomCursor.getBufferPosition()
+        scanRange = [Point.ZERO, [cursorPosition.row, Infinity]]
       } else {
-        const topCursor = cursorsOrdered.shift()
-        const cursorPosition = topCursor.getBufferPosition()
-        scanRange.start = Point.max(scanRange.start, topCursor.getCurrentLineBufferRange().start)
-        ranges.push(...collectRanges(regex, scanRange, false, cursorPosition))
+        const topCursor = cursorsOrdered.slice().shift()
+        cursorPosition = topCursor.getBufferPosition()
+        scanRange = [[cursorPosition.row, 0], editor.getEofBufferPosition()]
+      }
+      const ranges = collectRanges(regex, scanRange, cursorPosition)
+      rangesToHighlight.push(...ranges.filter(range => visibleRange.containsRange(range)))
+      if (isPreConfirm) {
+        for (const cursor of cursorsOrdered) {
+          const point = cursor.getBufferPosition()
+          const index = ranges.findIndex(range => range.start[compareMethodName](point))
+          if (index >= 0) {
+            const range = ranges[index + currentIndex]
+            if (range) {
+              landingRanges.push(range)
+              if (cursor.isLastCursor()) editor.scrollToBufferPosition(range.start)
+            }
+          }
+        }
       }
       // ranges.filter
     } else {
-      const cursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
-      for (const cursor of cursors) {
+      const visibleCursors = editor.getCursors().filter(cursor => visibleRange.containsPoint(cursor.getBufferPosition()))
+      for (const cursor of visibleCursors) {
         const scanRange = cursor.getCurrentLineBufferRange()
-        const _ranges = collectRanges(regex, scanRange, backwards, cursor.getBufferPosition())
+        const ranges = collectRanges(regex, scanRange, cursor.getBufferPosition())
+        rangesToHighlight.push(...ranges)
 
-        if (cursor.isLastCursor() && isPreConfirm) {
-          if (adjustIndex) {
-            currentIndex = this.vimState.utils.limitNumber(currentIndex, {min: 0, max: _ranges.length - 1})
+        if (isPreConfirm) {
+          if (adjustIndex) currentIndex = limitNumber(currentIndex, {min: 0, max: ranges.length - 1})
+
+          const range = ranges[currentIndex]
+          if (range) {
+            landingRanges.push(range)
+            if (cursor.isLastCursor()) editor.scrollToBufferPosition(range.start)
           }
-          currentRange = _ranges[currentIndex]
-          if (currentRange) editor.scrollToBufferPosition(currentRange.start)
         }
-
-        ranges.push(..._ranges)
       }
     }
-    if (!ranges.length) return
+    if (!rangesToHighlight.length) return
 
-    this.highlightRanges(ranges, decorationType, currentRange)
+    this.highlightRanges(rangesToHighlight, decorationType, landingRanges)
 
     return currentIndex
   }
 
-  highlightRanges(ranges, decorationType, currentRange) {
+  highlightRanges(ranges, decorationType, landingRanges) {
     if (this.clearMarkerTimeoutID) {
       clearTimeout(this.clearMarkerTimeoutID)
       this.clearMarkerTimeoutID = null
@@ -121,9 +138,9 @@ module.exports = class HighlightFind {
     const {timeout, decorationProps} = DecorationTypes[decorationType]
     this.decorationLayer.setProperties(decorationProps)
 
-    if (currentRange) {
-      const currentMarker = this.markerLayer.getMarkers().find(marker => marker.getBufferRange().isEqual(currentRange))
-      this.decorationLayer.setPropertiesForMarker(currentMarker, {
+    for (const landingRange of landingRanges) {
+      const marker = this.markerLayer.getMarkers().find(marker => marker.getBufferRange().isEqual(landingRange))
+      this.decorationLayer.setPropertiesForMarker(marker, {
         type: "highlight",
         class: "vim-mode-plus-find-char pre-confirm current",
       })

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -90,7 +90,7 @@ module.exports = class HighlightFind {
     this.vimState.editor.component.updateSync()
 
     for (const range of ranges) {
-      this.markerLayer.markBufferRange(range)
+      this.markerLayer.markBufferRange(range, {invalidate: "touch"})
     }
 
     const {timeout, decorationProps} = DecorationTypes[decorationType]

--- a/lib/highlight-find-manager.js
+++ b/lib/highlight-find-manager.js
@@ -40,7 +40,8 @@ module.exports = class HighlightFind {
     this.markerLayer.clear()
   }
 
-  highlightCursorRows(regex, decorationType, backwards, currentIndex) {
+  // Return adjusted currentIndex
+  highlightCursorRows(regex, decorationType, backwards, currentIndex, adjustIndex) {
     this.clearMarkers()
 
     const vimState = this.vimState
@@ -75,9 +76,14 @@ module.exports = class HighlightFind {
       const candidates = backwards
         ? ranges.slice().reverse().filter(range => range.start.isLessThan(cursorPosition))
         : ranges.filter(range => range.start.isGreaterThan(cursorPosition))
+      if (adjustIndex) {
+        currentIndex = this.vimState.utils.limitNumber(currentIndex, {min: 0, max: ranges.length - 1})
+      }
       currentRange = candidates[currentIndex]
     }
     this.highlightRanges(ranges, decorationType, currentRange)
+
+    return currentIndex
   }
 
   highlightRanges(ranges, decorationType, currentRange) {

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -906,7 +906,6 @@ class Find extends Motion
 
     charsMax = @getConfig("findCharsMax")
 
-    inputEditor = null
     if (charsMax > 1)
       options =
         autoConfirmTimeout: @getConfig("findConfirmByTimeout")
@@ -914,30 +913,15 @@ class Find extends Motion
         onCancel: =>
           @vimState.highlightFind.clearMarkers()
           @cancelOperation()
-        onWillInsertText: (event) =>
-          return unless @preConfirmedChars
-          switch event.text
-            when ";" then event.cancel(); @findPreConfirmed(+1)
-            when "," then event.cancel(); @findPreConfirmed(-1)
         commands:
           "vim-mode-plus:find-next-pre-confirmed": => @findPreConfirmed(+1)
           "vim-mode-plus:find-previous-pre-confirmed": =>  @findPreConfirmed(-1)
-          "vim-mode-plus:insert-semicolon-or-find-next-pre-confirmed": =>
-            if @preConfirmedChars
-              @findPreConfirmed(+1)
-            else
-              inputEditor.insertText(";")
-          "vim-mode-plus:insert-comma-or-find-previous-pre-confirmed": =>
-            if @preConfirmedChars
-              @findPreConfirmed(-1)
-            else
-              inputEditor.insertText(":")
 
     options ?= {}
     options.purpose = "find"
     options.charsMax = charsMax
 
-    inputEditor = @focusInput(options)
+    @focusInput(options)
 
   findPreConfirmed: (delta) ->
     if @preConfirmedChars and @getConfig("highlightFindChar")

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -901,7 +901,7 @@ class Find extends Motion
   initialize: ->
     super
 
-    @repeatIfNecessary()
+    @repeatIfNecessary() if @getConfig("reuseFindForRepeatFind")
     return if @isComplete()
 
     charsMax = @getConfig("findCharsMax")
@@ -930,10 +930,9 @@ class Find extends Motion
       @count = index + 1
 
   repeatIfNecessary: ->
-    if @getConfig("reuseFindForRepeatFind")
-      if @vimState.operationStack.getLastCommandName() in ["Find", "FindBackwards", "Till", "TillBackwards"]
-        @input = @vimState.globalState.get("currentFind").input
-        @repeated = true
+    if @vimState.operationStack.getLastCommandName() in ["Find", "FindBackwards", "Till", "TillBackwards"]
+      @input = @vimState.globalState.get("currentFind").input
+      @repeated = true
 
   isBackwards: ->
     @backwards
@@ -973,7 +972,7 @@ class Find extends Motion
 
   highlightTextInCursorRows: (text, decorationType, index = @getCount(-1), adjustIndex = false) ->
     return unless @getConfig("highlightFindChar")
-    @vimState.highlightFind.highlightCursorRows(@getRegex(text), decorationType, @isBackwards(), index, adjustIndex)
+    @vimState.highlightFind.highlightCursorRows(@getRegex(text), decorationType, @isBackwards(), @offset, index, adjustIndex)
 
   moveCursor: (cursor) ->
     point = @getPoint(cursor.getBufferPosition())

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -909,6 +909,7 @@ class Find extends Motion
     if (charsMax > 1)
       options =
         autoConfirmTimeout: @getConfig("findConfirmByTimeout")
+        onConfirm: (@input) => if @input then @processOperation() else @cancelOperation()
         onChange: (@preConfirmedChars) => @highlightTextInCursorRows(@preConfirmedChars, "pre-confirm")
         onCancel: =>
           @vimState.highlightFind.clearMarkers()

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -909,21 +909,24 @@ class Find extends Motion
     if (charsMax > 1)
       options =
         autoConfirmTimeout: @getConfig("findConfirmByTimeout")
-        onChange: (@chars) => @highlightTextInCursorRows(@chars, "pre-confirm")
+        onChange: (@preConfirmedChars) => @highlightTextInCursorRows(@preConfirmedChars, "pre-confirm")
         onCancel: =>
           @vimState.highlightFind.clearMarkers()
           @cancelOperation()
         commands:
-          "vim-mode-plus:find-next": =>
-            if @chars
-              @count += 1
-              @highlightTextInCursorRows(@chars, "pre-confirm")
+          "vim-mode-plus:find-next-pre-confirmed": => @findPreConfirmed(+1)
+          "vim-mode-plus:find-previous-pre-confirmed": =>  @findPreConfirmed(-1)
 
     options ?= {}
     options.purpose = "find"
     options.charsMax = charsMax
 
     @focusInput(options)
+
+  findPreConfirmed: (delta) ->
+    if @preConfirmedChars
+      @count += delta
+      @highlightTextInCursorRows(@preConfirmedChars, "pre-confirm")
 
   repeatIfNecessary: ->
     if @getConfig("reuseFindForRepeatFind")

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -909,10 +909,15 @@ class Find extends Motion
     if (charsMax > 1)
       options =
         autoConfirmTimeout: @getConfig("findConfirmByTimeout")
-        onChange: (char) => @highlightTextInCursorRows(char, "pre-confirm")
+        onChange: (@chars) => @highlightTextInCursorRows(@chars, "pre-confirm")
         onCancel: =>
           @vimState.highlightFind.clearMarkers()
           @cancelOperation()
+        commands:
+          "vim-mode-plus:find-next": =>
+            if @chars
+              @count += 1
+              @highlightTextInCursorRows(@chars, "pre-confirm")
 
     options ?= {}
     options.purpose = "find"

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -157,6 +157,12 @@ class Settings {
           ";": "core:confirm",
         },
       },
+      keymapSemicolonAndCommaToFindPreConfirmedInFindEditor: {
+        "atom-text-editor.vim-mode-plus-input.find.has-text": {
+          ";": "vim-mode-plus:find-next-pre-confirmed",
+          ",": "vim-mode-plus:find-previous-pre-confirmed",
+        },
+      },
       keymapIAndAToInsertAtTargetWhenHasOccurrence: {
         "atom-text-editor.vim-mode-plus.has-occurrence:not(.insert-mode)": {
           I: "vim-mode-plus:insert-at-start-of-target",
@@ -235,8 +241,15 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "[Can]: You can confirm find( `f` ) input by `;`.<br>e.g. `f a ;` instead of `f a enter`.<br>[Conflicts]: You cannot search `;` by `f`, `F`, `t` and `T`.",
   },
+  keymapSemicolonAndCommaToFindPreConfirmedInFindEditor: {
+    title: "[EXPERIMENTAL] keymap `;` and `,` to `find-next-pre-confirmed` and `find-previous-pre-confirmed` in find's mini-editor",
+    default: false,
+    description:
+      "[Can]: `f a ;` to move to 2nd `a`. `f a ; ;` to 3rd `a`. `f a ; ; ,` to 2nd `a`(two next(`;`), one back(`,`))<br>Especially useful when you use `f` as operator's target such as `c f x`<br>[Conflicts]: When enabled `f ; ;` goes to 2nd `;`not 1st double-semicolon(`;;`), `f , ,` goes to 2nd single `,` instead of 1st double-comma(`,,`)",
+  },
   keymapIAndAToInsertAtTargetWhenHasOccurrence: {
-    title: "[EXPERIMENTAL] keymap `I` and `A` to `insert-at-start-of-target` and `insert-at-end-of-target` when editor has `preset-occurrence` marker.",
+    title:
+      "[EXPERIMENTAL] keymap `I` and `A` to `insert-at-start-of-target` and `insert-at-end-of-target` when editor has `preset-occurrence` marker.",
     default: false,
     description:
       "[Can]: `I p`, `A p` to insert at start or end of `preset-occurrence` in paragraph(`p`).<br>`I` and `A` is operator which take target, you can combine it with any target like `I f`(`a-function`), `A z`(`a-fold`).<br>[Caution]: `I` and `A` behaves as operator as long as editor has `preset-occurrence`, even if there is no VISIBLE `preset-occurrence` in screen. You might want to `escape` to clear preset-occurrences on editor to make `I` and `A` behave normaly gain.<br>[Conflicts]: You cannot use normal `I` and `A` when `preset-occurrence` marker is exists.",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -18,6 +18,7 @@ const RENAMED_PARAMS = [
   {oldName: "findByTwoCharsAutoConfirmTimeout", newName: "findConfirmByTimeout"},
   {oldName: "keepColumnOnSelectTextObject", newName: "stayOnSelectTextObject"},
   {oldName: "moveToFirstCharacterOnVerticalMotion", newName: "stayOnVerticalMotion", setValueBy: invertValue},
+  {oldName: "keymapSemicolonToConfirmFind", newName: "keymapSemicolonToConfirmOnFindInput"},
 ]
 
 class Settings {
@@ -152,12 +153,12 @@ class Settings {
           "/": "vim-mode-plus:inner-comment-or-paragraph",
         },
       },
-      keymapSemicolonToConfirmFind: {
+      keymapSemicolonToConfirmOnFindInput: {
         "atom-text-editor.vim-mode-plus-input.find": {
           ";": "core:confirm",
         },
       },
-      keymapSemicolonAndCommaToFindPreConfirmedInFindEditor: {
+      keymapSemicolonAndCommaToFindPreConfirmedOnFindInput: {
         "atom-text-editor.vim-mode-plus-input.find.has-text": {
           ";": "vim-mode-plus:find-next-pre-confirmed",
           ",": "vim-mode-plus:find-previous-pre-confirmed",
@@ -235,17 +236,17 @@ module.exports = new Settings("vim-mode-plus", {
     description:
       "[Can]: `g / /` to comment-in commented region, `g / /` to comment-out paragraph.<br>[Conflicts]: `g / /`( `toggle-line-comments` by `search` motion )",
   },
-  keymapSemicolonToConfirmFind: {
-    title: "keymap `;` to confirm `find` motion",
+  keymapSemicolonToConfirmOnFindInput: {
+    title: "keymap `;` to confirm on `f` input",
     default: false,
     description:
       "[Can]: You can confirm find( `f` ) input by `;`.<br>e.g. `f a ;` instead of `f a enter`.<br>[Conflicts]: You cannot search `;` by `f`, `F`, `t` and `T`.",
   },
-  keymapSemicolonAndCommaToFindPreConfirmedInFindEditor: {
-    title: "[EXPERIMENTAL] keymap `;` and `,` to `find-next-pre-confirmed` and `find-previous-pre-confirmed` in find's mini-editor",
+  keymapSemicolonAndCommaToFindPreConfirmedOnFindInput: {
+    title: "[EXPERIMENTAL] keymap `;` and `,` to `find-next-pre-confirmed` and `find-previous-pre-confirmed` on `f` input",
     default: false,
     description:
-      "[Can]: `f a ;` to move to 2nd `a`. `f a ; ;` to 3rd `a`. `f a ; ; ,` to 2nd `a`(two next(`;`), one back(`,`))<br>Especially useful when you use `f` as operator's target such as `c f x`<br>[Conflicts]: When enabled `f ; ;` goes to 2nd `;`not 1st double-semicolon(`;;`), `f , ,` goes to 2nd single `,` instead of 1st double-comma(`,,`)",
+      "[Can]: `f a ;` to move to 2nd `a`. `f a ; ;` to 3rd `a`. `f a ; ; ,` to 2nd `a`(two next(`;`), one previous(`,`))<br>Especially useful when you use `f` as operator's target such as `c f x`.<br>[Conflicts]: When enabled, `f ; ;` goes to 2nd `;`(not 1st double-semicolon(`;;`)), `f , ,` goes to 2nd single `,`(not 1st double-comma(`,,`))",
   },
   keymapIAndAToInsertAtTargetWhenHasOccurrence: {
     title:

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -593,7 +593,7 @@ module.exports = class VimState {
 
   focusInput(options) {
     if (!focusInput) focusInput = require("./focus-input")
-    return focusInput(this, options)
+    focusInput(this, options)
   }
 
   readChar({onCancel, onConfirm}) {

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -593,7 +593,7 @@ module.exports = class VimState {
 
   focusInput(options) {
     if (!focusInput) focusInput = require("./focus-input")
-    focusInput(this, options)
+    return focusInput(this, options)
   }
 
   readChar({onCancel, onConfirm}) {

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -350,6 +350,39 @@ describe "Motion Find", ->
         ensure "T a", textC: "0:    a    a\n1:    a    |a\n2:    a    a\n"
         ensure "T a", textC: "0:    a    a\n1:    a|    a\n2:    a    a\n"
 
+    describe "find-next/previous-pre-confirmed", ->
+      beforeEach ->
+        settings.set("findCharsMax", 10)
+        # To pass hlFind logic it require "visible" screen range.
+        jasmine.attachToDOM(atom.workspace.getElement())
+
+      describe "can find one or two char", ->
+        it "adjust to next-pre-confirmed", ->
+          set                 textC: "|    a    ab    a    cd    a"
+          keystroke "f a "
+          element = vimState.inputEditor.element
+          dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
+          dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
+          ensure "enter",     textC: "    a    ab    |a    cd    a"
+
+        it "adjust to previous-pre-confirmed", ->
+          set                   textC: "|    a    ab    a    cd    a"
+          ensure "3 f a enter", textC: "    a    ab    |a    cd    a"
+          set                   textC: "|    a    ab    a    cd    a"
+          keystroke "3 f a"
+          element = vimState.inputEditor.element
+          dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
+          dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
+          ensure "enter",     textC: "    |a    ab    a    cd    a"
+
+        it "is useful to skip earlier spot interactivelly", ->
+          set  textC: 'text = "this is |\"example\" of use case"'
+          keystroke 'c t "'
+          element = vimState.inputEditor.element
+          dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab
+          dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab
+          ensure "enter", textC: 'text = "this is |"', mode: "insert"
+
     describe "findCharsMax", ->
       beforeEach ->
         # To pass hlFind logic it require "visible" screen range.

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -267,12 +267,22 @@ describe "VimState", ->
       describe "automaticallyEscapeInsertModeOnActivePaneItemChange = true", ->
         beforeEach ->
           settings.set('automaticallyEscapeInsertModeOnActivePaneItemChange', true)
+          jasmine.useRealClock()
 
-        it "return to escape mode for all vimEditors", ->
-          pane.activateItem(otherEditor)
-          expect(pane.getActiveItem()).toBe(otherEditor)
-          ensure mode: 'normal'
-          otherVim.ensure mode: 'normal'
+        it "automatically shift to normal mode except new active editor", ->
+          called = false
+
+          runs ->
+            atom.workspace.onDidStopChangingActivePaneItem -> called = true
+            pane.activateItem(otherEditor)
+
+          waitsFor ->
+            called
+
+          runs ->
+            expect(pane.getActiveItem()).toBe(otherEditor)
+            ensure mode: 'normal'
+            otherVim.ensure mode: 'insert'
 
   describe "replace-mode", ->
     describe "with content", ->

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -319,7 +319,7 @@ atom-text-editor {
     }
     &.pre-confirm .region {
       border-color: @syntax-color-modified;
-      &.current { border-bottom-width: 4px; }
+      &.current { border-bottom-width: 5px; }
     }
     &.post-confirm .region {
       .flash(vim-mode-plus-flash-find-char, 2.0s);


### PR DESCRIPTION
Yet another experiment for better-find
Related #851

This PR add following feature.
- Add `vim-mode-plus:find-next`(This is find's hidden editor specific command).
- Allow user to chose next match **before confirm**.
- When combined with operator this **before confirm** adjustment is super useful.

### Use case in my mind

- When your cursor is at `|`
- You have `;` mapped to `vim-mode-plus:find-next`.
- Text: `text = "this is |\"example\" of use case"`
- You want to change rest of text by `c t "`.
- But because of escaped `\"` is also matched to `"`, you stopped at earlier `"` than one you aimed.
- In this case you can start `c t "`.
  - But you noticed it matched earlier `"`, so adjust by `; ;`.
  - Now you can change intended range.


Why this feature is specially necessary is it's not replaceable by `.` repeat.
(`c t "` then insert-some-text, `.`) is NOT equals to (`c 2 t "` then insert-some-text).


### Example keymap

```coffeescript
"atom-text-editor.vim-mode-plus-input.find":
  ";": "vim-mode-plus:find-next"
```
