### PR TITLE
Blackholable operator by config

### DIFF
--- a/lib/operator.js
+++ b/lib/operator.js
@@ -234,9 +234,14 @@ class Operator extends Base {
   }
 
   setTextToRegister(text, selection) {
+    if (this.vimState.register.isUnnamed() && this.isBlackholeRegisteredOperator()) {
+      return
+    }
+
     if (this.target.isLinewise() && !text.endsWith("\n")) {
       text += "\n"
     }
+
     if (text) {
       this.vimState.register.set(null, {text, selection})
 
@@ -252,6 +257,16 @@ class Operator extends Base {
         }
       }
     }
+  }
+
+  isBlackholeRegisteredOperator() {
+    const operators = this.getConfig("blackholeRegisteredOperators")
+    const wildCardOperators = operators.filter(name => name.endsWith("*"))
+    const commandName = this.getCommandNameWithoutPrefix()
+    return (
+      wildCardOperators.some(name => new RegExp("^" + name.replace("*", ".*")).test(commandName)) ||
+      operators.includes(commandName)
+    )
   }
 
   needSaveToNumberedRegister(target) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -294,7 +294,7 @@ module.exports = new Settings("vim-mode-plus", {
     default: [],
     items: {type: "string"},
     description:
-      "List of operator command name to disable register update.<br>e.g. `delete-right, delete-left, delete, substitute`<br>Also you can use special value(`delete*`, `change*`, `substitute*`) to specify all same-family operators.",
+      "Comma separated list of operator command name to disable register update.<br>e.g. `delete-right, delete-left, delete, substitute`<br>Also you can use special value(`delete*`, `change*`, `substitute*`) to specify all same-family operators.",
   },
   dontUpdateRegisterOnChangeOrSubstitute: {
     default: false,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -290,6 +290,12 @@ module.exports = new Settings("vim-mode-plus", {
   },
   groupChangesWhenLeavingInsertMode: true,
   useClipboardAsDefaultRegister: true,
+  defaultBlackholedOperators: {
+    default: [],
+    items: {type: "string"},
+    description:
+      "List of operator name here, for these operators, vmp does not update clipboard unless explicitly specified.<br>e.g. Delete, Change, Substitute",
+  },
   dontUpdateRegisterOnChangeOrSubstitute: {
     default: false,
     description:

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -290,11 +290,11 @@ module.exports = new Settings("vim-mode-plus", {
   },
   groupChangesWhenLeavingInsertMode: true,
   useClipboardAsDefaultRegister: true,
-  defaultBlackholedOperators: {
+  blackholeRegisteredOperators: {
     default: [],
     items: {type: "string"},
     description:
-      "List of operator name here, for these operators, vmp does not update clipboard unless explicitly specified.<br>e.g. Delete, Change, Substitute",
+      "List of operator command name to disable register update.<br>e.g. `delete-right, delete-left, delete, substitute`<br>Also you can use special value(`delete*`, `change*`, `substitute*`) to specify all same-family operators.",
   },
   dontUpdateRegisterOnChangeOrSubstitute: {
     default: false,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -19,6 +19,11 @@ const RENAMED_PARAMS = [
   {oldName: "keepColumnOnSelectTextObject", newName: "stayOnSelectTextObject"},
   {oldName: "moveToFirstCharacterOnVerticalMotion", newName: "stayOnVerticalMotion", setValueBy: invertValue},
   {oldName: "keymapSemicolonToConfirmFind", newName: "keymapSemicolonToConfirmOnFindInput"},
+  {
+    oldName: "dontUpdateRegisterOnChangeOrSubstitute",
+    newName: "blackholeRegisteredOperators",
+    setValueBy: enabled => (enabled ? ["change*", "substitute*"] : undefined),
+  },
 ]
 
 class Settings {
@@ -295,11 +300,6 @@ module.exports = new Settings("vim-mode-plus", {
     items: {type: "string"},
     description:
       "Comma separated list of operator command name to disable register update.<br>e.g. `delete-right, delete-left, delete, substitute`<br>Also you can use special value(`delete*`, `change*`, `substitute*`) to specify all same-family operators.",
-  },
-  dontUpdateRegisterOnChangeOrSubstitute: {
-    default: false,
-    description:
-      "When enabled, `change` and `substitute` no longer update register content<br>Affects `c`, `C`, `s`, `S` operator.",
   },
   startInInsertMode: false,
   startInInsertModeScopes: {

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -494,16 +494,16 @@ describe "Prefixes", ->
           ]
 
         it "default", -> ensure register: {'"': text: "initial clipboard content"}
-        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content" }
-        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content" }
-        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content" }
-        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content" }
-        it 'y NOT mutate register', -> ensure 'y l', register: {'"': text: "initial clipboard content" }
-        it 'Y NOT mutate register', -> ensure 'Y', register: {'"': text: "initial clipboard content" }
-        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content" }
-        it 'S NOT mutate register', -> ensure 'S', register: {'"': text: "initial clipboard content" }
-        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content" }
-        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content" }
+        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
+        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
+        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
+        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content"}
+        it 'y NOT mutate register', -> ensure 'y l', register: {'"': text: "initial clipboard content"}
+        it 'Y NOT mutate register', -> ensure 'Y', register: {'"': text: "initial clipboard content"}
+        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content"}
+        it 'S NOT mutate register', -> ensure 'S', register: {'"': text: "initial clipboard content"}
+        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content"}
+        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content"}
 
       describe "blackhole selectively", ->
         beforeEach ->

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -438,3 +438,112 @@ describe "Prefixes", ->
       ensure 'd 2 w', text: "222 333 444 555 666 777 888 999"
     it "repeat operator and motion respectively", ->
       ensure '3 d 2 w', text: "666 777 888 999"
+  describe "Count modifier", ->
+    beforeEach ->
+      set
+        text: "000 111 222 333 444 555 666 777 888 999"
+        cursor: [0, 0]
+
+    it "repeat operator", ->
+      ensure '3 d w', text: "333 444 555 666 777 888 999"
+    it "repeat motion", ->
+      ensure 'd 2 w', text: "222 333 444 555 666 777 888 999"
+    it "repeat operator and motion respectively", ->
+      ensure '3 d 2 w', text: "666 777 888 999"
+
+  fdescribe "blackholeRegisteredOperators settings", ->
+    beforeEach ->
+      set
+        textC: "a|bc"
+
+    describe "when false(default)", ->
+      it "default", -> ensure register: {'"': text: "initial clipboard content"}
+      it 'c mutate register', -> ensure 'c l', register: {'"': text: 'b'}
+      it 'C mutate register', -> ensure 'C', register: {'"': text: 'bc'}
+      it 'x mutate register', -> ensure 'x', register: {'"': text: 'b'}
+      it 'X mutate register', -> ensure 'X', register: {'"': text: 'a'}
+      it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
+      it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
+      it 's mutate register', -> ensure 's', register: {'"': text: 'b'}
+      it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
+      it 'd mutate register', -> ensure 'd l', register: {'"': text: 'b'}
+      it 'D mutate register', -> ensure 'D', register: {'"': text: 'bc'}
+
+    describe "when true(default)", ->
+      describe "blackhole all", ->
+        beforeEach ->
+          settings.set "blackholeRegisteredOperators", [
+            "change" # c
+            "change-to-last-character-of-line" # C
+            "change-line" # C in visual
+            "change-occurrence"
+            "change-occurrence-from-search"
+            "delete" # d
+            "delete-to-last-character-of-line" # D
+            "delete-line" # D in visual
+            "delete-right" # x
+            "delete-left" # X
+            "substitute" # s
+            "substitute-line" # S
+            "yank" # y
+            "yank-line" # Y
+            # "delete*"
+            # "change*"
+            # "yank*"
+            # "substitute*"
+          ]
+
+        it "default", -> ensure register: {'"': text: "initial clipboard content"}
+        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content" }
+        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content" }
+        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content" }
+        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content" }
+        it 'y NOT mutate register', -> ensure 'y l', register: {'"': text: "initial clipboard content" }
+        it 'Y NOT mutate register', -> ensure 'Y', register: {'"': text: "initial clipboard content" }
+        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content" }
+        it 'S NOT mutate register', -> ensure 'S', register: {'"': text: "initial clipboard content" }
+        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content" }
+        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content" }
+
+      describe "blackhole selectively", ->
+        beforeEach ->
+          settings.set "blackholeRegisteredOperators", [
+            "change-to-last-character-of-line" # C
+            "delete-right" # x
+            "substitute" # s
+          ]
+
+        it "default", -> ensure register: {'"': text: "initial clipboard content"}
+        it 'c mutate register', -> ensure 'c l', register: {'"': text: 'b'}
+        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
+        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
+        it 'X mutate register', -> ensure 'X', register: {'"': text: 'a'}
+        it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
+        it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
+        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content"}
+        it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
+        it 'd mutate register', -> ensure 'd l', register: {'"': text: 'b'}
+        it 'D mutate register', -> ensure 'D', register: {'"': text: 'bc'}
+
+      describe "blackhole by wildcard", ->
+        beforeEach ->
+          settings.set "blackholeRegisteredOperators", [
+            "change*" # C
+            "delete*" # x
+            # "substitute*" # s
+            # "yank*"
+          ]
+
+        it "default", -> ensure register: {'"': text: "initial clipboard content"}
+        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
+        it 'c still CAN update register if specified explicitly', -> ensure '" a c l', register: {'a': text: "b"}
+        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
+        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
+        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
+        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content"}
+        it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
+        it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
+        it 's mutate register', -> ensure 's', register: {'"': text: 'b'}
+        it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
+        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content"}
+        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content"}

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -451,23 +451,24 @@ describe "Prefixes", ->
     it "repeat operator and motion respectively", ->
       ensure '3 d 2 w', text: "666 777 888 999"
 
-  fdescribe "blackholeRegisteredOperators settings", ->
+  describe "blackholeRegisteredOperators settings", ->
+    originalText = "initial clipboard content"
     beforeEach ->
       set
         textC: "a|bc"
 
     describe "when false(default)", ->
-      it "default", -> ensure register: {'"': text: "initial clipboard content"}
-      it 'c mutate register', -> ensure 'c l', register: {'"': text: 'b'}
-      it 'C mutate register', -> ensure 'C', register: {'"': text: 'bc'}
-      it 'x mutate register', -> ensure 'x', register: {'"': text: 'b'}
-      it 'X mutate register', -> ensure 'X', register: {'"': text: 'a'}
-      it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
-      it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
-      it 's mutate register', -> ensure 's', register: {'"': text: 'b'}
-      it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
-      it 'd mutate register', -> ensure 'd l', register: {'"': text: 'b'}
-      it 'D mutate register', -> ensure 'D', register: {'"': text: 'bc'}
+      it "default", -> ensure register: {'"': text: originalText}
+      it 'c update', -> ensure 'c l', register: {'"': text: 'b'}
+      it 'C update', -> ensure 'C', register: {'"': text: 'bc'}
+      it 'x update', -> ensure 'x', register: {'"': text: 'b'}
+      it 'X update', -> ensure 'X', register: {'"': text: 'a'}
+      it 'y update', -> ensure 'y l', register: {'"': text: 'b'}
+      it 'Y update', -> ensure 'Y', register: {'"': text: "abc\n"}
+      it 's update', -> ensure 's', register: {'"': text: 'b'}
+      it 'S update', -> ensure 'S', register: {'"': text: 'abc\n'}
+      it 'd update', -> ensure 'd l', register: {'"': text: 'b'}
+      it 'D update', -> ensure 'D', register: {'"': text: 'bc'}
 
     describe "when true(default)", ->
       describe "blackhole all", ->
@@ -493,17 +494,17 @@ describe "Prefixes", ->
             # "substitute*"
           ]
 
-        it "default", -> ensure register: {'"': text: "initial clipboard content"}
-        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
-        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
-        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
-        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content"}
-        it 'y NOT mutate register', -> ensure 'y l', register: {'"': text: "initial clipboard content"}
-        it 'Y NOT mutate register', -> ensure 'Y', register: {'"': text: "initial clipboard content"}
-        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content"}
-        it 'S NOT mutate register', -> ensure 'S', register: {'"': text: "initial clipboard content"}
-        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content"}
-        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content"}
+        it "default",      -> ensure        register: {'"': text: originalText}
+        it 'c NOT update', -> ensure 'c l', register: {'"': text: originalText}
+        it 'C NOT update', -> ensure 'C',   register: {'"': text: originalText}
+        it 'x NOT update', -> ensure 'x',   register: {'"': text: originalText}
+        it 'X NOT update', -> ensure 'X',   register: {'"': text: originalText}
+        it 'y NOT update', -> ensure 'y l', register: {'"': text: originalText}
+        it 'Y NOT update', -> ensure 'Y',   register: {'"': text: originalText}
+        it 's NOT update', -> ensure 's',   register: {'"': text: originalText}
+        it 'S NOT update', -> ensure 'S',   register: {'"': text: originalText}
+        it 'd NOT update', -> ensure 'd l', register: {'"': text: originalText}
+        it 'D NOT update', -> ensure 'D',   register: {'"': text: originalText}
 
       describe "blackhole selectively", ->
         beforeEach ->
@@ -513,17 +514,17 @@ describe "Prefixes", ->
             "substitute" # s
           ]
 
-        it "default", -> ensure register: {'"': text: "initial clipboard content"}
-        it 'c mutate register', -> ensure 'c l', register: {'"': text: 'b'}
-        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
-        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
-        it 'X mutate register', -> ensure 'X', register: {'"': text: 'a'}
-        it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
-        it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
-        it 's NOT mutate register', -> ensure 's', register: {'"': text: "initial clipboard content"}
-        it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
-        it 'd mutate register', -> ensure 'd l', register: {'"': text: 'b'}
-        it 'D mutate register', -> ensure 'D', register: {'"': text: 'bc'}
+        it "default",      -> ensure        register: {'"': text: originalText}
+        it 'c update',     -> ensure 'c l', register: {'"': text: 'b'}
+        it 'C NOT update', -> ensure 'C',   register: {'"': text: originalText}
+        it 'x NOT update', -> ensure 'x',   register: {'"': text: originalText}
+        it 'X update',     -> ensure 'X',   register: {'"': text: 'a'}
+        it 'y update',     -> ensure 'y l', register: {'"': text: 'b'}
+        it 'Y update',     -> ensure 'Y',   register: {'"': text: "abc\n"}
+        it 's NOT update', -> ensure 's',   register: {'"': text: originalText}
+        it 'S update',     -> ensure 'S',   register: {'"': text: 'abc\n'}
+        it 'd update',     -> ensure 'd l', register: {'"': text: 'b'}
+        it 'D update',     -> ensure 'D',   register: {'"': text: 'bc'}
 
       describe "blackhole by wildcard", ->
         beforeEach ->
@@ -534,16 +535,16 @@ describe "Prefixes", ->
             # "yank*"
           ]
 
-        it "default", -> ensure register: {'"': text: "initial clipboard content"}
-        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
-        it 'c still CAN update register if specified explicitly', -> ensure '" a c l', register: {'a': text: "b"}
-        it 'c NOT mutate register', -> ensure 'c l', register: {'"': text: "initial clipboard content"}
-        it 'C NOT mutate register', -> ensure 'C', register: {'"': text: "initial clipboard content"}
-        it 'x NOT mutate register', -> ensure 'x', register: {'"': text: "initial clipboard content"}
-        it 'X NOT mutate register', -> ensure 'X', register: {'"': text: "initial clipboard content"}
-        it 'y mutate register', -> ensure 'y l', register: {'"': text: 'b'}
-        it 'Y mutate register', -> ensure 'Y', register: {'"': text: "abc\n"}
-        it 's mutate register', -> ensure 's', register: {'"': text: 'b'}
-        it 'S mutate register', -> ensure 'S', register: {'"': text: 'abc\n'}
-        it 'd NOT mutate register', -> ensure 'd l', register: {'"': text: "initial clipboard content"}
-        it 'D NOT mutate register', -> ensure 'D', register: {'"': text: "initial clipboard content"}
+        it "default",      -> ensure        register: {'"': text: originalText}
+        it 'c NOT update', -> ensure 'c l', register: {'"': text: originalText}
+        it 'c update if specified', -> ensure '" a c l', register: {'a': text: "b"}
+        it 'c NOT update', -> ensure 'c l', register: {'"': text: originalText}
+        it 'C NOT update', -> ensure 'C',   register: {'"': text: originalText}
+        it 'x NOT update', -> ensure 'x',   register: {'"': text: originalText}
+        it 'X NOT update', -> ensure 'X',   register: {'"': text: originalText}
+        it 'y update',     -> ensure 'y l', register: {'"': text: 'b'}
+        it 'Y update',     -> ensure 'Y',   register: {'"': text: "abc\n"}
+        it 's update',     -> ensure 's',   register: {'"': text: 'b'}
+        it 'S update',     -> ensure 'S',   register: {'"': text: 'abc\n'}
+        it 'd NOT update', -> ensure 'd l', register: {'"': text: originalText}
+        it 'D NOT update', -> ensure 'D',   register: {'"': text: originalText}


### PR DESCRIPTION
suggested in #901

- new `blackholeRegisteredOperators` config hold list of operator command name which does not update register.
  - e.g. `change, change-line, delete`.
- This new config deprecate old `dontUpdateRegisterOnChangeOrSubstitute` configuration, since have same purpose and with more granular control(superset).
- `delete*`, `change*`, `yank*`, `substitute*` are specially supported value which meansd *all** operators of same family.
- Here is full list of available command(at this point, but won't change much in future).
  - `change` # c
  - `change-to-last-character-of-line` # C
  - `change-line` # C in visual
  - `change-occurrence`
  - `change-occurrence-from-search`
  - `delete` # d
  - `delete-to-last-character-of-line` # D
  - `delete-line` # D in visual
  - `delete-right` # x
  - `delete-left` # X
  - `substitute` # s
  - `substitute-line` # S
  - `yank` # y
  - `yank-line` # Y
  - `delete*`
  - `change*`
  - `yank*`
  - `substitute*`
