### PR TITLE
Edge stoppable at 1st and last row as long as column exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.8.0: WIP
 - Improve: make `[` and `]` stop at first row and last row(again).
   - `[`(`move-up-to-edge`) and `]`(`move-down-to-edge`) now stop at first and last row as target column is stoppable.
+  - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
+  - Now re-introduced this feature with avoiding edge case reported in #481.
 
 # 1.7.0:
 - Fix: `f escape f` no longer throw exception when `reuseFindForRepeatFind` was enabled #883

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.8.0: WIP
+- Improve: make `[` and `]` stop at first row and last row(again).
+  - `[`(`move-up-to-edge`) and `]`(`move-down-to-edge`) now stop at first and last row as target column is stoppable.
+
 # 1.7.0:
 - Fix: `f escape f` no longer throw exception when `reuseFindForRepeatFind` was enabled #883
 - New: `insert-at-head-of-target` operator, in the past I removed this operator, but I need this now #881.

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -304,7 +304,7 @@ class MoveUpToEdge extends Motion
       false
 
   isStoppablePoint: (point) ->
-    if @isNonWhiteSpacePoint(point)
+    if @isNonWhiteSpacePoint(point) or @isFirstRowOrLastRowAndStoppable(point)
       true
     else
       leftPoint = point.translate([0, -1])
@@ -314,6 +314,15 @@ class MoveUpToEdge extends Motion
   isNonWhiteSpacePoint: (point) ->
     char = getTextInScreenRange(@editor, Range.fromPointWithDelta(point, 0, 1))
     char? and /\S/.test(char)
+
+  isFirstRowOrLastRowAndStoppable: (point) ->
+    # In normal-mode we adjust cursor by moving-left if cursor at EOL of non-blank row.
+    # So explicitly guard to not answer it stoppable.
+    if @isMode('normal') and pointIsAtEndOfLineAtNonEmptyRow(@editor, point)
+      false
+    else
+      point.isEqual(@editor.clipScreenPosition(point)) and
+        ((point.row is 0) or (point.row is @getVimLastBufferRow()))
 
 class MoveDownToEdge extends MoveUpToEdge
   @extend()

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -310,7 +310,21 @@ describe "Motion general", ->
             cursor: [2, 2]
 
         describe "when column is leading spaces", ->
-          it "doesn't move cursor", ->
+          it "move cursor if it's stoppable", ->
+            ensure '[', cursor: [0, 2]
+            ensure ']', cursor: [4, 2]
+
+          it "doesn't move cursor if it's NOT stoppable", ->
+            set
+              text_: """
+              __
+              ____this is text of line 1
+              ____this is text of line 2
+              ______hello line 3
+              ______hello line 4
+              __
+              """
+              cursor: [2, 2]
             ensure '[', cursor: [2, 2]
             ensure ']', cursor: [2, 2]
 


### PR DESCRIPTION
- Improve: make `[` and `]` stop at first row and last row(again).
  - `[`(`move-up-to-edge`) and `]`(`move-down-to-edge`) now stop at first and last row as target column is stoppable.
  - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
  - Now re-introduced this feature with avoiding edge case reported in #481.
