### PR TITLE
Allow scroll cursor past end of last line

### DIFF
--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -415,7 +415,10 @@ ScrollCursor.register(false)
 // z enter
 class ScrollCursorToTop extends ScrollCursor {
   isScrollable() {
-    return this.editor.getLastVisibleScreenRow() !== this.editor.getLastScreenRow()
+    return (
+      atom.config.get("editor.scrollPastEnd") ||
+      this.editor.getLastVisibleScreenRow() !== this.editor.getLastScreenRow()
+    )
   }
 
   getScrollTop() {


### PR DESCRIPTION
Allow the `ScrollCursorToTop` command to scroll past the end of the last line when the appropriate editor config is enabled. This aligns `vim-mode-plus` closer to native vim. Fixes #896.