### PR TITLE
reconcile visual-mode with outer-vmp command in better way(my hope!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 1.5.0:
+- Improve, Fix: Reconcile visual-mode with outer-vmp command in better way(my hope!) #878
+  - Fix #874: `cmd-d`(`find-and-replace:select-next`) in normal mode respect `SelectNext#wordSelected` state for `find-and-replace`.
+    - Behavior diff with text = `atom atomic atom`
+      - Old: `cmd-d cmd-d` select 1st and 2nd `atom`. Here, `atom` of `atomic` is selected, bad!.
+      - New: `cmd-d cmd-d` select 1st and 3rd `atom`.
+  - Fix: #873 Now whenever outer-vmp command modify selection, vmp starts `visual-mode` accordingly.
+    - How vmp handle temporal selection modification done in single-command?
+    - When outer-vmp command select some range(1) and clear(2) within single-command.
+    - Vmp start `visual-mode` at (1), then reset to `normal-mode` at (2).
+    - This is NOT elegant solution, but there is no other better way.
+    - We cannot determine selection is eventually cleared or not within `editor.onDidChangeSelectionRange` event.
+    - Delaying, debouncing to minimize useless mode-shift is bad for UX, user see slight delay for cursor updated.
+
 # 1.4.0:
 - New: Numbered register(`0-9`) and small delete register(`-`). #871
   - When are they updated?

--- a/lib/mode-manager.js
+++ b/lib/mode-manager.js
@@ -45,6 +45,7 @@ module.exports = class ModeManager {
   activate(newMode, newSubmode = null) {
     // Avoid odd state(=visual-mode but selection is empty)
     if (newMode === "visual" && this.editor.isEmpty()) return
+    this.vimState.ignoreSelectionChange = true
 
     this.emitter.emit("will-activate-mode", {mode: newMode, submode: newSubmode})
 
@@ -83,6 +84,7 @@ module.exports = class ModeManager {
     }
 
     this.emitter.emit("did-activate-mode", {mode: this.mode, submode: this.submode})
+    this.vimState.ignoreSelectionChange = false
   }
 
   deactivate() {

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -45,7 +45,7 @@ module.exports = class OperationStack {
   reset() {
     this.resetCount()
     this.stack = []
-    this.processing = false
+    this.running = false
 
     // this has to be BEFORE this.operationSubscriptions.dispose()
     this.vimState.emitDidResetOperationStack()
@@ -80,6 +80,8 @@ module.exports = class OperationStack {
   // Main
   // -------------------------
   run(klass, properties) {
+    this.running = true
+
     if (this.mode === "visual") {
       for (const $selection of this.swrap.getSelections(this.editor)) {
         if (!$selection.hasProperties()) $selection.saveProperties()
@@ -166,12 +168,11 @@ module.exports = class OperationStack {
     if (!(error instanceof OperationAbortedError)) throw error
   }
 
-  isProcessing() {
-    return this.processing
+  isRunning() {
+    return this.running
   }
 
   process() {
-    this.processing = true
     if (this.stack.length === 2) {
       // [FIXME ideally]
       // If target is not complete, we postpone composing target with operator to keep situation simple.

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -369,6 +369,15 @@ module.exports = class VimState {
     return this.editor.getSelections().some(selection => !selection.isEmpty())
   }
 
+  // This function is mainly called in editor.onDidChangeSelectionRange enent
+  // Purpose of this function is to auto-start/stop visual-mode when outer-vmp modify selection.
+  // See. vim-mode-plus#878, #873 for detail
+  //
+  // - When outer-vmp command select some range(1) and clear(2) within single-command.
+  // - Vmp start `visual-mode` at (1), then reset to `normal-mode` at (2).
+  // - This is NOT elegant solution, but there is no other better way.
+  // - We cannot determine selection is eventually cleared or not within `editor.onDidChangeSelectionRange` event.
+  // - Delaying, debouncing to minimize useless mode-shift is bad for UX, user see slight delay for cursor updated.
   reconcileVisualModeWithActualSelection(shiftToNormalIfNoSelection = true) {
     // This guard is somewhat verbose and duplicate, but I prefer duplication than increase chance of infinite loop.
     if (this.shouldIgnoreChangeSelection()) return
@@ -380,18 +389,12 @@ module.exports = class VimState {
       this.cursorStyleManager.refresh()
     }
 
-    if (this.haveSomeNonEmptySelection()) {
-      if (this.mode === "visual") updatePropertyAndCursorCurrentVisibility()
-      else this.activate("visual", this.swrap.detectWise(this.editor))
-    } else if (this.mode === "visual") {
-      // Why this is necessary? Take following `copy-word` as example.
-      //   1. `copy-word` executed
-      //   2. select word and copy text to clipboard
-      //   3. selection cleared, now `copy-word` finished.
-      // At step-2, vmp auto-shift-to-visual-mode(there is no way to distinguish temporal selection modification).
-      // At step-3, vmp need to reset to normal mode since now selection is empty.
-      // We cannot skip auto-shift-to-visual-mode on step-2 and nor delaying it by debouncing.
-      // We cannot say which is last step from event.
+    const hasSelection = this.haveSomeNonEmptySelection()
+    const isVisual = this.mode === "visual"
+
+    if (hasSelection && isVisual) updatePropertyAndCursorCurrentVisibility()
+    else if (hasSelection && !isVisual) this.activate("visual", this.swrap.detectWise(this.editor))
+    else if (!hasSelection && isVisual) {
       if (shiftToNormalIfNoSelection) this.activate("normal")
       else updatePropertyAndCursorCurrentVisibility()
     }

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -147,8 +147,13 @@ module.exports = class VimState {
     this.modeManager = new ModeManager(this)
     this.previousSelection = {}
     this.scrollAnimationEffect = null
+    this.ignoreSelectionChange = false
 
-    this.subscriptions.add(this.observeMouse(), this.observeCommandDispatch())
+    this.subscriptions.add(
+      this.observeMouse(),
+      this.editor.onDidAddSelection(selection => this.reconcileVisualModeWithActualSelection()),
+      this.editor.onDidChangeSelectionRange(event => this.reconcileVisualModeWithActualSelection())
+    )
 
     this.editorElement.classList.add("vim-mode-plus")
 
@@ -364,120 +369,82 @@ module.exports = class VimState {
     return this.editor.getSelections().some(selection => !selection.isEmpty())
   }
 
-  observeCommandDispatch() {
-    const isInterestingEvent = ({target, type}) => {
-      // Intentionally using target.closest('atom-text-editor')
-      // Don't use target.getModel() which is work for CustomEvent(=command) but not work for mouse event.
-      if (!(target && target.closest && target.closest("atom-text-editor") === this.editorElement)) {
-        return false
-      }
+  reconcileVisualModeWithActualSelection(shiftToNormalIfNoSelection = true) {
+    // This guard is somewhat verbose and duplicate, but I prefer duplication than increase chance of infinite loop.
+    if (this.shouldIgnoreChangeSelection()) return
 
-      // [Cauttion]: both `vim-mode-plus` and `vim-mode-plus-user` should be ignored.
-      return type.includes(":") && !type.startsWith("vim-mode-plus") && type !== "command-palette:toggle"
+    this.ignoreSelectionChange = true
+
+    const updatePropertyAndCursorCurrentVisibility = () => {
+      this.swrap.getSelections(this.editor).forEach($s => $s.saveProperties())
+      this.cursorStyleManager.refresh()
     }
 
-    return atom.commands.onDidDispatch(event => {
-      if (atom.workspace.getActiveTextEditor() !== this.editor) return
-      if (this.__operationStack && this.operationStack.isProcessing()) return
-      if (this.mode === "insert") return
+    if (this.haveSomeNonEmptySelection()) {
+      if (this.mode === "visual") updatePropertyAndCursorCurrentVisibility()
+      else this.activate("visual", this.swrap.detectWise(this.editor))
+    } else if (this.mode === "visual") {
+      // Why this is necessary? Take following `copy-word` as example.
+      //   1. `copy-word` executed
+      //   2. select word and copy text to clipboard
+      //   3. selection cleared, now `copy-word` finished.
+      // At step-2, vmp auto-shift-to-visual-mode(there is no way to distinguish temporal selection modification).
+      // At step-3, vmp need to reset to normal mode since now selection is empty.
+      // We cannot skip auto-shift-to-visual-mode on step-2 and nor delaying it by debouncing.
+      // We cannot say which is last step from event.
+      if (shiftToNormalIfNoSelection) this.activate("normal")
+      else updatePropertyAndCursorCurrentVisibility()
+    }
 
-      if (!isInterestingEvent(event)) return
+    this.ignoreSelectionChange = false
+  }
 
-      if (this.haveSomeNonEmptySelection()) {
-        this.editorElement.component.updateSync()
-        const wise = this.swrap.detectWise(this.editor)
-        if (this.isMode("visual", wise)) {
-          this.swrap.getSelections(this.editor).forEach($s => $s.saveProperties())
-          this.cursorStyleManager.refresh()
-        } else {
-          this.activate("visual", wise)
-        }
-      } else if (this.mode === "visual") {
-        if (this.submode === "blockwise") {
-          this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
-        }
-        this.activate("normal")
-      }
-    })
+  shouldIgnoreChangeSelection() {
+    return (
+      this.ignoreSelectionChange || this.mode === "insert" || (this.__operationStack && this.operationStack.isRunning())
+    )
   }
 
   observeMouse() {
-    let selectionChangeObserver,
-      activateNormalOnMouseUp,
-      nextMouseEvent = "mousedown-capture",
-      ignoreSelectionChange = false
-
-    const {editor} = this
-
-    const updateVisualModeWithCurrentSelection = () => {
-      if (this.mode === "visual") {
-        this.swrap.getSelections(editor).forEach($s => $s.saveProperties())
-        this.cursorStyleManager.refresh()
-      } else if (this.haveSomeNonEmptySelection()) {
-        ignoreSelectionChange = true
-        this.activate("visual", this.swrap.detectWise(editor))
-        ignoreSelectionChange = false
-      }
-    }
-
-    const shouldIgnoreMouse = () => {
-      return (
-        ignoreSelectionChange || this.mode === "insert" || (this.__operationStack && this.operationStack.isProcessing())
-      )
-    }
+    let nextMouseEvent = "mousedown-capture"
 
     // To keep original cursor screen range(tail range of selection) keep selected on `shift+click`
     // At this phase, cursor position is NOT yet updated, so we interact with original before-clicked cursor position.
     const handleMouseDownCapture = () => {
-      if (shouldIgnoreMouse()) return
+      if (this.shouldIgnoreChangeSelection()) return
+      if (nextMouseEvent === "mousedown-capture") {
+        nextMouseEvent = "mousedown-bubble"
 
-      if (nextMouseEvent !== "mousedown-capture") return
-      nextMouseEvent = "mousedown-bubble"
-
-      for (const selection of editor.getSelections()) {
-        selection.initialScreenRange = this.swrap(selection).getTailScreenRange()
+        for (const selection of this.editor.getSelections()) {
+          selection.initialScreenRange = this.swrap(selection).getTailScreenRange()
+        }
       }
     }
 
     const handleMouseDownBubble = () => {
-      if (shouldIgnoreMouse()) return
-
-      if (nextMouseEvent !== "mousedown-bubble") return
-      nextMouseEvent = "mouseup"
-
-      activateNormalOnMouseUp = false
-
-      if (this.mode === "visual" && !this.haveSomeNonEmptySelection()) {
-        if (this.submode === "blockwise") {
-          this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
+      if (this.shouldIgnoreChangeSelection()) return
+      if (nextMouseEvent === "mousedown-bubble") {
+        nextMouseEvent = "mouseup"
+        if (this.mode === "visual" && !this.haveSomeNonEmptySelection()) {
+          if (this.submode === "blockwise") {
+            this.getBlockwiseSelections().forEach(bs => bs.skipNormalization())
+          }
         }
-        // We can't switch to normal mode here since selection might be modified by mousemove(drag).
-        activateNormalOnMouseUp = true
+        for (const selection of this.editor.getSelections().filter(s => s.isEmpty())) {
+          selection.initialScreenRange = this.swrap(selection).getTailScreenRange()
+        }
+        // For shilft+click which not involve mousemove event.
+        this.reconcileVisualModeWithActualSelection(false) // Prevent auto-shift-to-normal-mode by passing `false`
       }
-
-      for (const selection of editor.getSelections().filter(s => s.isEmpty())) {
-        selection.initialScreenRange = this.swrap(selection).getTailScreenRange()
-      }
-
-      // For shilft+click which not involve mousemove event.
-      updateVisualModeWithCurrentSelection()
-
-      selectionChangeObserver = editor.onDidChangeSelectionRange(() => {
-        if (ignoreSelectionChange) return
-        activateNormalOnMouseUp = false
-        updateVisualModeWithCurrentSelection()
-      })
     }
 
     const handleMouseUp = () => {
-      if (shouldIgnoreMouse()) return
-
+      if (this.shouldIgnoreChangeSelection()) return
       // Why explicitly assure mouse-event lifecycle? see #830 for detail.
-      if (nextMouseEvent !== "mouseup") return
-      nextMouseEvent = "mousedown-capture"
-
-      if (selectionChangeObserver) selectionChangeObserver.dispose()
-      if (activateNormalOnMouseUp) this.activate("normal")
+      if (nextMouseEvent === "mouseup") {
+        nextMouseEvent = "mousedown-capture"
+        this.reconcileVisualModeWithActualSelection()
+      }
     }
 
     this.editorElement.addEventListener("mousedown", handleMouseDownCapture, true)


### PR DESCRIPTION
Fix #874  and issues which is not reported but definitely exists.
Related #873

Now when outer-vmp command modify selection, vmp catch this selection change and start `visual-mode` accordingly.

But this approach is the one I've tried to avoid because `editor.onDidchange` is too frequently fired event, and if I'm not careful it can cause infinite loop.

Anyway I cannot find better approach than this for now, so will go this approach!.
