### PR TITLE
confirm on occurrence-operation to avoid becoming unresponsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,11 @@
   - Now stoppable as long as target column is exist at first row or last row.
   - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
   - Now re-introduced this feature with avoiding edge case reported in #481.
-- Improve: Confirm on occurrence operation #888
-  - TODO
+- Improve: Confirm on occurrence operation #888, #894
+  - Now ask confirmation before starting to create `occurrence-markers` in `g o`(`preset-occurrence`), or `c o`(using `o` modifier) operation.
+  - Allows cancellation to avoid editor become unresponsive while creating tons of markers.
+    - e.g. If you `g o` accidentally for single-space and editor have huge matches, no longer freeze editor if you cancel confirmation.
+  - New: config `confirmThresholdOnOccurrenceOperation`(default `2000`) control confirmation threshold.
 - Keymap: Shorthand keymap for `inner-entire` in `operator-pending-mode` for Linux and Windows.
   - Windows and Linux user can `ctrl-a` as shorthand of `i e`(`inner-entire`).
     - Usage example: `y ctrl-a` to yank all text in buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - Now stoppable as long as target column is exist at first row or last row.
   - This behavior is added at #314(v0.49.0) but removed at #481(v0.66.0).
   - Now re-introduced this feature with avoiding edge case reported in #481.
+- Improve: Confirm on occurrence operation #888
+  - TODO
 - Keymap: Shorthand keymap for `inner-entire` in `operator-pending-mode` for Linux and Windows.
   - Windows and Linux user can `ctrl-a` as shorthand of `i e`(`inner-entire`).
     - Usage example: `y ctrl-a` to yank all text in buffer.

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -34,7 +34,7 @@ module.exports = class OccurrenceManager {
   }
 
   markBufferRangeByPattern(pattern, occurrenceType) {
-    const markRange = ({range}) => this.markerLayer.markBufferRange(range, {invalidate: "inside"})
+    const markRange = range => this.markerLayer.markBufferRange(range, {invalidate: "inside"})
     const {editor} = this.vimState
     if (occurrenceType === "subword") {
       const subwordRegex = editor.getLastCursor().subwordRegExp()
@@ -42,10 +42,26 @@ module.exports = class OccurrenceManager {
       editor.scan(pattern, ({range}) => {
         const {row} = range.start
         if (!cache[row]) cache[row] = collectRangeInBufferRow(editor, row, subwordRegex)
-        if (cache[row].some(subwordRange => subwordRange.isEqual(range))) markRange({range})
+        if (cache[row].some(subwordRange => subwordRange.isEqual(range))) markRange(range)
       })
     } else {
-      editor.scan(pattern, markRange)
+      const ranges = []
+      editor.scan(pattern, ({range}) => ranges.push(range))
+      if (this.canCreateMarkersForLength(ranges.length)) ranges.forEach(markRange)
+    }
+  }
+
+  canCreateMarkersForLength(length) {
+    const threshold = this.vimState.getConfig("confirmThresholdOnOccurrenceOperation")
+    if (threshold >= length) {
+      return true
+    } else {
+      const options = {
+        message: `Too many(${length}) matches. Do you want to continue?`,
+        detailedMessage: `If you want increase threshold(current: ${threshold}), change "Confirm Threshold On Create Preset Occurrences" configuration.`,
+        buttons: ["Continue", "Cancel"],
+      }
+      return atom.confirm(options) === 0
     }
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -470,6 +470,11 @@ module.exports = new Settings("vim-mode-plus", {
     default: "short",
     enum: ["short", "long"],
   },
+  confirmThresholdOnOccurrenceOperation: {
+    default: 2000,
+    description:
+      "When attempt to create occurrence-marker exceeding this threshold, vmp asks confirmation to continue<br>This is to prevent editor from freezing while creating tons of markers.<br>Affects: `g o` or `o` modifier(e.g. `c o p`)",
+  },
   debug: {
     default: false,
     description: "[Dev use]",

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -282,7 +282,6 @@ describe "Occurrence", ->
 
           """
 
-
   describe "from visual-mode.is-narrowed", ->
     beforeEach ->
       set
@@ -1142,3 +1141,46 @@ describe "Occurrence", ->
             returrn name + " " + greeting
           }
           """
+
+  describe "confirmThresholdOnOccurrenceOperation config", ->
+    beforeEach ->
+      set textC: "|oo oo oo oo oo\n"
+      spyOn(atom, 'confirm')
+
+    describe "when under threshold", ->
+      beforeEach ->
+        settings.set("confirmThresholdOnOccurrenceOperation", 100)
+
+      it "does not ask confirmation on o-modifier", ->
+        ensure "c o", mode: "operator-pending", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']
+        expect(atom.confirm).not.toHaveBeenCalled()
+
+      it "does not ask confirmation on `g o`", ->
+        ensure "g o", mode: "normal", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']
+        expect(atom.confirm).not.toHaveBeenCalled()
+
+    describe "when exceeding threshold", ->
+      beforeEach ->
+        settings.set("confirmThresholdOnOccurrenceOperation", 2)
+
+      it "ask confirmation on o-modifier", ->
+        ensure "c o", mode: "operator-pending", occurrenceText: []
+        expect(atom.confirm).toHaveBeenCalled()
+
+      it "can cancel and confirm on o-modifier", ->
+        atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Cancel")
+        ensure "c o", mode: "operator-pending", occurrenceText: []
+        ensure mode: "operator-pending", occurrenceText: []
+        atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Continue")
+        ensure "o", mode: "operator-pending", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']
+
+      it "ask confirmation on `g o`", ->
+        ensure "g o", mode: "normal", occurrenceText: []
+        expect(atom.confirm).toHaveBeenCalled()
+
+      it "can cancel and confirm on `g o`", ->
+        atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Cancel")
+        ensure "g o", mode: "normal", occurrenceText: []
+        ensure mode: "normal", occurrenceText: []
+        atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Continue")
+        ensure "g o", mode: "normal", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']


### PR DESCRIPTION
Fix #888

- If matches exceeds `confirmThresholdOnOccurrenceOperation`, ask confirmation to give user to cancel.
- default: `2000`.
