### PR TITLE
linewise-bounded-operator works linwise in occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+# 1.6.0: Occurrence respects operator-bound-wise.
+- Improve: `Linewise-bound-operator` now works `linewise` in `occurrence-operation`(formerly works as `characterwise`).
+  - What's `occurrence-operation`?
+    - Operation with `o` modifier(e.g. `c o f`) or operation with preset-occurrence(e.g. `g o c f`).
+  - What's `linewise-bound-operator`?
+    - In `visual-mode`, `D`, `C`, `Y` works as linewise regardless of`visual-mode`'s wise.
+  - Example
+    - Delete `console` word including **lines**
+      1. Place cursor at `console`.
+      2. `g o v i p D`
+        - `g o`: mark `console` as preset-occurrence by
+        - `v i p`: start `visual-mode` then select paragraph by `i p`.
+        - `D`: `delete-line` delete all `console` word including lines(you can still use `d` if you want to delete occurrence only.)
+    - Toggle-line-comment for `console` word including **lines**
+      1. Place cursor at `console`.
+      2. `g / o p`
+        - `g /`: start `vim-mode-plus:toggle-line-comments` operator.
+        - `o`: set `o`(occurrence) modifier.
+        - `p`: specify `inner-paragraph`(here `p` is short hand of `i p`). Now all `console` including lines are commented out.
+    - Upper case for `console` including **lines**.
+      1. Place cursor at `console`.
+      2. `g U o V p` or `g U V o p`
+        - `g U`: start `vim-mode-plus:upper-case` operator.
+        - `o`: set `o`(occurrence) modifier.
+        - `V`: set `V` modifier, which force wise to `linewise`.
+        - `p`: specify `inner-paragraph`. Now all `console` including **lines** are upper-cased.
+  - Theoretical background:
+    - Most operator have no wise in operator, in this case operation's wise is determined by target(motion or text-object).
+    - Some exceptional operator have wise in operator level, in this case, operation's wise is forced to this pre-bound wise.
+    - `linewise-bound-operator` is operator which wise is bound to `linewise`.
+    - When `V` operator-modifier is used in operation, it's one-time linewise-bound-operation which forces operation's wise to `linewise`.
+  - Behavioral diff
+    - Old: all `occurrence-operation` works as `characterwise`.
+    - New: `linewise-bound-operator` works `linewise`.
+  - Takeout
+    - Some operators(e.g. `C`, `Y`, `D`, `g /`, `>`, `<` etc) have pre-bound to `linewise`.
+    - `linewise-pre-bound-operator` works for lines(= `linewise`) in `occurrence-operation`.
+    - You can force wise to `linewise` by `V` operator-modifier in `occurrence-operation`, for normal operator.
+    - Also remember you can distinguish [`c` and `C`], [`y` and `Y`], [`d` and `D`] in `visual-linewise` mode.
+      - Use capital letter version(`C`, `Y`, `D`) if you want `linewise` behavior.
+
 # 1.5.0: Reconcile visual-mode with outer-vmp command in better way. #878
 - Summary: This is ambitious and dangerous change.
   - If success, lots of potential issue would be fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.0: Occurrence respects operator-bound-wise.
+# 1.6.0: Occurrence respects operator-bound-wise. [WIP]
 - Improve: `Linewise-bound-operator` now works `linewise` in `occurrence-operation`(formerly works as `characterwise`).
   - What's `occurrence-operation`?
     - Operation with `o` modifier(e.g. `c o f`) or operation with preset-occurrence(e.g. `g o c f`).

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -131,8 +131,8 @@
   's': 'vim-mode-plus:substitute'
   'x': 'vim-mode-plus:delete-right' # to avoid `d x` is treated as `d d`
 
-  'D': 'vim-mode-plus:delete-line'
-  'C': 'vim-mode-plus:change-line'
+  'D': 'vim-mode-plus:delete-to-last-character-of-line'
+  'C': 'vim-mode-plus:change-to-last-character-of-line'
   'S': 'vim-mode-plus:substitute-line'
   'Y': 'vim-mode-plus:yank-line'
 
@@ -447,8 +447,6 @@
   'I': 'vim-mode-plus:insert-at-first-character-of-line'
   'A': 'vim-mode-plus:insert-after-end-of-line'
   'g i': 'vim-mode-plus:insert-at-last-insert'
-  'D': 'vim-mode-plus:delete-to-last-character-of-line'
-  'C': 'vim-mode-plus:change-to-last-character-of-line'
 
   'R': 'vim-mode-plus:activate-replace-mode'
   'v': 'vim-mode-plus:activate-characterwise-visual-mode'
@@ -652,14 +650,14 @@
 
 # visual-blockwise
 # -------------------------
+'atom-text-editor.vim-mode-plus.visual-mode.characterwise':
+  'D': 'vim-mode-plus:delete-line'
+  'C': 'vim-mode-plus:change-line'
+  'Y': 'vim-mode-plus:yank-line'
+
 'atom-text-editor.vim-mode-plus.visual-mode.blockwise':
   'o': 'vim-mode-plus:blockwise-other-end'
   'O': 'vim-mode-plus:reverse-selections'
-  'D': 'vim-mode-plus:delete-to-last-character-of-line'
-  'C': 'vim-mode-plus:change-to-last-character-of-line'
-
-  # FIXME: I want make following works for consistency
-  # 'Y': 'vim-mode-plus:yank-to-last-character-of-line'
 
 # Input mini editor e.g. mark, surround, find, till.
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -641,6 +641,9 @@
   'V': 'vim-mode-plus:activate-linewise-visual-mode'
   'ctrl-v': 'vim-mode-plus:activate-blockwise-visual-mode'
   'enter': 'vim-mode-plus:create-persistent-selection'
+  'D': 'vim-mode-plus:delete-line'
+  'C': 'vim-mode-plus:change-line'
+  'Y': 'vim-mode-plus:yank-line'
 
 'atom-text-editor.vim-mode-plus.has-persistent-selection.normal-mode, atom-text-editor.vim-mode-plus.visual-mode':
   'I': 'vim-mode-plus:insert-at-start-of-target'
@@ -648,18 +651,13 @@
   # 'p': 'vim-mode-plus:swap-with-register'
   # 'P': 'vim-mode-plus:swap-with-register'
 
-# visual-characterwise
-# -------------------------
-'atom-text-editor.vim-mode-plus.visual-mode.characterwise':
-  'D': 'vim-mode-plus:delete-line'
-  'C': 'vim-mode-plus:change-line'
-  'Y': 'vim-mode-plus:yank-line'
-
 # visual-blockwise
 # -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode.blockwise':
   'o': 'vim-mode-plus:blockwise-other-end'
   'O': 'vim-mode-plus:reverse-selections'
+  'D': 'vim-mode-plus:delete-to-last-character-of-line'
+  'C': 'vim-mode-plus:change-to-last-character-of-line'
 
 # Input mini editor e.g. mark, surround, find, till.
 # -------------------------

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -648,13 +648,15 @@
   # 'p': 'vim-mode-plus:swap-with-register'
   # 'P': 'vim-mode-plus:swap-with-register'
 
-# visual-blockwise
+# visual-characterwise
 # -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode.characterwise':
   'D': 'vim-mode-plus:delete-line'
   'C': 'vim-mode-plus:change-line'
   'Y': 'vim-mode-plus:yank-line'
 
+# visual-blockwise
+# -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode.blockwise':
   'o': 'vim-mode-plus:blockwise-other-end'
   'O': 'vim-mode-plus:reverse-selections'

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -130,10 +130,12 @@
   'c': 'vim-mode-plus:change'
   's': 'vim-mode-plus:substitute'
   'x': 'vim-mode-plus:delete-right' # to avoid `d x` is treated as `d d`
-  'D': 'vim-mode-plus:delete-line'
 
-  'C': 'vim-mode-plus:change-to-last-character-of-line'
+  'D': 'vim-mode-plus:delete-line'
+  'C': 'vim-mode-plus:change-line'
   'S': 'vim-mode-plus:substitute-line'
+  'Y': 'vim-mode-plus:yank-line'
+
   'r': 'vim-mode-plus:replace'
   'g o': 'vim-mode-plus:toggle-preset-occurrence'
   'g O': 'vim-mode-plus:toggle-preset-subword-occurrence'
@@ -147,7 +149,6 @@
   'J': 'vim-mode-plus:join'
   'g J': 'vim-mode-plus:join-with-keeping-space'
   'y': 'vim-mode-plus:yank'
-  'Y': 'vim-mode-plus:yank-line'
   'P': 'vim-mode-plus:put-before'
   'p': 'vim-mode-plus:put-after'
 
@@ -447,6 +448,7 @@
   'A': 'vim-mode-plus:insert-after-end-of-line'
   'g i': 'vim-mode-plus:insert-at-last-insert'
   'D': 'vim-mode-plus:delete-to-last-character-of-line'
+  'C': 'vim-mode-plus:change-to-last-character-of-line'
 
   'R': 'vim-mode-plus:activate-replace-mode'
   'v': 'vim-mode-plus:activate-characterwise-visual-mode'
@@ -648,17 +650,16 @@
   # 'p': 'vim-mode-plus:swap-with-register'
   # 'P': 'vim-mode-plus:swap-with-register'
 
-# visual-characterwise
-# -------------------------
-'atom-text-editor.vim-mode-plus.visual-mode.characterwise':
-  'C': 'vim-mode-plus:change-line'
-
 # visual-blockwise
 # -------------------------
 'atom-text-editor.vim-mode-plus.visual-mode.blockwise':
   'o': 'vim-mode-plus:blockwise-other-end'
   'O': 'vim-mode-plus:reverse-selections'
-  'D': 'vim-mode-plus:delete-to-last-character-of-line' # To avoid overridden by delete-line in visual-mode
+  'D': 'vim-mode-plus:delete-to-last-character-of-line'
+  'C': 'vim-mode-plus:change-to-last-character-of-line'
+
+  # FIXME: I want make following works for consistency
+  # 'Y': 'vim-mode-plus:yank-to-last-character-of-line'
 
 # Input mini editor e.g. mark, surround, find, till.
 # -------------------------

--- a/lib/mutation-manager.js
+++ b/lib/mutation-manager.js
@@ -71,7 +71,7 @@ module.exports = class MutationManager {
   }
 
   getSelectedBufferRangesForCheckpoint(checkpoint) {
-    return Array.from(this.mutationsBySelection.values())
+    return [...this.mutationsBySelection.values()]
       .map(mutation => mutation.bufferRangeByCheckpoint[checkpoint])
       .filter(range => range)
   }

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -156,6 +156,7 @@ module.exports = class OccurrenceManager {
     const allRanges = []
     const markersSelected = []
     const {editor} = this.vimState
+    const rowsToSelect = new Set()
 
     for (const selection of editor.getSelections()) {
       const markers = this.getMarkersIntersectsWithSelection(selection, isVisualMode)
@@ -163,18 +164,32 @@ module.exports = class OccurrenceManager {
 
       const ranges = markers.map(marker => marker.getBufferRange())
       markersSelected.push(...markers)
-      // [HACK] Find closest range and move it to last item in ranges array.
+      // [HACK] Find closest occurrence range and move it to last item in ranges array.
       // Purpose of this is to make closest range become **last-selection**.
       // It is important to show autocomplete+ popup at proper position( popup shows up at last-selection ).
       // E.g. `c o f`(change occurrence in a-function) show autocomplete+ popup at closest occurrence.
       const closestRange = this.getClosestRangeForSelection(ranges, selection)
       ranges.splice(ranges.indexOf(closestRange), 1) // remove
+      const rangesExceptClosestRange = ranges.slice()
       ranges.push(closestRange) // then push to last
-      allRanges.push(...ranges)
+
+      if (wise === "linewise") {
+        for (const range of [closestRange, ...rangesExceptClosestRange]) {
+          const row = range.start.row
+          if (rowsToSelect.has(row)) continue
+          rowsToSelect.add(row)
+          allRanges.push(range)
+        }
+      } else {
+        allRanges.push(...ranges)
+      }
+
       const closestRangeIndex = allRanges.indexOf(closestRange)
-      // Remember connection between originalSelection and index of closestRange.
-      // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
-      closestRangeIndexByOriginalSelection.set(selection, closestRangeIndex)
+      if (closestRangeIndex >= 0) {
+        // Remember connection between originalSelection and index of closestRange.
+        // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
+        closestRangeIndexByOriginalSelection.set(selection, closestRangeIndex)
+      }
     }
 
     if (allRanges.length) {

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -150,9 +150,9 @@ module.exports = class OccurrenceManager {
   // e.g.
   //  - c(change): So that autocomplete+popup shows at original cursor position or near.
   //  - g U(upper-case): So that undo/redo can respect last cursor position.
-  select(forceWise) {
+  select(wise) {
     const isVisualMode = this.vimState.mode === "visual"
-    const indexByOldSelection = new Map()
+    const closestRangeIndexByOriginalSelection = new Map()
     const allRanges = []
     const markersSelected = []
     const {editor} = this.vimState
@@ -163,14 +163,18 @@ module.exports = class OccurrenceManager {
 
       const ranges = markers.map(marker => marker.getBufferRange())
       markersSelected.push(...markers)
-      // [HACK] Place closest range to last so that final last-selection become closest one.
-      // E.g.
-      // `c o f`(change occurrence in a-function) show autocomplete+ popup at closest occurrence.( popup shows at last-selection )
+      // [HACK] Find closest range and move it to last item in ranges array.
+      // Purpose of this is to make closest range become **last-selection**.
+      // It is important to show autocomplete+ popup at proper position( popup shows up at last-selection ).
+      // E.g. `c o f`(change occurrence in a-function) show autocomplete+ popup at closest occurrence.
       const closestRange = this.getClosestRangeForSelection(ranges, selection)
-      ranges.splice(ranges.indexOf(closestRange), 1)
-      ranges.push(closestRange)
+      ranges.splice(ranges.indexOf(closestRange), 1) // remove
+      ranges.push(closestRange) // then push to last
       allRanges.push(...ranges)
-      indexByOldSelection.set(selection, allRanges.indexOf(closestRange))
+      const closestRangeIndex = allRanges.indexOf(closestRange)
+      // Remember connection between originalSelection and index of closestRange.
+      // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
+      closestRangeIndexByOriginalSelection.set(selection, closestRangeIndex)
     }
 
     if (allRanges.length) {
@@ -182,13 +186,13 @@ module.exports = class OccurrenceManager {
 
       editor.setSelectedBufferRanges(allRanges)
       const selections = editor.getSelections()
-      indexByOldSelection.forEach((index, oldSelection) =>
-        this.vimState.mutationManager.migrateMutation(oldSelection, selections[index])
-      )
+      closestRangeIndexByOriginalSelection.forEach((closestRangeIndex, originalSelection) => {
+        this.vimState.mutationManager.migrateMutation(originalSelection, selections[closestRangeIndex])
+      })
 
-      // wise of occurrence is default 'characterwise' but when forceWise was passed.
+      // wise of occurrence is default 'characterwise' but when wise was passed.
       // It apply forced wise AFTER select occurrence.
-      // Currently only linewise forceWise is supported.
+      // Currently only linewise wise is supported.
       // When this is used is linewise-bounded-operator + occurrence operation
       // e.g. `g / o p`(`g /` is linewise-bounded-operator)
       // e.g. `g o v i p D`(`D` is delete-line, linewise-bounded).
@@ -196,9 +200,10 @@ module.exports = class OccurrenceManager {
       this.destroyMarkers(markersSelected)
       for (const $selection of this.vimState.swrap.getSelections(editor)) {
         $selection.saveProperties()
-        if (forceWise === "linewise") $selection.applyWise(forceWise)
+        if (wise === "linewise") $selection.applyWise(wise)
       }
-      if (forceWise === "linewise") editor.mergeSelectionsOnSameRows()
+      const originalSelections = editor.getSelections()
+      if (wise === "linewise") editor.mergeSelectionsOnSameRows()
       return true
     } else {
       return false

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -1,4 +1,4 @@
-const {Emitter} = require("atom")
+const {Emitter, CompositeDisposable} = require("atom")
 const {shrinkRangeEndToBeforeNewLine, collectRangeInBufferRow} = require("./utils")
 
 module.exports = class OccurrenceManager {
@@ -156,7 +156,6 @@ module.exports = class OccurrenceManager {
     const rangesToSelect = []
     const markersSelected = []
     const {editor} = this.vimState
-    const rowsToSelect = new Set()
 
     for (const selection of editor.getSelections()) {
       const markers = this.getMarkersIntersectsWithSelection(selection, isVisualMode)
@@ -172,27 +171,12 @@ module.exports = class OccurrenceManager {
       ranges.splice(ranges.indexOf(closestRange), 1) // remove
       ranges.push(closestRange) // then push to last
 
-      // In linewise-occurence, select one occurrence per single line. We achieve this by not adding rangesToSelect.
-      // This is far simpler than "select-all-occurrence then merge-selections then re-associates migration information".
-      if (wise === "linewise") {
-        // NOTE: purpose of reverse here is to process closestRange first, make closestRange survive over other ranges.
-        for (const range of ranges.slice().reverse()) {
-          const row = range.start.row
-          if (!rowsToSelect.has(row)) {
-            rowsToSelect.add(row)
-            rangesToSelect.push(range)
-          }
-        }
-      } else {
-        rangesToSelect.push(...ranges)
-      }
+      rangesToSelect.push(...ranges)
 
       const closestRangeIndex = rangesToSelect.indexOf(closestRange)
-      if (closestRangeIndex >= 0) {
-        // Remember connection between originalSelection and index of closestRange.
-        // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
-        closestRangeIndexByOriginalSelection.set(selection, closestRangeIndex)
-      }
+      // Remember connection between originalSelection and index of closestRange.
+      // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
+      closestRangeIndexByOriginalSelection.set(selection, closestRangeIndex)
     }
 
     if (rangesToSelect.length) {
@@ -207,21 +191,47 @@ module.exports = class OccurrenceManager {
       closestRangeIndexByOriginalSelection.forEach((closestRangeIndex, originalSelection) => {
         this.vimState.mutationManager.migrateMutation(originalSelection, selections[closestRangeIndex])
       })
-
-      // wise of occurrence is default 'characterwise' but when wise was passed.
-      // It apply forced wise AFTER select occurrence.
-      // Currently only linewise wise is supported.
-      // When this is used is linewise-bounded-operator + occurrence operation
-      // e.g. `g / o p`(`g /` is linewise-bounded-operator)
-      // e.g. `g o v i p D`(`D` is delete-line, linewise-bounded).
-
       this.destroyMarkers(markersSelected)
       for (const $selection of this.vimState.swrap.getSelections(editor)) {
         $selection.saveProperties()
-        if (wise === "linewise") $selection.applyWise(wise)
       }
-      const originalSelections = editor.getSelections()
-      if (wise === "linewise") editor.mergeSelectionsOnSameRows()
+
+      if (wise === "linewise") {
+        // In linewise-occurence operation, what happens is here
+        // 1. select linewise by applyWise(linewise)
+        // 2. Observe selection.onDidDestroy to remember which selection is detroyed on mergeSelectionsOnSameRows in next step(step3).
+        // 3. mergeSelectionsOnSameRows(), it merge selections in adjacent row, as a result, it destroy some selections.
+        // 4. For destroyed selection, we migrate mutaion for destroyed selection with new selection info.
+
+        for (const $selection of this.vimState.swrap.getSelections(editor)) {
+          $selection.applyWise("linewise")
+        }
+
+        const {mutationsBySelection} = this.vimState.mutationManager
+        const disposables = new CompositeDisposable()
+        const rangeByMutation = new Map()
+        const orphanedMutations = []
+
+        for (const [selection, mutation] of mutationsBySelection) {
+          // Need preserve range while it's alive.
+          rangeByMutation.set(mutation, selection.getBufferRange())
+          disposables.add(selection.onDidDestroy(() => orphanedMutations.push(mutation)))
+        }
+        editor.mergeSelectionsOnSameRows() // This destroy merged selection.
+        disposables.dispose()
+
+        const selections = editor.getSelections()
+        for (const mutation of orphanedMutations) {
+          mutationsBySelection.delete(mutation.selection)
+
+          const range = rangeByMutation.get(mutation)
+          // Selection contains original mutation range is merger selection we should migrate to.
+          const selection = selections.find(selection => selection.getBufferRange().containsRange(range))
+          mutation.selection = selection
+          mutationsBySelection.set(selection, mutation)
+        }
+      }
+
       return true
     } else {
       return false

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -150,7 +150,7 @@ module.exports = class OccurrenceManager {
   // e.g.
   //  - c(change): So that autocomplete+popup shows at original cursor position or near.
   //  - g U(upper-case): So that undo/redo can respect last cursor position.
-  select() {
+  select(forceWise) {
     const isVisualMode = this.vimState.mode === "visual"
     const indexByOldSelection = new Map()
     const allRanges = []
@@ -186,8 +186,19 @@ module.exports = class OccurrenceManager {
         this.vimState.mutationManager.migrateMutation(oldSelection, selections[index])
       )
 
+      // wise of occurrence is default 'characterwise' but when forceWise was passed.
+      // It apply forced wise AFTER select occurrence.
+      // Currently only linewise forceWise is supported.
+      // When this is used is linewise-bounded-operator + occurrence operation
+      // e.g. `g / o p`(`g /` is linewise-bounded-operator)
+      // e.g. `g o v i p D`(`D` is delete-line, linewise-bounded).
+
       this.destroyMarkers(markersSelected)
-      this.vimState.swrap.getSelections(editor).forEach($selection => $selection.saveProperties())
+      for (const $selection of this.vimState.swrap.getSelections(editor)) {
+        $selection.saveProperties()
+        if (forceWise === "linewise") $selection.applyWise(forceWise)
+      }
+      if (forceWise === "linewise") editor.mergeSelectionsOnSameRows()
       return true
     } else {
       return false

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -172,6 +172,8 @@ module.exports = class OccurrenceManager {
       ranges.splice(ranges.indexOf(closestRange), 1) // remove
       ranges.push(closestRange) // then push to last
 
+      // In linewise-occurence, select one occurrence per single line. We achieve this by not adding rangesToSelect.
+      // This is far simpler than "select-all-occurrence then merge-selections then re-associates migration information".
       if (wise === "linewise") {
         // NOTE: purpose of reverse here is to process closestRange first, make closestRange survive over other ranges.
         for (const range of ranges.slice().reverse()) {

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -153,7 +153,7 @@ module.exports = class OccurrenceManager {
   select(wise) {
     const isVisualMode = this.vimState.mode === "visual"
     const closestRangeIndexByOriginalSelection = new Map()
-    const allRanges = []
+    const rangesToSelect = []
     const markersSelected = []
     const {editor} = this.vimState
     const rowsToSelect = new Set()
@@ -170,21 +170,22 @@ module.exports = class OccurrenceManager {
       // E.g. `c o f`(change occurrence in a-function) show autocomplete+ popup at closest occurrence.
       const closestRange = this.getClosestRangeForSelection(ranges, selection)
       ranges.splice(ranges.indexOf(closestRange), 1) // remove
-      const rangesExceptClosestRange = ranges.slice()
       ranges.push(closestRange) // then push to last
 
       if (wise === "linewise") {
-        for (const range of [closestRange, ...rangesExceptClosestRange]) {
+        // NOTE: purpose of reverse here is to process closestRange first, make closestRange survive over other ranges.
+        for (const range of ranges.slice().reverse()) {
           const row = range.start.row
-          if (rowsToSelect.has(row)) continue
-          rowsToSelect.add(row)
-          allRanges.push(range)
+          if (!rowsToSelect.has(row)) {
+            rowsToSelect.add(row)
+            rangesToSelect.push(range)
+          }
         }
       } else {
-        allRanges.push(...ranges)
+        rangesToSelect.push(...ranges)
       }
 
-      const closestRangeIndex = allRanges.indexOf(closestRange)
+      const closestRangeIndex = rangesToSelect.indexOf(closestRange)
       if (closestRangeIndex >= 0) {
         // Remember connection between originalSelection and index of closestRange.
         // After select occurrence, selection is re-created, then we have to migrate mutation info using this info.
@@ -192,14 +193,14 @@ module.exports = class OccurrenceManager {
       }
     }
 
-    if (allRanges.length) {
+    if (rangesToSelect.length) {
       if (isVisualMode) {
         // To avoid selected occurrence ruined by normalization when disposing current submode to shift to new submode.
         this.vimState.modeManager.deactivate()
         this.vimState.submode = null
       }
 
-      editor.setSelectedBufferRanges(allRanges)
+      editor.setSelectedBufferRanges(rangesToSelect)
       const selections = editor.getSelections()
       closestRangeIndexByOriginalSelection.forEach((closestRangeIndex, originalSelection) => {
         this.vimState.mutationManager.migrateMutation(originalSelection, selections[closestRangeIndex])

--- a/lib/operator-transform-string.coffee
+++ b/lib/operator-transform-string.coffee
@@ -405,8 +405,10 @@ class AutoIndent extends Indent
 
 class ToggleLineComments extends TransformString
   @extend()
+  flashTarget: false
   stayByMarker: true
   wise: 'linewise'
+
   mutateSelection: (selection) ->
     selection.toggleLineComments()
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -260,7 +260,8 @@ class Operator extends Base
     return @targetSelected if @targetSelected?
     @mutationManager.init({@stayByMarker})
 
-    @target.forceWise(@wise) if @wise?
+    boundWise = @wise
+    @target.forceWise(boundWise) if boundWise?
     @emitWillSelectTarget()
 
     # Allow cursor position adjustment 'on-will-select-target' hook.
@@ -282,8 +283,9 @@ class Operator extends Base
       # Here we save patterns which represent unioned regex which @occurrenceManager knows.
       @patternForOccurrence ?= @occurrenceManager.buildPattern()
 
-      if @occurrenceManager.select()
+      if @occurrenceManager.select(boundWise)
         @occurrenceSelected = true
+        @occurrenceWise = boundWise ? "characterwise"
         @mutationManager.setCheckpoint('did-select-occurrence')
 
     if @targetSelected = @vimState.haveSomeNonEmptySelection() or @target.name is "Empty"
@@ -297,7 +299,7 @@ class Operator extends Base
   restoreCursorPositionsIfNecessary: ->
     return unless @restorePositions
     stay = @stayAtSamePosition ? @getConfig(@stayOptionName) or (@occurrenceSelected and @getConfig('stayOnOccurrence'))
-    wise = if @occurrenceSelected then 'characterwise' else @target.wise
+    wise = if @occurrenceSelected then @occurrenceWise else @target.wise
     @mutationManager.restoreCursorPositions({stay, wise, @setToFirstCharacterOnLinewise})
 
 # Select
@@ -462,6 +464,7 @@ class DeleteLine extends Delete
   @extend()
   wise: 'linewise'
   target: "MoveToRelativeLine"
+  flashTarget: false
 
 # Yank
 # =========================

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -432,8 +432,10 @@ class Delete extends Operator
   setToFirstCharacterOnLinewise: true
 
   execute: ->
-    if @target.wise is 'blockwise'
-      @restorePositions = false
+    @onDidSelectTarget =>
+      @flashTarget = false if (@occurrenceSelected and @occurrenceWise is "linewise")
+
+    @restorePositions = false  if @target.wise is 'blockwise'
     super
 
   mutateSelection: (selection) ->

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -260,8 +260,7 @@ class Operator extends Base
     return @targetSelected if @targetSelected?
     @mutationManager.init({@stayByMarker})
 
-    boundWise = @wise
-    @target.forceWise(boundWise) if boundWise?
+    @target.forceWise(@wise) if @wise?
     @emitWillSelectTarget()
 
     # Allow cursor position adjustment 'on-will-select-target' hook.
@@ -283,9 +282,9 @@ class Operator extends Base
       # Here we save patterns which represent unioned regex which @occurrenceManager knows.
       @patternForOccurrence ?= @occurrenceManager.buildPattern()
 
-      if @occurrenceManager.select(boundWise)
+      @occurrenceWise = @wise ? "characterwise"
+      if @occurrenceManager.select(@occurrenceWise)
         @occurrenceSelected = true
-        @occurrenceWise = boundWise ? "characterwise"
         @mutationManager.setCheckpoint('did-select-occurrence')
 
     if @targetSelected = @vimState.haveSomeNonEmptySelection() or @target.name is "Empty"

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -210,13 +210,13 @@ module.exports = new Settings("vim-mode-plus", {
     title: "keymap `p` and `P` to `put-after-with-auto-indent` and `put-before-with-auto-indent`",
     default: false,
     description:
-      "Remap `p` and `P` to auto indent version.<br>\n`p` remapped to `put-after-with-auto-indent` from original `put-after`<br>\n`P` remapped to `put-before-with-auto-indent` from original `put-before`<br>\n[Conflicts]: Original `put-after` and `put-before` become unavailable unless you set different keymap by yourself.",
+      "Remap `p` and `P` to auto indent version.<br>`p` remapped to `put-after-with-auto-indent` from original `put-after`<br>`P` remapped to `put-before-with-auto-indent` from original `put-before`<br>[Conflicts]: Original `put-after` and `put-before` become unavailable unless you set different keymap by yourself.",
   },
   keymapCCToChangeInnerSmartWord: {
     title: "keymap `c c` to `change inner-smart-word`",
     default: false,
     description:
-      "[Can]: `c c` to `change inner-smart-word`<br>\n[Conflicts]: `c c`( change-current-line ), but you still can use `S` or `c i l` which is equivalent to original `c c`.",
+      "[Can]: `c c` to `change inner-smart-word`<br>[Conflicts]: `c c`( change-current-line ), but you still can use `S` or `c i l` which is equivalent to original `c c`.",
   },
   keymapSemicolonToInnerAnyPairInOperatorPendingMode: {
     title: "keymap `;` to `inner-any-pair` in `operator-pending-mode`",
@@ -261,14 +261,14 @@ module.exports = new Settings("vim-mode-plus", {
     default: "smart",
     enum: ["smart", "simple"],
     description:
-      "When you think undo/redo cursor position has BUG, set this to `simple`.<br>\n`smart`: Good accuracy but have cursor-not-updated-on-different-editor limitation<br>\n`simple`: Always work, but accuracy is not as good as `smart`.<br>",
+      "When you think undo/redo cursor position has BUG, set this to `simple`.<br>`smart`: Good accuracy but have cursor-not-updated-on-different-editor limitation<br>`simple`: Always work, but accuracy is not as good as `smart`.<br>",
   },
   groupChangesWhenLeavingInsertMode: true,
   useClipboardAsDefaultRegister: true,
   dontUpdateRegisterOnChangeOrSubstitute: {
     default: false,
     description:
-      "When set to `true` any `change` or `substitute` operation no longer update register content<br>\nAffects `c`, `C`, `s`, `S` operator.",
+      "When enabled, `change` and `substitute` no longer update register content<br>Affects `c`, `C`, `s`, `S` operator.",
   },
   startInInsertMode: false,
   startInInsertModeScopes: {
@@ -286,7 +286,7 @@ module.exports = new Settings("vim-mode-plus", {
   numberRegex: {
     default: "-?[0-9]+",
     description:
-      "Used to find number in `ctrl-a` and `ctrl-x`.<br>\nTo ignore `-`( minus ) char within string like `identifier-1` use `(?:\\B-)?[0-9]+`",
+      "Used to find number in `ctrl-a` and `ctrl-x`.<br>To ignore `-`( minus ) char within string like `identifier-1` use `(?:\\B-)?[0-9]+`",
   },
   clearHighlightSearchOnResetNormalMode: {
     default: true,
@@ -300,7 +300,7 @@ module.exports = new Settings("vim-mode-plus", {
     default: [],
     items: {type: "string"},
     description:
-      "Comma separated list of character, which add space around surrounded text.<br>\nFor vim-surround compatible behavior, set `(, {, [, <`.",
+      "Comma separated list of character, which add space around surrounded text.<br>For vim-surround compatible behavior, set `(, {, [, <`.",
   },
   sequentialPaste: {
     default: false,
@@ -336,11 +336,11 @@ module.exports = new Settings("vim-mode-plus", {
   reuseFindForRepeatFind: {
     default: false,
     description:
-      "When `true`, can repeat last-find by `f` and `F`( backwards ), you still can use normal `,` and `;`.<br>e.g. `f a f` move cursor to 2nd `a`.<br>Affects to: `f`, `F`, `t`, `T`.",
+      "When enabled, can repeat last-find by `f` and `F`( backwards ), you still can use normal `,` and `;`.<br>e.g. `f a f` move cursor to 2nd `a`.<br>Affects to: `f`, `F`, `t`, `T`.",
   },
   findAcrossLines: {
     default: false,
-    description: "When `true`, `f` searches over next lines.<br>Affects `f`, `F`, `t`, `T`.",
+    description: "When enabled, `f` searches over next lines.<br>Affects `f`, `F`, `t`, `T`.",
   },
   ignoreCaseForSearch: {
     default: false,
@@ -385,7 +385,7 @@ module.exports = new Settings("vim-mode-plus", {
   stayOnOccurrence: {
     default: true,
     description:
-      "Don't move cursor when operator works on occurrences( when `true`, override operator specific `stayOn` options )",
+      "Don't move cursor when operator works on occurrences<br>When enabled, override operator specific `stayOn` options.",
   },
   stayOnSelectTextObject: {
     default: true,
@@ -395,7 +395,7 @@ module.exports = new Settings("vim-mode-plus", {
   stayOnVerticalMotion: {
     default: true,
     description:
-      "Almost equivalent to `startofline` pure-Vim option(but it's meaning is **inverted**). When false, move cursor to first char.<br>\nAffects to `ctrl-f`, `ctrl-b`, `ctrl-d`, `ctrl-u`, `G`, `H`, `M`, `L`, `g g`<br>\nUnlike pure-Vim, `d`, `<<`, `>>` are not affected by this option, use independent `stayOn` options.",
+      "Almost equivalent to `startofline` pure-Vim option(but it's meaning is **inverted**). When false, move cursor to first char.<br>Affects to `ctrl-f`, `ctrl-b`, `ctrl-d`, `ctrl-u`, `G`, `H`, `M`, `L`, `g g`<br>Unlike pure-Vim, `d`, `<<`, `>>` are not affected by this option, use independent `stayOn` options.",
   },
   allowMoveToOffScreenColumnOnScreenLineMotion: {
     default: true,
@@ -406,7 +406,7 @@ module.exports = new Settings("vim-mode-plus", {
   flashOnMoveToOccurrence: {
     default: true,
     description:
-      "When preset-occurrence( `g o` ) is exist on editor, you can move between occurrences by `tab` and `shift-tab`<br>When set to `true`, flash occurrence under cursor after move",
+      "When preset-occurrence( `g o` ) is exist on editor, you can move between occurrences by `tab` and `shift-tab`<br>When enabled, flash occurrence under cursor after move",
   },
   flashOnOperate: true,
   flashOnOperateBlacklist: {
@@ -436,7 +436,7 @@ module.exports = new Settings("vim-mode-plus", {
   centerPaneOnMaximizePane: {
     default: true,
     description:
-      "Set to `false`, if you never need centering effect.<br>If you usually want centering but **occasionally** don't, leave this setting to `true` and use `vim-mode-plus:maximize-pane`( `cmd-enter` or `ctrl-w z` ) and `vim-mode-plus:maximize-pane-without-center`( `ctrl-w Z` ) command respectively.",
+      "Set to `false`, if you never need centering effect.<br>If you usually want centering but **occasionally** don't, leave this enabled and use `vim-mode-plus:maximize-pane`( `cmd-enter` or `ctrl-w z` ) and `vim-mode-plus:maximize-pane-without-center`( `ctrl-w Z` ) command respectively.",
   },
   smoothScrollOnFullScrollMotion: {
     default: false,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -118,7 +118,7 @@ class Settings {
   observeConditionalKeymaps() {
     const conditionalKeymaps = {
       keymapYToYankToLastCharacterOfLine: {
-        "atom-text-editor.vim-mode-plus:not(.insert-mode)": {
+        "atom-text-editor.vim-mode-plus.normal-mode": {
           Y: "vim-mode-plus:yank-to-last-character-of-line",
         },
       },

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -1041,3 +1041,104 @@ describe "Occurrence", ->
       describe "add preset subword-occurrence", ->
         it "mark subword under cursor", ->
           ensure 'g O', occurrenceText: ['Case', 'Case', 'Case', 'Case']
+
+  describe "linewise-bound-operation in occurrence operation", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage("language-javascript")
+
+      runs ->
+        set
+          grammar: 'source.js'
+          textC: """
+          function hello(name) {
+            console.log("debug-1")
+            |console.log("debug-2")
+
+            const greeting = "hello"
+            console.log("debug-3")
+
+            console.log("debug-4, includ `console` word")
+            returrn name + " " + greeting
+          }
+          """
+
+    describe "with preset-occurrence", ->
+      it "works characterwise for `delete` operator", ->
+        ensure "g o v i f", mode: ['visual', 'linewise']
+        ensure "d",
+          textC: """
+          function hello(name) {
+            |.log("debug-1")
+            .log("debug-2")
+
+            const greeting = "hello"
+            .log("debug-3")
+
+            .log("debug-4, includ `` word")
+            returrn name + " " + greeting
+          }
+          """
+      it "works linewise for `delete-line` operator", ->
+        ensure "g o v i f D",
+          textC: """
+          function hello(name) {
+          |
+            const greeting = "hello"
+
+            returrn name + " " + greeting
+          }
+          """
+    describe "when specified both o and V operator-modifier", ->
+      it "delete `console` including line by `V` modifier", ->
+        ensure "d o V f",
+          textC: """
+          function hello(name) {
+          |
+            const greeting = "hello"
+
+            returrn name + " " + greeting
+          }
+          """
+      it "upper-case `console` including line by `V` modifier", ->
+        ensure "g U o V f",
+          textC: """
+          function hello(name) {
+            CONSOLE.LOG("DEBUG-1")
+            |CONSOLE.LOG("DEBUG-2")
+
+            const greeting = "hello"
+            CONSOLE.LOG("DEBUG-3")
+
+            CONSOLE.LOG("DEBUG-4, INCLUD `CONSOLE` WORD")
+            returrn name + " " + greeting
+          }
+          """
+    describe "with o operator-modifier", ->
+      it "toggle-line-comments of `occurrence` inclding **lines**", ->
+        ensure "g / o f",
+          textC: """
+          function hello(name) {
+            // console.log("debug-1")
+            // |console.log("debug-2")
+
+            const greeting = "hello"
+            // console.log("debug-3")
+
+            // console.log("debug-4, includ `console` word")
+            returrn name + " " + greeting
+          }
+          """
+        ensure '.',
+          textC: """
+          function hello(name) {
+            console.log("debug-1")
+            |console.log("debug-2")
+
+            const greeting = "hello"
+            console.log("debug-3")
+
+            console.log("debug-4, includ `console` word")
+            returrn name + " " + greeting
+          }
+          """


### PR DESCRIPTION
Fix #870

Before this PR, occurrence operation(via `o` modifier or `preset-occurrence` by `g o`) was always works as **characterwise**.
This PR make linewise-bounded-operator works as `linewise` even in `occurrence` operation.

As like `D` works in `linewise` even in `visual.characterwise` mode,
As like `D` works in `linewise` even in occurrence operation.(select occurrence then re-select linewise).

This is **great improvement** I haven't noticed this idea until recently.
- consistent
- this behavior greatly simplify complex operation.

# Example

### beforeEach

set text

```javascript
text = addIndent(text, indentString)
console.log("6 HEY!", inspect([1, 2, 3]))
console.log("8 HEY!", inspect([1, 2, 3]))
console.log("9 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
console.log("11 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
```

Place cursor at `console`(whichever is OK).

### toggle line-comment for `console` containing lines.

`g / o p`

```javascript
text = addIndent(text, indentString)
// console.log("6 HEY!", inspect([1, 2, 3]))
// console.log("8 HEY!", inspect([1, 2, 3]))
// console.log("9 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
// console.log("11 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
```

### Delete `console` containing lines

Select paragraph by `v i p` then `D`(`delete-line`)

```javascript
text = addIndent(text, indentString)
text = addIndent(text, indentString)
text = addIndent(text, indentString)
```

### Indent `console` containing lines

`g o > p`(mark `console`, then `indent` `inner-paragraph`).

```javascript
text = addIndent(text, indentString)
  console.log("6 HEY!", inspect([1, 2, 3]))
  console.log("8 HEY!", inspect([1, 2, 3]))
  console.log("9 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
  console.log("11 HEY!", inspect([1, 2, 3]))
text = addIndent(text, indentString)
```
