### PR TITLE
make sure "point" is an instance of Point

### DIFF
--- a/lib/motion.js
+++ b/lib/motion.js
@@ -440,7 +440,8 @@ class MoveToNextWord extends Motion {
         let point = this.getPoint(regex, cursorPosition)
         if (isFinal && isAsTargetExceptSelectInVisualMode) {
           if (this.operator.is("Change") && !wasOnWhiteSpace) {
-            point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
+				point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
+				point = new Point(point.row, point.column)
           } else {
             point = Point.min(point, getEndOfLineForBufferRow(this.editor, cursorPosition.row))
           }
@@ -471,7 +472,8 @@ class MoveToEndOfWord extends Motion {
 
   moveToNextEndOfWord(cursor) {
     moveCursorToNextNonWhitespace(cursor)
-    const point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex}).translate([0, -1])
+	 let point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
+	 point = new Point(point.row, point.column).translate([0, -1])
     cursor.setBufferPosition(Point.min(point, this.getVimEofBufferPosition()))
   }
 
@@ -515,7 +517,8 @@ class MoveToPreviousEndOfWord extends MoveToPreviousWord {
   }
 
   moveToNextEndOfWord(cursor) {
-    const point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex}).translate([0, -1])
+	 let point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
+	 point = new Point(point.row, point.column).translate([0, -1])
     cursor.setBufferPosition(Point.min(point, this.getVimEofBufferPosition()))
   }
 }

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -441,7 +441,7 @@ class MoveToNextWord extends Motion {
         if (isFinal && isAsTargetExceptSelectInVisualMode) {
           if (this.operator.is("Change") && !wasOnWhiteSpace) {
 				point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
-				point = new Point(point.row, point.column)
+				if(point.constructor !== Point) point = new Point(point.row, point.column)
           } else {
             point = Point.min(point, getEndOfLineForBufferRow(this.editor, cursorPosition.row))
           }
@@ -473,7 +473,8 @@ class MoveToEndOfWord extends Motion {
   moveToNextEndOfWord(cursor) {
     moveCursorToNextNonWhitespace(cursor)
 	 let point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
-	 point = new Point(point.row, point.column).translate([0, -1])
+	 if(point.constructor !== Point) point = new Point(point.row, point.column)
+	 point = point.translate([0, -1])
     cursor.setBufferPosition(Point.min(point, this.getVimEofBufferPosition()))
   }
 
@@ -518,7 +519,8 @@ class MoveToPreviousEndOfWord extends MoveToPreviousWord {
 
   moveToNextEndOfWord(cursor) {
 	 let point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
-	 point = new Point(point.row, point.column).translate([0, -1])
+	 if(point.constructor !== Point) point = new Point(point.row, point.column)
+	 point = point.translate([0, -1])
     cursor.setBufferPosition(Point.min(point, this.getVimEofBufferPosition()))
   }
 }


### PR DESCRIPTION
"cursor.getEndOfCurrentWordBufferPosition" returns regular object instead of instance of Point, which breaks the "MoveToEndOfWord" class