### PR TITLE
expose select operator as normal command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
   - `[`(`move-up-to-edge`) and `]`(`move-down-to-edge`) now stop at first and last row as target column is stoppable.
   - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
   - Now re-introduced this feature with avoiding edge case reported in #481.
+- Expose select operator as user-command.
+  - TODO
+- Keymap: Shorhand keymap for `inner-entire` in `operator-pending-mode` for Linux and Windows.
+  - Windows and Linux user can `ctrl-a` as shorthand of `i e`(`inner-entire`).
+    - Usage example: `y ctrl-a` to yank all text in buffer.
+  - For macOS user `cmd-a` is provided as shorthand of `i e` from older version(v0.88.0).
 
 # 1.7.0:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.6.0...v1.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Windows and Linux user can `ctrl-a` as shorthand of `i e`(`inner-entire`).
     - Usage example: `y ctrl-a` to yank all text in buffer.
   - For macOS user `cmd-a` is provided as shorthand of `i e` from older version(v0.88.0).
+- New: Operator command `insert-at-head-of-occurrence`, `insert-at-head-of-subword-occurrence`.
+  - Previously only `start` and `end` version of this commands are provided.
 
 # 1.7.0:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.6.0...v1.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,25 @@
-# 1.8.0: WIP
+# 1.8.0: Expose select operator as normal command
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.7.0...v1.8.0)
+- New: `select` operator just for `select` target.
+  - `select` is super essential operator which have been used in every motion in `visual-mode`.
+  - But this `select` operator was not available to user.
+  - Now vmp expose this as `select` operator with slight modification.
+    - Original `Select` operator used in `visual-mode` was renamed to `SelectInVisualMode`.
+    - The diff between `Select` and `SelectInVisualMode` is
+      - `Select`: Accept `preset-occurrence` and `persistent-selection` but `SelectInVisualMode` is not so that usr can modify  selection without being interfered by these.
+- New Config: `keymapSToSelect` conditional keymap. When enabled, `s` behaves as `select` operator.
+  - `s p`: select paragraph. Equivalent to `v i p`.
+  - `s i i`: select `inner-indentation` Equivalent to `v i i`.
+  - `s o p`: select `occurrence` in paragraph.
+  - `g o s p`: select `occurrence` in paragraph(use `preset-occurrence` by `g o`).
+  - `s o p o escape`: Place cursors to each start position of `occurrence` in paragraph.
+  - `s o p I`: insert at start position of `occurrence` in paragraph.
+  - `s o p A`: insert at end position of `occurrence` in paragraph.
 - Improve: make `[` and `]` stop at first row and last row(again).
   - `[`(`move-up-to-edge`) and `]`(`move-down-to-edge`) now stop at first and last row as target column is stoppable.
   - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
   - Now re-introduced this feature with avoiding edge case reported in #481.
-- Expose select operator as user-command.
-  - TODO
-- Keymap: Shorhand keymap for `inner-entire` in `operator-pending-mode` for Linux and Windows.
+- Keymap: Shorthand keymap for `inner-entire` in `operator-pending-mode` for Linux and Windows.
   - Windows and Linux user can `ctrl-a` as shorthand of `i e`(`inner-entire`).
     - Usage example: `y ctrl-a` to yank all text in buffer.
   - For macOS user `cmd-a` is provided as shorthand of `i e` from older version(v0.88.0).

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -493,6 +493,12 @@
   # In this scope, all operator keys are safely remappable.
   # e.g. p, d, D, x, u, X, S, ., r
 
+'.platform-win32, atom-text-editor.vim-mode-plus.operator-pending-mode':
+  'ctrl-a': 'vim-mode-plus:inner-entire'
+
+'.platform-linux, atom-text-editor.vim-mode-plus.operator-pending-mode':
+  'ctrl-a': 'vim-mode-plus:inner-entire'
+
 # operator-pending with operator specified
 # -------------------------
 # `c c` to works as change current line.

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -516,7 +516,6 @@
   'p': 'vim-mode-plus:inner-paragraph'
   'P': 'vim-mode-plus:inner-paragraph' # in-case SHIFT is not keyuped. when O modifier
   'r': 'vim-mode-plus:a-persistent-selection'
-  'v': 'vim-mode-plus:inner-visible-area'
   'f': 'vim-mode-plus:a-function'
   'F': 'vim-mode-plus:a-function' # in-case SHIFT is not keyuped. when O modifier
   'l': 'vim-mode-plus:inner-current-line'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -97,7 +97,7 @@ class Base
   target: null # Set in Operator
   operator: null # Set in operator's target( Motion or TextObject )
   isAsTargetExceptSelect: ->
-    @operator? and not @operator.instanceof('Select')
+    @operator? and not @operator.instanceof('SelectInVisualMode')
 
   abort: ->
     OperationAbortedError ?= require './errors'

--- a/lib/base.coffee
+++ b/lib/base.coffee
@@ -96,7 +96,8 @@ class Base
   repeated: false
   target: null # Set in Operator
   operator: null # Set in operator's target( Motion or TextObject )
-  isAsTargetExceptSelect: ->
+
+  isAsTargetExceptSelectInVisualMode: ->
     @operator? and not @operator.instanceof('SelectInVisualMode')
 
   abort: ->

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -5,6 +5,8 @@ Operator:
   file: "./operator"
 Select:
   file: "./operator"
+  commandName: "vim-mode-plus:select"
+  commandScope: "atom-text-editor"
 SelectLatestChange:
   file: "./operator"
   commandName: "vim-mode-plus:select-latest-change"

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -175,6 +175,10 @@ InsertAtEndOfOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-occurrence"
   commandScope: "atom-text-editor"
+InsertAtHeadOfOccurrence:
+  file: "./operator-insert"
+  commandName: "vim-mode-plus:insert-at-head-of-occurrence"
+  commandScope: "atom-text-editor"
 InsertAtStartOfSubwordOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-start-of-subword-occurrence"
@@ -182,6 +186,10 @@ InsertAtStartOfSubwordOccurrence:
 InsertAtEndOfSubwordOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-subword-occurrence"
+  commandScope: "atom-text-editor"
+InsertAtHeadOfSubwordOccurrence:
+  file: "./operator-insert"
+  commandName: "vim-mode-plus:insert-at-head-of-subword-occurrence"
   commandScope: "atom-text-editor"
 InsertAtStartOfSmartWord:
   file: "./operator-insert"

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -23,6 +23,8 @@ SelectOccurrence:
   file: "./operator"
   commandName: "vim-mode-plus:select-occurrence"
   commandScope: "atom-text-editor"
+SelectInVisualMode:
+  file: "./operator"
 CreatePersistentSelection:
   file: "./operator"
   commandName: "vim-mode-plus:create-persistent-selection"

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -62,7 +62,7 @@ module.exports = class Developer {
     return subscriptions
   }
 
-  setGlobalVimStat() {
+  setGlobalVimState() {
     global.vimState = getEditorState(atom.workspace.getActiveTextEditor())
     console.log("set global.vimState for debug", global.vimState);
   }

--- a/lib/mode-manager.js
+++ b/lib/mode-manager.js
@@ -17,8 +17,8 @@ module.exports = class ModeManager {
 
   destroy() {}
 
-  isMode(mode, submode = null) {
-    return mode === this.mode && submode === this.submode
+  isMode(mode, submode) {
+    return mode === this.mode && (submode ? submode === this.submode : true)
   }
 
   // Event

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -181,7 +181,7 @@ class MoveLeft extends Motion
 class MoveRight extends Motion
   @extend()
   canWrapToNextLine: (cursor) ->
-    if @isAsTargetExceptSelect() and not cursor.isAtEndOfLine()
+    if @isAsTargetExceptSelectInVisualMode() and not cursor.isAtEndOfLine()
       false
     else
       @getConfig('wrapLeftRightMotion')
@@ -372,15 +372,15 @@ class MoveToNextWord extends Motion
     return if pointIsAtVimEndOfFile(@editor, cursorPosition)
     wasOnWhiteSpace = pointIsOnWhiteSpace(@editor, cursorPosition)
 
-    isAsTargetExceptSelect = @isAsTargetExceptSelect()
+    isAsTargetExceptSelectInVisualMode = @isAsTargetExceptSelectInVisualMode()
     @moveCursorCountTimes cursor, ({isFinal}) =>
       cursorPosition = cursor.getBufferPosition()
-      if isEmptyRow(@editor, cursorPosition.row) and isAsTargetExceptSelect
+      if isEmptyRow(@editor, cursorPosition.row) and isAsTargetExceptSelectInVisualMode
         point = cursorPosition.traverse([1, 0])
       else
         pattern = @wordRegex ? cursor.wordRegExp()
         point = @getPoint(pattern, cursorPosition)
-        if isFinal and isAsTargetExceptSelect
+        if isFinal and isAsTargetExceptSelectInVisualMode
           if @operator.is('Change') and (not wasOnWhiteSpace)
             point = cursor.getEndOfCurrentWordBufferPosition({@wordRegex})
           else
@@ -772,7 +772,7 @@ class MoveToTopOfScreen extends Motion
     @setCursorBufferRow(cursor, bufferRow)
 
   getScrolloff: ->
-    if @isAsTargetExceptSelect()
+    if @isAsTargetExceptSelectInVisualMode()
       0
     else
       @scrolloff
@@ -962,7 +962,7 @@ class Find extends Motion
   execute: ->
     super
     decorationType = "post-confirm"
-    decorationType += " long" if @isAsTargetExceptSelect()
+    decorationType += " long" if (@operator? and not @operator?.instanceof("Select"))
     @editor.component.getNextUpdatePromise().then =>
       @highlightTextInCursorRows(@input, decorationType)
 

--- a/lib/motion.coffee
+++ b/lib/motion.coffee
@@ -85,13 +85,16 @@ class Motion extends Base
 
   # NOTE: Modify selection by modtion, selection is already "normalized" before this function is called.
   select: ->
-    isOrWasVisual = @mode is 'visual' or @is('CurrentSelection') # need to care was visual for `.` repeated.
+    @selectSucceeded = false
+
+    isOrWasVisual = @operator?.instanceof('Select') or @is('CurrentSelection') # need to care was visual for `.` repeated.
     for selection in @editor.getSelections()
       selection.modifySelection =>
         @moveWithSaveJump(selection.cursor)
 
-      succeeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
-      if isOrWasVisual or (succeeded and (@inclusive or @isLinewise()))
+      @selectSucceeded = @moveSucceeded ? not selection.isEmpty() or (@moveSuccessOnLinewise and @isLinewise())
+
+      if isOrWasVisual or (@selectSucceeded and (@inclusive or @isLinewise()))
         $selection = @swrap(selection)
         $selection.saveProperties(true) # save property of "already-normalized-selection"
         $selection.applyWise(@wise)

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -222,6 +222,10 @@ module.exports = class OccurrenceManager {
         editor.mergeSelectionsOnSameRows() // This destroy merged selection.
         disposables.dispose()
 
+        for (const $selection of this.vimState.swrap.getSelections(editor)) {
+          $selection.saveProperties()
+        }
+
         const selections = editor.getSelections()
         for (const mutation of orphanedMutations) {
           mutationsBySelection.delete(mutation.selection)

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -1,11 +1,11 @@
 const {Disposable, CompositeDisposable} = require("atom")
 const Base = require("./base")
-let OperationAbortedError, Select, MoveToRelativeLine
+let OperationAbortedError, SelectInVisualMode, MoveToRelativeLine
 
 // opration life in operationStack
 // 1. run
 //    instantiated by new.
-//    compliment implicit Operator.Select operator if necessary.
+//    compliment implicit Operator.SelectInVisualMode operator if necessary.
 //    push operation to stack.
 // 2. process
 //    reduce stack by, popping top of stack then set it as target of new top.
@@ -73,8 +73,8 @@ module.exports = class OperationStack {
   }
 
   newSelectWithTarget(target) {
-    if (!Select) Select = Base.getClass("Select")
-    return new Select(this.vimState).setTarget(target)
+    if (!SelectInVisualMode) SelectInVisualMode = Base.getClass("SelectInVisualMode")
+    return new SelectInVisualMode(this.vimState).setTarget(target)
   }
 
   // Main

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -5,7 +5,7 @@ let OperationAbortedError, SelectInVisualMode, MoveToRelativeLine
 // opration life in operationStack
 // 1. run
 //    instantiated by new.
-//    compliment implicit Operator.SelectInVisualMode operator if necessary.
+//    complement implicit Operator.SelectInVisualMode operator if necessary.
 //    push operation to stack.
 // 2. process
 //    reduce stack by, popping top of stack then set it as target of new top.

--- a/lib/operator-insert.coffee
+++ b/lib/operator-insert.coffee
@@ -117,7 +117,7 @@ class ActivateInsertMode extends Operator
 
     else
       @investigateCursorPosition() if @getConfig("debug")
-      
+
       @normalizeSelectionsIfNecessary()
       @createBufferCheckpoint('undo')
       @selectTarget() if @target?
@@ -275,14 +275,16 @@ class InsertAtHeadOfTarget extends InsertByTarget
   @extend()
   which: 'head'
 
-class InsertAtStartOfOccurrence extends InsertByTarget
+class InsertAtStartOfOccurrence extends InsertAtStartOfTarget
   @extend()
-  which: 'start'
   occurrence: true
 
-class InsertAtEndOfOccurrence extends InsertByTarget
+class InsertAtEndOfOccurrence extends InsertAtEndOfTarget
   @extend()
-  which: 'end'
+  occurrence: true
+
+class InsertAtHeadOfOccurrence extends InsertAtHeadOfTarget
+  @extend()
   occurrence: true
 
 class InsertAtStartOfSubwordOccurrence extends InsertAtStartOfOccurrence
@@ -290,6 +292,10 @@ class InsertAtStartOfSubwordOccurrence extends InsertAtStartOfOccurrence
   occurrenceType: 'subword'
 
 class InsertAtEndOfSubwordOccurrence extends InsertAtEndOfOccurrence
+  @extend()
+  occurrenceType: 'subword'
+
+class InsertAtHeadOfSubwordOccurrence extends InsertAtHeadOfOccurrence
   @extend()
   occurrenceType: 'subword'
 

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -307,6 +307,7 @@ class Select extends Operator
   recordable: false
 
   execute: ->
+    succeeded = false
     @startMutation =>
       if @selectTarget()
         if (@target.isTextObject() and @target.selectSucceeded) or @target.isMotion()
@@ -314,6 +315,9 @@ class Select extends Operator
 
           wise = if @occurrenceSelected then @occurrenceWise else @target.wise
           @activateModeIfNecessary('visual', wise)
+          succeeded = true
+
+    @cancelOperation() unless succeeded
 
 class SelectLatestChange extends Select
   @extend()
@@ -369,13 +373,10 @@ class TogglePersistentSelection extends CreatePersistentSelection
   isComplete: ->
     point = @editor.getCursorBufferPosition()
     @markerToRemove = @persistentSelection.getMarkerAtPoint(point)
-    if @markerToRemove
-      true
-    else
-      super
+    @markerToRemove? or super
 
   execute: ->
-    if @markerToRemove
+    if @markerToRemove?
       @markerToRemove.destroy()
     else
       super

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -313,18 +313,20 @@ class Operator extends Base
 # - Directly invoke text-object from normal-mode
 #   - e.g: Invoke `Inner Paragraph` from command-palette.
 class Select extends Operator
-  @extend(false)
+  @extend()
   flashTarget: false
   recordable: false
   acceptPresetOccurrence: false
   acceptPersistentSelection: false
 
   execute: ->
-    @startMutation(@selectTarget.bind(this))
+    @startMutation =>
+      if @selectTarget()
+        if (@target.isTextObject() and @target.selectSucceeded) or @target.isMotion()
+          @editor.scrollToCursorPosition() if @target.isTextObject()
 
-    if @target.isTextObject() and @target.selectSucceeded
-      @editor.scrollToCursorPosition()
-      @activateModeIfNecessary('visual', @target.wise)
+          wise = if @occurrenceSelected then @occurrenceWise else @target.wise
+          @activateModeIfNecessary('visual', wise)
 
 class SelectLatestChange extends Select
   @extend()
@@ -340,15 +342,11 @@ class SelectPersistentSelection extends Select
   @description: "Select persistent-selection and clear all persistent-selection, it's like convert to real-selection"
   target: "APersistentSelection"
 
-class SelectOccurrence extends Operator
+class SelectOccurrence extends Select
   @extend()
   @description: "Add selection onto each matching word within target range"
   occurrence: true
-
-  execute: ->
-    @startMutation =>
-      if @selectTarget()
-        @activateModeIfNecessary('visual', 'characterwise')
+  acceptPersistentSelection: true
 
 # Persistent Selection
 # =========================

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -328,6 +328,7 @@ class SelectPersistentSelection extends Select
   @extend()
   @description: "Select persistent-selection and clear all persistent-selection, it's like convert to real-selection"
   target: "APersistentSelection"
+  acceptPersistentSelection: false
 
 class SelectOccurrence extends Select
   @extend()

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -305,39 +305,45 @@ class Select extends Operator
   @extend()
   flashTarget: false
   recordable: false
+  updateSelectionProperties: true
 
   execute: ->
-    succeeded = false
-    @startMutation =>
-      if @selectTarget()
-        if (@target.isTextObject() and @target.selectSucceeded) or @target.isMotion()
-          @editor.scrollToCursorPosition() if @target.isTextObject()
+    if @updateSelectionProperties
+      for $selection in @swrap.getSelections(@editor) when not $selection.hasProperties()
+        $selection.saveProperties()
 
-          wise = if @occurrenceSelected then @occurrenceWise else @target.wise
-          @activateModeIfNecessary('visual', wise)
-          succeeded = true
+    @startMutation => @selectTarget()
 
-    @cancelOperation() unless succeeded
+    if (@target.selectSucceeded)
+      @editor.scrollToCursorPosition() if @target.isTextObject()
+      wise = if @occurrenceSelected then @occurrenceWise else @target.wise
+      @activateModeIfNecessary('visual', wise)
+    else
+      @cancelOperation()
 
 class SelectLatestChange extends Select
   @extend()
   @description: "Select latest yanked or changed range"
   target: 'ALatestChange'
+  updateSelectionProperties: false
 
 class SelectPreviousSelection extends Select
   @extend()
   target: "PreviousSelection"
+  updateSelectionProperties: false
 
 class SelectPersistentSelection extends Select
   @extend()
   @description: "Select persistent-selection and clear all persistent-selection, it's like convert to real-selection"
   target: "APersistentSelection"
   acceptPersistentSelection: false
+  updateSelectionProperties: false
 
 class SelectOccurrence extends Select
   @extend()
   @description: "Add selection onto each matching word within target range"
   occurrence: true
+  updateSelectionProperties: false
 
 # SelectInVisualMode: used in visual-mode
 # When text-object is invoked from normal or viusal-mode, operation would be

--- a/lib/operator.coffee
+++ b/lib/operator.coffee
@@ -301,23 +301,10 @@ class Operator extends Base
     wise = if @occurrenceSelected then @occurrenceWise else @target.wise
     @mutationManager.restoreCursorPositions({stay, wise, @setToFirstCharacterOnLinewise})
 
-# Select
-# When text-object is invoked from normal or viusal-mode, operation would be
-#  => Select operator with target=text-object
-# When motion is invoked from visual-mode, operation would be
-#  => Select operator with target=motion)
-# ================================
-# Select is used in TWO situation.
-# - visual-mode operation
-#   - e.g: `v l`, `V j`, `v i p`...
-# - Directly invoke text-object from normal-mode
-#   - e.g: Invoke `Inner Paragraph` from command-palette.
 class Select extends Operator
   @extend()
   flashTarget: false
   recordable: false
-  acceptPresetOccurrence: false
-  acceptPersistentSelection: false
 
   execute: ->
     @startMutation =>
@@ -346,7 +333,22 @@ class SelectOccurrence extends Select
   @extend()
   @description: "Add selection onto each matching word within target range"
   occurrence: true
-  acceptPersistentSelection: true
+
+# SelectInVisualMode: used in visual-mode
+# When text-object is invoked from normal or viusal-mode, operation would be
+#  => SelectInVisualMode operator with target=text-object
+# When motion is invoked from visual-mode, operation would be
+#  => SelectInVisualMode operator with target=motion)
+# ================================
+# SelectInVisualMode is used in TWO situation.
+# - visual-mode operation
+#   - e.g: `v l`, `V j`, `v i p`...
+# - Directly invoke text-object from normal-mode
+#   - e.g: Invoke `Inner Paragraph` from command-palette.
+class SelectInVisualMode extends Select
+  @extend(false)
+  acceptPresetOccurrence: false
+  acceptPersistentSelection: false
 
 # Persistent Selection
 # =========================

--- a/lib/register-manager.js
+++ b/lib/register-manager.js
@@ -219,7 +219,7 @@ module.exports = class RegisterManager {
     if (name != null) {
       this.name = name
       this.editorElement.classList.toggle("with-register", true)
-      this.vimState.hover.set(`"${this.name}`)
+      this.vimState.hover.set('"' + this.name)
     } else {
       this.vimState.readChar({
         onConfirm: name => {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -122,6 +122,11 @@ class Settings {
           Y: "vim-mode-plus:yank-to-last-character-of-line",
         },
       },
+      keymapSToSelect: {
+        "atom-text-editor.vim-mode-plus:not(.insert-mode)": {
+          s: "vim-mode-plus:select",
+        },
+      },
       keymapUnderscoreToReplaceWithRegister: {
         "atom-text-editor.vim-mode-plus:not(.insert-mode)": {
           _: "vim-mode-plus:replace-with-register",
@@ -199,6 +204,12 @@ module.exports = new Settings("vim-mode-plus", {
     default: false,
     description:
       "[Can]: `Y` behave as `y $` instead of default `y y`, This make `Y` consistent with `C`(works as `c $`) and `D`(works as `d $`).",
+  },
+  keymapSToSelect: {
+    title: "keymap `s` to `select`",
+    default: false,
+    description:
+      "[Can]: `s p` to select paragraph, `s o p` to select occurrence in paragraph.<br>[Conflicts]: `s`(`substitute`). Use `c l` or `x i` instead",
   },
   keymapUnderscoreToReplaceWithRegister: {
     title: "keymap `_` to `replace-with-register`",
@@ -304,7 +315,8 @@ module.exports = new Settings("vim-mode-plus", {
   },
   sequentialPaste: {
     default: false,
-    description: "When enabled `put-aftffer`(`p`), `put-before`(`P`), and `replace-with-register` pop older register entry on each sequential execution<br>The sequential execution is activated if next execution is **whithin** 1seconds(flash is not yet disappar).",
+    description:
+      "When enabled `put-after`(`p`), `put-before`(`P`), and `replace-with-register` pop older register entry on each sequential execution<br>The sequential execution is activated if next execution is **whithin** 1seconds(flash is not yet disappar).",
   },
   sequentialPasteMaxHistory: {
     default: 3,

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -92,7 +92,7 @@ class TextObject extends Base
     # Some TextObject's wise is NOT deterministic. It has to be detected from selected range.
     @wise ?= @swrap.detectWise(@editor)
 
-    if @mode is 'visual'
+    if @operator.instanceof("Select")
       if @selectSucceeded
         switch @wise
           when 'characterwise'

--- a/lib/text-object.coffee
+++ b/lib/text-object.coffee
@@ -68,7 +68,7 @@ class TextObject extends Base
 
     # Whennever TextObject is executed, it has @operator
     # Called from Operator::selectTarget()
-    #  - `v i p`, is `Select` operator with @target = `InnerParagraph`.
+    #  - `v i p`, is `SelectInVisualMode` operator with @target = `InnerParagraph`.
     #  - `d i p`, is `Delete` operator with @target = `InnerParagraph`.
     if @operator?
       @select()

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1559,3 +1559,14 @@ describe "Operator general", ->
         ensure "s $", # p is `i p` shorthand.
           mode: ["visual", "characterwise"]
           selectedText: "ooo xxx ***"
+
+      it "return to normal-mode when fail to select", ->
+        # attempt to select inner-function but there is no function.
+        ensure "s i f",
+          mode: "normal"
+          cursor: [0, 2]
+
+        # attempt to find 'z' but no "z".
+        ensure "s f z",
+          mode: "normal"
+          cursor: [0, 2]

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1490,10 +1490,15 @@ describe "Operator general", ->
       it "select text-object", ->
         ensure "s p", # p is `i p` shorthand.
           mode: ["visual", "linewise"]
-          selectedText: """
-          0 ooo xxx ***
-          1 xxx *** ooo\n
-          """
+          selectedText: "0 ooo xxx ***\n1 xxx *** ooo\n"
+          propertyHead: [1, 13]
+
+      it "select by motion j with stayOnSelectTextObject", ->
+        settings.set("stayOnSelectTextObject", true)
+        ensure "s i p",
+          mode: ["visual", "linewise"]
+          selectedText: "0 ooo xxx ***\n1 xxx *** ooo\n"
+          propertyHead: [1, 2]
 
       it "select occurrence in text-object with occurrence-modifier", ->
         ensure "s o p", # p is `i p` shorthand.

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1470,3 +1470,92 @@ describe "Operator general", ->
         line2
         line3
         """
+
+  describe 'Select as operator', ->
+    beforeEach ->
+      settings.set('keymapSToSelect', true)
+      jasmine.attachToDOM(editorElement)
+
+    describe "select by target", ->
+      beforeEach ->
+        set
+          textC: """
+          0 |ooo xxx ***
+          1 xxx *** ooo
+
+          3 ooo xxx ***
+          4 xxx *** ooo\n
+          """
+
+      it "select text-object", ->
+        ensure "s p", # p is `i p` shorthand.
+          mode: ["visual", "linewise"]
+          selectedText: """
+          0 ooo xxx ***
+          1 xxx *** ooo\n
+          """
+
+      it "select occurrence in text-object with occurrence-modifier", ->
+        ensure "s o p", # p is `i p` shorthand.
+          mode: ["visual", "characterwise"]
+          selectedText: ["ooo", "ooo"]
+          selectedBufferRangeOrdered: [
+            [[0, 2], [0, 5]]
+            [[1, 10], [1, 13]]
+          ]
+
+      it "select occurrence in text-object with preset-occurrence", ->
+        ensure "g o s p", # p is `i p` shorthand.
+          mode: ["visual", "characterwise"]
+          selectedText: ["ooo", "ooo"]
+          selectedBufferRangeOrdered: [
+            [[0, 2], [0, 5]]
+            [[1, 10], [1, 13]]
+          ]
+
+      it "convert presistent-selection into normal selection", ->
+        ensure "v j enter",
+          mode: "normal"
+          persistentSelectionCount: 1
+          persistentSelectionBufferRange: [
+            [[0, 2], [1, 3]]
+          ]
+
+        ensure "j j v j",
+          persistentSelectionCount: 1
+          persistentSelectionBufferRange: [
+            [[0, 2], [1, 3]]
+          ]
+          mode: ["visual", "characterwise"]
+          selectedText: "ooo xxx ***\n4 x"
+
+        # Now it's show time, to convert persistent selection into normal selection
+        # by only `s`.
+        ensure "s",
+          mode: ["visual", "characterwise"]
+          persistentSelectionCount: 0
+          selectedTextOrdered: ["ooo xxx ***\n1 x", "ooo xxx ***\n4 x"]
+
+      it "select preset-occurrence in presistent-selection and normal selection", ->
+        ensure "g o",
+          occurrenceText: ['ooo', 'ooo', 'ooo', 'ooo']
+
+        ensure "V j enter G V",
+          persistentSelectionCount: 1
+          mode: ["visual", "linewise"]
+          selectedText: "4 xxx *** ooo\n"
+
+        ensure "s", # Notice `ooo` in row 3 is EXCLUDED.
+          persistentSelectionCount: 0
+          mode: ["visual", "characterwise"]
+          selectedText: ["ooo", "ooo", "ooo"]
+          selectedBufferRangeOrdered: [
+            [[0, 2], [0, 5]]
+            [[1, 10], [1, 13]]
+            [[4, 10], [4, 13]]
+          ]
+
+      it "select by motion", ->
+        ensure "s $", # p is `i p` shorthand.
+          mode: ["visual", "characterwise"]
+          selectedText: "ooo xxx ***"

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1558,7 +1558,7 @@ describe "Operator general", ->
       it "select by motion $", ->
         ensure "s $",
           mode: ["visual", "characterwise"]
-          selectedText: "ooo xxx ***"
+          selectedText: "ooo xxx ***\n"
 
       it "select by motion j", ->
         ensure "s j",
@@ -1568,7 +1568,7 @@ describe "Operator general", ->
       it "select by motion j v-modifier", ->
         ensure "s v j",
           mode: ["visual", "characterwise"]
-          selectedText: "ooo xxx ***\n1 "
+          selectedText: "ooo xxx ***\n1 x"
 
       it "select occurrence by motion G", ->
         ensure "s o G",

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1555,10 +1555,39 @@ describe "Operator general", ->
             [[4, 10], [4, 13]]
           ]
 
-      it "select by motion", ->
-        ensure "s $", # p is `i p` shorthand.
+      it "select by motion $", ->
+        ensure "s $",
           mode: ["visual", "characterwise"]
           selectedText: "ooo xxx ***"
+
+      it "select by motion j", ->
+        ensure "s j",
+          mode: ["visual", "linewise"]
+          selectedText: "0 ooo xxx ***\n1 xxx *** ooo\n"
+
+      it "select by motion j v-modifier", ->
+        ensure "s v j",
+          mode: ["visual", "characterwise"]
+          selectedText: "ooo xxx ***\n1 "
+
+      it "select occurrence by motion G", ->
+        ensure "s o G",
+          mode: ["visual", "characterwise"]
+          selectedText: ["ooo", "ooo", "ooo", "ooo"]
+          selectedBufferRangeOrdered: [
+            [[0, 2], [0, 5]]
+            [[1, 10], [1, 13]]
+            [[3, 2], [3, 5]]
+            [[4, 10], [4, 13]]
+          ]
+
+      it "select occurrence by motion G with explicit V-modifier", ->
+        ensure "s o V G",
+          mode: ["visual", "linewise"]
+          selectedTextOrdered: [
+            "0 ooo xxx ***\n1 xxx *** ooo\n"
+            "3 ooo xxx ***\n4 xxx *** ooo\n"
+          ]
 
       it "return to normal-mode when fail to select", ->
         # attempt to select inner-function but there is no function.

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1604,3 +1604,32 @@ describe "Operator general", ->
         ensure "s f z",
           mode: "normal"
           cursor: [0, 2]
+
+      describe "complex scenario", ->
+        beforeEach ->
+          waitsForPromise ->
+            atom.packages.activatePackage('language-javascript')
+
+          runs ->
+            set
+              grammar: 'source.js'
+              textC: """
+              const result = []
+              for (const !member of members) {
+                let member2 = member + member
+                let member3 = member + member + member
+                result.push(member2, member3)
+              }\n
+              """
+
+        it "select occurrence in a-fold ,reverse(o) then escape to normal-mode", ->
+          ensure "s o z o escape",
+            mode: "normal"
+            textC: """
+            const result = []
+            for (const |member of members) {
+              let member2 = |member + |member
+              let member3 = |member + |member + |member
+              result.push(member2, member3)
+            }\n
+            """

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -814,6 +814,7 @@ describe "Operator TransformString", ->
           """
       # TODO#698 FIX when finished
       it "surround text for each word in visual selection", ->
+        settings.set("stayOnSelectTextObject", true)
         ensure 'v i p m s "',
           textC: """
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -25,6 +25,8 @@ beforeEach ->
   settings.set("stayOnTransformString", false)
   settings.set("stayOnYank", false)
   settings.set("stayOnDelete", false)
+  settings.set("stayOnSelectTextObject", false)
+  settings.set("stayOnVerticalMotion", true)
 
 # Utils
 # -------------------------


### PR DESCRIPTION
Came up with idea while thinking for question in #890.

This PR expose `Select` operator as normal command.

- `Select` operator is super essential operator for vim.
- It's always complemented in `visual-mode`.
- `Select` operator is implicit operator used when text-object or motion is executed in `visual-mode`, in other word, it's used in operation which move cursor in `visual-mode`.
- When you do `v j`, `j` is executed in `visual-mode`.
- In this case, vmp treat `j` as `Select` operation with targeting `j` motion.

Why I haven't exposed this operator till now is, vmp's this part was not clean/consistent enough to expose user.
Also I didn't understand for `select` operation clearly as I do now.

- This is **general-purpose** operator.
- So longer need to remember differnt `g d`(`select-occurrence`) keymap, :tada:
- If new `keymapSToSelect` conditional keymap have enabled,  `s` is mapped to `select` operator, `s o` is equivalent to `g d`.(via conditional keymap)
```
'atom-text-editor.vim-mode-plus:not(.insert-mode)':
  's': 'vim-mode-plus:select'
```
- Furthermore user can use `s O` to select `subword-occurrence`.
- `s p` to select paragraph, less keystroke than `v i p`.
- Since `s` enter `operator-pending-mode`, thus user can use `p` operator-pending-mode specific shorthand rather than normal `i p`.

# Changes summary.

- Operator used in `visual-mode` is renamed from `Select` to `SelectInVisualMode`.
- Then now `Select` is normal operator which behave as in same way as other operator.
- `Select` operator just select target then finish(normal operator start mutation after select).
- The diff between `Select` and `SelectInVisualMode` is
  - `SelectInVisualMode` does not autoAccept `preset-occurrence` or `persistent-selection` so that user can modify selection without being interfered by pre-existing `persistent-selection` or `preset-occurrence` marker.
