### PR TITLE
Support numbered register [0-9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # 1.4.0: WIP
+- New: Numbered register(`0-9`) and small delete register(`-`). #871
+  - When are they updated?
+    - `0` is for yank, `1-9` is for `change` and `delete`.
+    - `-` is for small `change` and `delete`, what `small` means is "content is less-than-one-line".
+  - Currently no command to display register's content
+    - Package author can access register by `vimState.register.get(REGISTER_NAME)`.
+- Fix: `f`, `r` doesn't work correctly when user modified `.plain.text` grammar. #869
+  - This issue only happen when user set `.plain.text` grammar to have `softWrap = true` and `softWrapHangingIndent > 1`.
+- Internal: Cleanup RegisterManager code to reduce my confusion.
+- New: SequentialPaste for `p`, `P` and `replace-with-register`.
+  - Unnamed register(`"`) maintain history at maximum `sequentialPasteMaxHistory`.
+  - When user execute `p` sequentially, it pop content from older history.
+  - Intended to be used as lazy quick escape hatch from very recent unwanted register mutation.
+    - Not intended to enhance into pick from select-list. Use `clipboard-plus` in that case.
+  - New configuration to control this new feature.
+    - Config: `sequentialPaste`(default `false`) when enabled, pop history on sequential paste by `p`, `P`, and `replace-with-register`.
+    - Config: `sequentialPasteMaxHistory`(default `3`). maintain history specified this value.
 - Improve: `f` family related
   - Improve: Restore original scrollTop when `findAcrossLines` enabled and cancelled after scroll.
   - Rename config: `keymapSemicolonToConfirmFind` to `keymapSemicolonToConfirmOnFindInput`(auto-migrate)

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -448,7 +448,13 @@ class Yank extends Operator
   stayOptionName: 'stayOnYank'
 
   mutateSelection: (selection) ->
-    @setTextToRegisterForSelection(selection)
+    @setTextToRegister(selection.getText(), selection)
+
+  setTextToRegister: (text, selection) ->
+    text += "\n" if (@target.isLinewise() and (not text.endsWith('\n')))
+    if text
+      @vimState.register.set(null, {text, selection})
+      @vimState.register.set('0', {text, selection}) if @vimState.register.isUnnamed()
 
 class YankLine extends Yank
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -198,16 +198,16 @@ class Operator extends Base
       @vimState.register.set(null, {text, selection})
 
       if @vimState.register.isUnnamed()
-        if @instanceOf("Delete") or @instanceOf("Change")
-          if not @shouldSaveToNumberedRegister(@target) and isSingleLineText(text) # small-change
+        if @instanceof("Delete") or @instanceof("Change")
+          if not @needSaveToNumberedRegister(@target) and isSingleLineText(text) # small-change
             @vimState.register.set('-', {text, selection})
           else
             @vimState.register.set('1', {text, selection})
 
-        else if @instanceOf("Yank")
+        else if @instanceof("Yank")
           @vimState.register.set('0', {text, selection})
 
-  targetShouldSaveToNumberedRegister: (target) ->
+  needSaveToNumberedRegister: (target) ->
     # Used to determine what register to use on change and delete operation.
     # Following motion should save to 1-9 register regerdless of content is small or big.
     goesToNumberedRegisterMotionNames = [

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -8,6 +8,7 @@ _ = require 'underscore-plus'
   moveCursorToFirstCharacterAtRow
   ensureEndsWithNewLineForBufferRow
   adjustIndentWithKeepingLayout
+  isSingleLineText
 } = require './utils'
 Base = require './base'
 
@@ -193,7 +194,29 @@ class Operator extends Base
 
   setTextToRegister: (text, selection) ->
     text += "\n" if (@target.isLinewise() and (not text.endsWith('\n')))
-    @vimState.register.set(null, {text, selection}) if text
+    if text
+      @vimState.register.set(null, {text, selection})
+
+      if @vimState.register.isUnnamed()
+        if @instanceOf("Delete") or @instanceOf("Change")
+          if not @shouldSaveToNumberedRegister(@target) and isSingleLineText(text) # small-change
+            @vimState.register.set('-', {text, selection})
+          else
+            @vimState.register.set('1', {text, selection})
+
+        else if @instanceOf("Yank")
+          @vimState.register.set('0', {text, selection})
+
+  targetShouldSaveToNumberedRegister: (target) ->
+    # Used to determine what register to use on change and delete operation.
+    # Following motion should save to 1-9 register regerdless of content is small or big.
+    goesToNumberedRegisterMotionNames = [
+      "MoveToPair" # %
+      "MoveToNextSentence" # (, )
+      "Search" # /, ?, n, N
+      "MoveToNextParagraph" # {, }
+    ]
+    goesToNumberedRegisterMotionNames.some((name) -> target.instanceof(name))
 
   normalizeSelectionsIfNecessary: ->
     if @target?.isMotion() and (@mode is 'visual')
@@ -412,7 +435,7 @@ class Delete extends Operator
       @restorePositions = false
     super
 
-  mutateSelection: (selection) =>
+  mutateSelection: (selection) ->
     @setTextToRegisterForSelection(selection)
     selection.deleteSelectedText()
 
@@ -448,13 +471,7 @@ class Yank extends Operator
   stayOptionName: 'stayOnYank'
 
   mutateSelection: (selection) ->
-    @setTextToRegister(selection.getText(), selection)
-
-  setTextToRegister: (text, selection) ->
-    text += "\n" if (@target.isLinewise() and (not text.endsWith('\n')))
-    if text
-      @vimState.register.set(null, {text, selection})
-      @vimState.register.set('0', {text, selection}) if @vimState.register.isUnnamed()
+    @setTextToRegisterForSelection(selection)
 
 class YankLine extends Yank
   @extend()

--- a/lib/register-manager.js
+++ b/lib/register-manager.js
@@ -1,6 +1,6 @@
 const {normalizeIndent} = require("./utils")
 
-const REGISTERS_REGEX = /[0-9a-zA-Z*+%_".]/
+const REGISTERS_REGEX = /[-0-9a-zA-Z*+%_".]/
 const READ_ONLY_REGISTERS_REGEX = /[%_]/
 
 // TODO: Vim support following registers.
@@ -178,7 +178,19 @@ module.exports = class RegisterManager {
       const oldValue = this.data[name]
       this.data[name] = oldValue ? this.appendValue(oldValue, value) : value
     } else {
-      this.data[name] = value
+      if (name === "1") {
+        this.data["9"] = this.data["8"]
+        this.data["8"] = this.data["7"]
+        this.data["7"] = this.data["6"]
+        this.data["6"] = this.data["5"]
+        this.data["5"] = this.data["4"]
+        this.data["4"] = this.data["3"]
+        this.data["3"] = this.data["2"]
+        this.data["2"] = this.data["1"]
+        this.data["1"] = value
+      } else {
+        this.data[name] = value
+      }
     }
   }
 

--- a/lib/register-manager.js
+++ b/lib/register-manager.js
@@ -1,6 +1,6 @@
 const {normalizeIndent} = require("./utils")
 
-const REGISTERS_REGEX = /[a-zA-Z*+%_".]/
+const REGISTERS_REGEX = /[0-9a-zA-Z*+%_".]/
 const READ_ONLY_REGISTERS_REGEX = /[%_]/
 
 // TODO: Vim support following registers.

--- a/lib/register-manager.js
+++ b/lib/register-manager.js
@@ -199,6 +199,10 @@ module.exports = class RegisterManager {
     return finalValue
   }
 
+  isUnnamed() {
+    return this.name == null || this.name === '"'
+  }
+
   setName(name) {
     if (name != null) {
       this.name = name

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -314,7 +314,7 @@ module.exports = new Settings("vim-mode-plus", {
     default: 1,
     minimum: 1,
     description:
-      'Auto confirm when find( `f` )\'s input reaches this lenth.<br>Increasing this number greatly reduces the possible matches, but you now need confirm( `enter` ) for shorter input.<br><br>[Hint]: Set big number(such as `100`) with also enabling `findConfirmByTimeout`, then you **always** land(confirm) by timeout. Thus you now can expect **FIXED-TIMING-GAP** against your input(in "f > input > timeout > land" flow).<br><br>See also "`keymap `;` to confirm `find` motion`" configuration to make manual confirmation easy.',
+      'Auto confirm when find( `f` )\'s input reaches this lenth.<br>Increasing this number greatly reduces the possible matches, but you now need confirm( `enter` ) for shorter input.<br><br>[Hint]: Set big number(such as `100`) with also enabling `findConfirmByTimeout`, then you **always** land(confirm) by timeout. Thus you now can expect **FIXED-TIMING-GAP** against your input(in "f > input > timeout > land" flow).<br><br>See also "keymap `;` to confirm `find` motion" configuration to make manual confirmation easy.',
   },
   findConfirmByTimeout: {
     default: 0,

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -172,6 +172,149 @@ describe "Prefixes", ->
           set    register: '%': text: 'new content'
           ensure register: '%': text: '/Users/atom/known_value.txt'
 
+    describe "the numbered 0-9 register", ->
+      describe "0", ->
+        it "keep most recent yank-ed text", ->
+          ensure register: '"': {text: 'initial clipboard content'}, '0': {text: undefined}
+          set textC: "|000"
+          ensure "y w", register: '"': {text: "000"}, '0': {text: "000"}
+          ensure "y l", register: '"': {text: "0"}, '0': {text: "0"}
+
+      describe "1-9 and small-delete(-) register", ->
+        beforeEach ->
+          set textC: "|0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+
+        it "keep deleted text", ->
+          ensure "d d",
+            textC:  "|1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '0\n'},     '-': {text: undefined},
+              '1': {text: '0\n'},     '2': {text: undefined}, '3': {text: undefined},
+              '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '1\n'},     '-': {text: undefined},
+              '1': {text: '1\n'},     '2': {text: '0\n'}, '3': {text: undefined},
+              '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|3\n4\n5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '2\n'}, '-': {text: undefined},
+              '1': {text: '2\n'}, '2': {text: '1\n'}, '3': {text: '0\n'},
+              '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|4\n5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '3\n'}, '-': {text: undefined},
+              '1': {text: '3\n'}, '2': {text: '2\n'}, '3': {text: '1\n'},
+              '4': {text: '0\n'}, '5': {text: undefined}, '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '4\n'}, '-': {text: undefined},
+              '1': {text: '4\n'},     '2': {text: '3\n'},     '3': {text: '2\n'},
+              '4': {text: '1\n'},     '5': {text: '0\n'},     '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '5\n'}, '-': {text: undefined},
+              '1': {text: '5\n'},     '2': {text: '4\n'},     '3': {text: '3\n'},
+              '4': {text: '2\n'},     '5': {text: '1\n'},     '6': {text: '0\n'},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|7\n8\n9\n10\n"
+            register:
+              '"': {text: '6\n'}, '-': {text: undefined},
+              '1': {text: '6\n'}, '2': {text: '5\n'},     '3': {text: '4\n'},
+              '4': {text: '3\n'}, '5': {text: '2\n'},     '6': {text: '1\n'},
+              '7': {text: '0\n'}, '8': {text: undefined}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|8\n9\n10\n"
+            register:
+              '"': {text: '7\n'}, '-': {text: undefined},
+              '1': {text: '7\n'}, '2': {text: '6\n'}, '3': {text: '5\n'},
+              '4': {text: '4\n'}, '5': {text: '3\n'}, '6': {text: '2\n'},
+              '7': {text: '1\n'}, '8': {text: '0\n'}, '9': {text: undefined},
+          ensure ".",
+            textC:  "|9\n10\n"
+            register:
+              '"': {text: '8\n'}, '-': {text: undefined},
+              '1': {text: '8\n'}, '2': {text: '7\n'}, '3': {text: '6\n'},
+              '4': {text: '5\n'}, '5': {text: '4\n'}, '6': {text: '3\n'},
+              '7': {text: '2\n'}, '8': {text: '1\n'}, '9': {text: '0\n'},
+          ensure ".",
+            textC:  "|10\n"
+            register:
+              '"': {text: '9\n'}, '-': {text: undefined},
+              '1': {text: '9\n'}, '2': {text: '8\n'}, '3': {text: '7\n'},
+              '4': {text: '6\n'}, '5': {text: '5\n'}, '6': {text: '4\n'},
+              '7': {text: '3\n'}, '8': {text: '2\n'}, '9': {text: '1\n'}
+        it "also keeps changed text", ->
+          ensure "c j",
+            textC:  "|\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+            register:
+              '"': {text: '0\n1\n'}, '-': {text: undefined},
+              '1': {text: '0\n1\n'}, '2': {text: undefined}, '3': {text: undefined},
+              '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+              '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+
+        describe "which goes to numbered and which goes to small-delete register", ->
+          beforeEach ->
+            set textC: "|{abc}\n"
+
+          it "small-change goes to - register", ->
+            ensure "c $",
+              textC: "|\n"
+              register:
+                '"': {text: '{abc}'}, '-': {text: '{abc}'},
+                '1': {text: undefined}, '2': {text: undefined}, '3': {text: undefined},
+                '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+                '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          it "small-delete goes to - register", ->
+            ensure "d $",
+              textC: "|\n"
+              register:
+                '"': {text: '{abc}'}, '-': {text: '{abc}'},
+                '1': {text: undefined}, '2': {text: undefined}, '3': {text: undefined},
+                '4': {text: undefined}, '5': {text: undefined}, '6': {text: undefined},
+                '7': {text: undefined}, '8': {text: undefined}, '9': {text: undefined},
+          it "[exception] % motion always save to numbered", ->
+            set textC: "|{abc}\n"
+            ensure "d %", textC: "|\n", register: {'"': {text: '{abc}'}, '-': {text: undefined}, '1': {text: '{abc}'}, '2': {text: undefined}}
+          it "[exception] / motion always save to numbered", ->
+            jasmine.attachToDOM(atom.workspace.getElement())
+            set textC: "|{abc}\n"
+            ensure "d / } enter",
+              textC: "|}\n",
+              register: {'"': {text: '{abc'}, '-': {text: undefined}, '1': {text: '{abc'}, '2': {text: undefined}}
+
+          it "/, n motion always save to numbered", ->
+            jasmine.attachToDOM(atom.workspace.getElement())
+            set textC: "|abc axx abc\n"
+            ensure "d / a enter",
+              textC: "|axx abc\n",
+              register: {'"': {text: 'abc '}, '-': {text: undefined}, '1': {text: 'abc '}, '2': {text: undefined}}
+            ensure "d n",
+              textC: "|abc\n",
+              register: {'"': {text: 'axx '}, '-': {text: undefined}, '1': {text: 'axx '}, '2': {text: 'abc '}}
+          it "?, N motion always save to numbered", ->
+            jasmine.attachToDOM(atom.workspace.getElement())
+            set textC: "abc axx |abc\n"
+            ensure "d ? a enter",
+              textC: "abc |abc\n",
+              register: {'"': {text: 'axx '}, '-': {text: undefined}, '1': {text: 'axx '}, '2': {text: undefined}}
+            ensure "0",
+              textC: "|abc abc\n",
+            ensure "c N",
+              textC: "|abc\n",
+              register: {'"': {text: 'abc '}, '-': {text: undefined}, '1': {text: 'abc '}, '2': {text: "axx "}}
+
     describe "the ctrl-r command in insert mode", ->
       beforeEach ->
         set register: '"': text: '345'


### PR DESCRIPTION
Related #293

# `0-9`: numbred register

For:
- `0`: Most recent unnamed(`"`)-yank, every yank goes to this register.
- `1-9`: Most recent unnamed-and-not-small-delete-or-change(not-small = not-one-line)
	- If target motion is one of ``` %()`/?nN{} ```, use this register regardless of content(for vi-compat).
	- For other targets and content is not small, this register is used.
	- On each save, register content shifts from newest(`1`) to oldest(`9`).

Spec:

```
2. Numbered registers "0 to "9

Vim fills these registers with text from yank and delete commands.
   Numbered register 0 contains the text from the most recent yank command,
unless the command specified another register with ["x].
   Numbered register 1 contains the text deleted by the most recent delete or
change command, unless the command specified another register or the text is
less than one line (the small delete register is used then).  An exception is
made for the delete operator with these movement commands: |%|, |(|, |)|, |`|,
|/|, |?|, |n|, |N|, |{| and |}|.  Register "1 is always used then (this is Vi
compatible).  The "- register is used as well if the delete is within a line.
Note that these characters may be mapped.  E.g. |%| is mapped by the matchit
plugin.
   With each successive deletion or change, Vim shifts the previous contents
of register 1 into register 2, 2 into 3, and so forth, losing the previous
contents of register 9.
{Vi: numbered register contents are lost when changing files; register 0 does
not exist}
```


# `-`: small deletion register

For: Most recent small delete-or-change(less-than-one-line), its used based on contents.

Spec

```
3. Small delete register "-				*quote_-* *quote-*
This register contains text from commands that delete less than one line,
except when the command specifies a register with ["x].
{not in Vi}
```

# Scenario based: what should be happens in operation

### `0`

- `" a y y`: doesn't save to `0` register, since `a` register specified.
- `" " y y`: save to `0`, since it's unnamed
- `y y`: save to `0`, since it's unnamed.

### `1-9`

- `" a d d`: doesn't save to `1` register, since `a` register specified.
- `" " d d`: save to `1`, since it's unnamed
- `d d`: save to `1`, since it's unnamed.
- `" a c c`: doesn't save to `1` register, since `a` register specified.
- `" " c c`: save to `1`, since it's unnamed
- `c c`: save to `1`, since it's unnamed.

- `c l`: does not save to `1`, since it's small. it goes to `-` register.
- `d l`: does not save to `1`, since it's small. it goes to `-` register.

- `c %`: goes always to `1`, it's for vi-compatibility. and goes to `-` if small
- `d %`: goes always to `1`, it's for vi-compatibility. and goes to `-` if small
- `c n`: goes always to `1`, it's for vi-compatibility. and goes to `-` if small
- `d n`: goes always to `1`, it's for vi-compatibility. and goes to `-` if small
