### PR TITLE
Replace special earlySelect care by simply allowing async execution for surround, replace

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -140,6 +140,12 @@ class Base {
     this.vimState.focusInput(options)
   }
 
+  focusInputPromisified({hideCursor}) {
+    return new Promise((onConfirm, onCancel) => {
+      this.vimState.focusInput({onConfirm, onCancel, hideCursor})
+    })
+  }
+
   readChar() {
     this.vimState.readChar({
       onConfirm: input => {

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -200,22 +200,8 @@ module.exports = class OperationStack {
   }
 
   cancel(operation) {
-    let cursorPositionRestored = false
-
-    // NOTE: `change-surround-any-pair` might be cancelled without entering
-    // operator-pending when it fail to detect any-pair range.
-    if (operation.getBufferCheckpoint) {
-      const undoCheckpoint = operation.getBufferCheckpoint("undo")
-      if (undoCheckpoint) {
-        this.editor.revertToCheckpoint(undoCheckpoint)
-        cursorPositionRestored = true
-      }
-    }
-
     if (this.mode === "operator-pending") {
-      if (!cursorPositionRestored) {
-        this.vimState.mutationManager.restoreCursorsToInitialPosition()
-      }
+      this.vimState.mutationManager.restoreCursorsToInitialPosition()
       this.modeManager.activate("normal")
     }
     this.finish(operation, true)
@@ -244,6 +230,7 @@ module.exports = class OperationStack {
     }
 
     this.vimState.cursorStyleManager.refresh()
+    // console.log('DONE!');
     this.vimState.reset()
   }
 

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -200,8 +200,20 @@ module.exports = class OperationStack {
   }
 
   cancel(operation) {
+    let cursorPositionRestored = false
+
+    // NOTE: `change-surround-any-pair` might be cancelled without entering
+    // operator-pending when it fail to detect any-pair range.
+    const undoCheckpoint = operation.getBufferCheckpoint("undo")
+    if (undoCheckpoint) {
+      this.editor.revertToCheckpoint(undoCheckpoint)
+      cursorPositionRestored = true
+    }
+
     if (this.mode === "operator-pending") {
-      this.vimState.mutationManager.restoreCursorsToInitialPosition()
+      if (!cursorPositionRestored) {
+        this.vimState.mutationManager.restoreCursorsToInitialPosition()
+      }
       this.modeManager.activate("normal")
     }
     this.finish(operation, true)

--- a/lib/operation-stack.js
+++ b/lib/operation-stack.js
@@ -204,10 +204,12 @@ module.exports = class OperationStack {
 
     // NOTE: `change-surround-any-pair` might be cancelled without entering
     // operator-pending when it fail to detect any-pair range.
-    const undoCheckpoint = operation.getBufferCheckpoint("undo")
-    if (undoCheckpoint) {
-      this.editor.revertToCheckpoint(undoCheckpoint)
-      cursorPositionRestored = true
+    if (operation.getBufferCheckpoint) {
+      const undoCheckpoint = operation.getBufferCheckpoint("undo")
+      if (undoCheckpoint) {
+        this.editor.revertToCheckpoint(undoCheckpoint)
+        cursorPositionRestored = true
+      }
     }
 
     if (this.mode === "operator-pending") {

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -628,12 +628,12 @@ class SurroundBase extends TransformString {
     }
   }
 
-  async focusInputPromisified() {
+  async focusInputPromisified(...args) {
     if (this.surroundAction === "change-surround") {
       const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
       this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
     }
-    return this.super()
+    return super.focusInputPromisified(...args)
   }
 }
 SurroundBase.register(false)

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -83,15 +83,8 @@ LowerCase.register()
 // -------------------------
 class Replace extends TransformString {
   flashCheckpoint = "did-select-occurrence"
-  input = null
-  requireInput = true
   autoIndentNewline = true
-  supportEarlySelect = true
-
-  initialize() {
-    this.onDidSelectTarget(() => this.focusInput({hideCursor: true}))
-    super.initialize()
-  }
+  readInputAfterExecute = true
 
   getNewText(text) {
     if (this.target.is("MoveRightBufferColumn") && text.length !== this.getCount()) {
@@ -587,6 +580,7 @@ ReflowWithStay.register()
 // Surround < TransformString
 // -------------------------
 class SurroundBase extends TransformString {
+  surroundAction = null
   pairs = [["(", ")"], ["{", "}"], ["[", "]"], ["<", ">"]]
   pairsByAlias = {
     b: ["(", ")"],
@@ -595,21 +589,7 @@ class SurroundBase extends TransformString {
     a: ["<", ">"],
   }
 
-  pairCharsAllowForwarding = "[](){}"
-  input = null
-  requireInput = true
-  supportEarlySelect = true
-
-  focusInputForSurroundChar() {
-    this.focusInput({hideCursor: true})
-  }
-
-  focusInputForTargetPairChar() {
-    this.focusInput({onConfirm: char => this.onConfirmTargetPairChar(char)})
-  }
-
   getPair(char) {
-    let pair
     return char in this.pairsByAlias
       ? this.pairsByAlias[char]
       : [...this.pairs, [char, char]].find(pair => pair.includes(char))
@@ -638,21 +618,29 @@ class SurroundBase extends TransformString {
     return this.utils.isSingleLineText(text) && open !== close ? innerText.trim() : innerText
   }
 
-  onConfirmTargetPairChar(char) {
-    this.setTarget(this.getInstance("APair", {pair: this.getPair(char)}))
+  getNewText(text) {
+    if (this.surroundAction === "surround") {
+      return this.surround(text, this.input)
+    } else if (this.surroundAction === "delete-surround") {
+      return this.deleteSurround(text)
+    } else if (this.surroundAction === "change-surround") {
+      return this.surround(this.deleteSurround(text), this.input, {keepLayout: true})
+    }
+  }
+
+  async focusInputPromisified() {
+    if (this.surroundAction === "change-surround") {
+      const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
+      this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
+    }
+    return this.super()
   }
 }
 SurroundBase.register(false)
 
 class Surround extends SurroundBase {
-  initialize() {
-    this.onDidSelectTarget(() => this.focusInputForSurroundChar())
-    super.initialize()
-  }
-
-  getNewText(text) {
-    return this.surround(text, this.input)
-  }
+  surroundAction = "surround"
+  readInputAfterExecute = true
 }
 Surround.register()
 
@@ -675,28 +663,23 @@ MapSurround.register()
 // Delete Surround
 // -------------------------
 class DeleteSurround extends SurroundBase {
+  surroundAction = "delete-surround"
   initialize() {
     if (!this.target) {
-      this.focusInputForTargetPairChar()
+      this.focusInput({
+        onConfirm: char => {
+          this.setTarget(this.getInstance("APair", {pair: this.getPair(char)}))
+          this.processOperation()
+        },
+      })
     }
     super.initialize()
-  }
-
-  onConfirmTargetPairChar(char) {
-    super.onConfirmTargetPairChar(char)
-    this.input = char
-    this.processOperation()
-  }
-
-  getNewText(text) {
-    return this.deleteSurround(text)
   }
 }
 DeleteSurround.register()
 
 class DeleteSurroundAnyPair extends DeleteSurround {
   target = "AAnyPair"
-  requireInput = false
 }
 DeleteSurroundAnyPair.register()
 
@@ -707,32 +690,9 @@ DeleteSurroundAnyPairAllowForwarding.register()
 
 // Change Surround
 // -------------------------
-class ChangeSurround extends SurroundBase {
-  showDeleteCharOnHover() {
-    const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
-    const char = this.editor.getSelectedText()[0]
-    this.vimState.hover.set(char, hoverPoint)
-  }
-
-  initialize() {
-    if (this.target) {
-      this.onDidFailSelectTarget(() => this.abort())
-    } else {
-      this.onDidFailSelectTarget(() => this.cancelOperation())
-      this.focusInputForTargetPairChar()
-    }
-
-    this.onDidSelectTarget(() => {
-      this.showDeleteCharOnHover()
-      this.focusInputForSurroundChar()
-    })
-    super.initialize()
-  }
-
-  getNewText(text) {
-    const innerText = this.deleteSurround(text)
-    return this.surround(innerText, this.input, {keepLayout: true})
-  }
+class ChangeSurround extends DeleteSurround {
+  surroundAction = "change-surround"
+  readInputAfterExecute = true
 }
 ChangeSurround.register()
 

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -627,14 +627,6 @@ class SurroundBase extends TransformString {
       return this.surround(this.deleteSurround(text), this.input, {keepLayout: true})
     }
   }
-
-  async focusInputPromisified(...args) {
-    if (this.surroundAction === "change-surround") {
-      const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
-      this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
-    }
-    return super.focusInputPromisified(...args)
-  }
 }
 SurroundBase.register(false)
 
@@ -693,6 +685,13 @@ DeleteSurroundAnyPairAllowForwarding.register()
 class ChangeSurround extends DeleteSurround {
   surroundAction = "change-surround"
   readInputAfterExecute = true
+
+  // Override to show changing char on hover
+  async focusInputPromisified(...args) {
+    const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
+    this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
+    return super.focusInputPromisified(...args)
+  }
 }
 ChangeSurround.register()
 

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -29,7 +29,6 @@ class Operator extends Base {
   acceptPersistentSelection = true
 
   bufferCheckpointByPurpose = null
-  mutateSelectionOrderd = false
 
   supportEarlySelect = false // allow selectTarget before input complete
   targetSelected = null
@@ -271,13 +270,11 @@ class Operator extends Base {
       // - Skip selection normalization: already normalized before @selectTarget()
       // - Manual checkpoint grouping: to create checkpoint before @selectTarget()
       fn()
-      this.emitWillFinishMutation()
       this.groupChangesSinceBufferCheckpoint("undo")
     } else {
       this.normalizeSelectionsIfNecessary()
       this.editor.transact(() => {
         fn()
-        this.emitWillFinishMutation()
       })
     }
 
@@ -288,11 +285,7 @@ class Operator extends Base {
   execute() {
     this.startMutation(() => {
       if (this.selectTarget()) {
-        const selections = this.mutateSelectionOrderd
-          ? this.editor.getSelectionsOrderedByBufferPosition()
-          : this.editor.getSelections()
-
-        for (const selection of selections) {
+        for (const selection of this.editor.getSelectionsOrderedByBufferPosition()) {
           this.mutateSelection(selection)
         }
         this.mutationManager.setCheckpoint("did-finish")
@@ -671,7 +664,6 @@ Decrease.register()
 class IncrementNumber extends Increase {
   baseNumber = null
   target = null
-  mutateSelectionOrderd = true
 
   getNextNumber(numberString) {
     if (this.baseNumber != null) {

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -30,8 +30,8 @@ class Operator extends Base {
 
   bufferCheckpointByPurpose = null
 
-  supportEarlySelect = false // allow selectTarget before input complete
   targetSelected = null
+  readInputAfterExecute = false
 
   // Called when operation finished
   // This is essentially to reset state for `.` repeat.
@@ -198,12 +198,6 @@ class Operator extends Base {
     this.target = target
     this.target.operator = this
     this.emitDidSetTarget(this)
-
-    if (this.supportEarlySelect) {
-      this.normalizeSelectionsIfNecessary()
-      this.createBufferCheckpoint("undo")
-      this.selectTarget()
-    }
   }
 
   setTextToRegisterForSelection(selection) {
@@ -266,35 +260,50 @@ class Operator extends Base {
   }
 
   startMutation(fn) {
-    if (this.targetSelected != null) {
-      // - Skip selection normalization: already normalized before @selectTarget()
-      // - Manual checkpoint grouping: to create checkpoint before @selectTarget()
-      fn()
-      this.groupChangesSinceBufferCheckpoint("undo")
-    } else {
-      this.normalizeSelectionsIfNecessary()
-      this.editor.transact(() => {
-        fn()
-      })
-    }
-
+    this.normalizeSelectionsIfNecessary()
+    this.editor.transact(fn)
     this.emitDidFinishMutation()
+  }
+
+  mutateSelections() {
+    for (const selection of this.editor.getSelectionsOrderedByBufferPosition()) {
+      this.mutateSelection(selection)
+    }
+    this.mutationManager.setCheckpoint("did-finish")
+    this.restoreCursorPositionsIfNecessary()
   }
 
   // Main
   execute() {
+    if (this.readInputAfterExecute && !this.repeated) {
+      return this.executeAsyncToReadInputAfterExecute()
+    }
+
     this.startMutation(() => {
-      if (this.selectTarget()) {
-        for (const selection of this.editor.getSelectionsOrderedByBufferPosition()) {
-          this.mutateSelection(selection)
-        }
-        this.mutationManager.setCheckpoint("did-finish")
-        this.restoreCursorPositionsIfNecessary()
-      }
+      if (this.selectTarget()) this.mutateSelections()
     })
 
     // Even though we fail to select target and fail to mutate,
     // we have to return to normal-mode from operator-pending or visual
+    this.activateMode("normal")
+  }
+
+  async executeAsyncToReadInputAfterExecute() {
+    this.normalizeSelectionsIfNecessary()
+    this.createBufferCheckpoint("undo")
+
+    if (this.selectTarget()) {
+      try {
+        this.input = await this.focusInputPromisified({hideCursor: true})
+      } catch (e) {
+        this.cancelOperation()
+        return
+      }
+      this.mutateSelections()
+      this.groupChangesSinceBufferCheckpoint("undo")
+    }
+
+    this.emitDidFinishMutation()
     this.activateMode("normal")
   }
 

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -296,10 +296,10 @@ class Operator extends Base {
       try {
         this.input = await this.focusInputPromisified({hideCursor: true})
       } catch (e) {
-        if (this.mode === "visual") {
-          this.deleteBufferCheckpoint("undo")
+        if (this.mode !== "visual") {
+          this.editor.revertToCheckpoint(this.getBufferCheckpoint("undo"))
+          this.activateMode("normal")
         }
-        this.cancelOperation()
         return
       }
       this.mutateSelections()

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -296,6 +296,9 @@ class Operator extends Base {
       try {
         this.input = await this.focusInputPromisified({hideCursor: true})
       } catch (e) {
+        if (this.mode === "visual") {
+          this.deleteBufferCheckpoint("undo")
+        }
         this.cancelOperation()
         return
       }

--- a/spec/insert-mode-spec.coffee
+++ b/spec/insert-mode-spec.coffee
@@ -19,7 +19,7 @@ describe "Insert mode commands", ->
           efghi
           """
         cursor: [[1, 0], [3, 0]]
-      ensure 'i', {}
+      ensure 'i'
 
     describe "the ctrl-y command", ->
       it "copies from the line above", ->
@@ -66,7 +66,7 @@ describe "Insert mode commands", ->
           """
 
         editor.insertText 'a'
-        ensure
+        ensure null,
           textC: """
             12a|345
 
@@ -124,7 +124,7 @@ describe "Insert mode commands", ->
     describe "InsertLastInserted", ->
       ensureInsertLastInserted = (key, options) ->
         {insert, text, finalText} = options
-        ensure key, {}
+        ensure key
         editor.insertText(insert)
         ensure "escape", text: text
         ensure "G I ctrl-a", text: finalText
@@ -139,7 +139,7 @@ describe "Insert mode commands", ->
           def\n
           """
         set text: "", cursor: [0, 0]
-        ensure 'i', {}
+        ensure 'i'
         editor.insertText(initialText)
         ensure "escape g g",
           text: initialText

--- a/spec/insert-mode-spec.coffee
+++ b/spec/insert-mode-spec.coffee
@@ -1,13 +1,13 @@
 {getVimState} = require './spec-helper'
 
 describe "Insert mode commands", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (_vimState, vim) ->
       vimState = _vimState
       {editor, editorElement} = _vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
   describe "Copy from line above/below", ->
     beforeEach ->
@@ -19,7 +19,7 @@ describe "Insert mode commands", ->
           efghi
           """
         cursor: [[1, 0], [3, 0]]
-      keystroke 'i'
+      ensure 'i', {}
 
     describe "the ctrl-y command", ->
       it "copies from the line above", ->
@@ -124,7 +124,7 @@ describe "Insert mode commands", ->
     describe "InsertLastInserted", ->
       ensureInsertLastInserted = (key, options) ->
         {insert, text, finalText} = options
-        keystroke key
+        ensure key, {}
         editor.insertText(insert)
         ensure "escape", text: text
         ensure "G I ctrl-a", text: finalText
@@ -139,7 +139,7 @@ describe "Insert mode commands", ->
           def\n
           """
         set text: "", cursor: [0, 0]
-        keystroke 'i'
+        ensure 'i', {}
         editor.insertText(initialText)
         ensure "escape g g",
           text: initialText

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "Motion Find", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     settings.set('useExperimentalFasterInput', true)
@@ -11,7 +11,7 @@ describe "Motion Find", ->
     getVimState (state, _vim) ->
       vimState = state # to refer as vimState later.
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
 
   xdescribe 'the f performance', ->
     timesToExecute = 500
@@ -39,7 +39,7 @@ describe "Motion Find", ->
 
       it '[with keybind] moves to l char', ->
         testPerformanceOfKeybind = ->
-          keystroke "f l" for n in [1..timesToExecute]
+          ensure("f l", {}) for n in [1..timesToExecute]
           ensure cursor: [0, timesToExecute + 1]
 
         console.log "== keybind"
@@ -52,7 +52,7 @@ describe "Motion Find", ->
     xdescribe '[with hidden-input] moves to l char', ->
       it '[with hidden-input] moves to l char', ->
         testPerformanceOfHiddenInput = ->
-          keystroke 'f l' for n in [1..timesToExecute]
+          ensure('f l', {}) for n in [1..timesToExecute]
           ensure cursor: [0, timesToExecute + 1]
 
         console.log "== hidden"
@@ -291,12 +291,12 @@ describe "Motion Find", ->
 
       # replay same find in the other editor
       pane.activateItem(otherEditor)
-      other.keystroke ';'
+      other.ensure ';', {}
       ensure cursor: [0, 2]
       other.ensure cursor: [0, 4]
 
       # do a till in the other editor
-      other.keystroke 't r'
+      other.ensure 't r', {}
       ensure cursor: [0, 2]
       other.ensure cursor: [0, 5]
 
@@ -394,7 +394,7 @@ describe "Motion Find", ->
       describe "can find one or two char", ->
         it "adjust to next-pre-confirmed", ->
           set                 textC: "|    a    ab    a    cd    a"
-          keystroke "f a"
+          ensure "f a", {}
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
@@ -404,7 +404,7 @@ describe "Motion Find", ->
           set                   textC: "|    a    ab    a    cd    a"
           ensure "3 f a enter", textC: "    a    ab    |a    cd    a"
           set                   textC: "|    a    ab    a    cd    a"
-          keystroke "3 f a"
+          ensure "3 f a", {}
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
           dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
@@ -412,7 +412,7 @@ describe "Motion Find", ->
 
         it "is useful to skip earlier spot interactivelly", ->
           set  textC: 'text = "this is |\"example\" of use case"'
-          keystroke 'c t "'
+          ensure 'c t "', {}
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab

--- a/spec/motion-find-spec.coffee
+++ b/spec/motion-find-spec.coffee
@@ -39,8 +39,8 @@ describe "Motion Find", ->
 
       it '[with keybind] moves to l char', ->
         testPerformanceOfKeybind = ->
-          ensure("f l", {}) for n in [1..timesToExecute]
-          ensure cursor: [0, timesToExecute + 1]
+          ensure("f l") for n in [1..timesToExecute]
+          ensure null, cursor: [0, timesToExecute + 1]
 
         console.log "== keybind"
         ensure "f l", cursor: [0, 2]
@@ -52,8 +52,8 @@ describe "Motion Find", ->
     xdescribe '[with hidden-input] moves to l char', ->
       it '[with hidden-input] moves to l char', ->
         testPerformanceOfHiddenInput = ->
-          ensure('f l', {}) for n in [1..timesToExecute]
-          ensure cursor: [0, timesToExecute + 1]
+          ensure('f l') for n in [1..timesToExecute]
+          ensure null, cursor: [0, timesToExecute + 1]
 
         console.log "== hidden"
         ensure 'f l', cursor: [0, 2]
@@ -287,27 +287,27 @@ describe "Motion Find", ->
 
     it "shares the most recent find/till command with other editors", ->
       ensure 'f b', cursor: [0, 2]
-      other.ensure cursor: [0, 0]
+      other.ensure null, cursor: [0, 0]
 
       # replay same find in the other editor
       pane.activateItem(otherEditor)
-      other.ensure ';', {}
-      ensure cursor: [0, 2]
-      other.ensure cursor: [0, 4]
+      other.ensure ';'
+      ensure null, cursor: [0, 2]
+      other.ensure null, cursor: [0, 4]
 
       # do a till in the other editor
-      other.ensure 't r', {}
-      ensure cursor: [0, 2]
-      other.ensure cursor: [0, 5]
+      other.ensure 't r'
+      ensure null, cursor: [0, 2]
+      other.ensure null, cursor: [0, 5]
 
       # and replay in the normal editor
       pane.activateItem(editor)
       ensure ';', cursor: [0, 7]
-      other.ensure cursor: [0, 5]
+      other.ensure null, cursor: [0, 5]
 
     it "is still repeatable after original editor was destroyed", ->
       ensure 'f b', cursor: [0, 2]
-      other.ensure cursor: [0, 0]
+      other.ensure null, cursor: [0, 0]
 
       pane.activateItem(otherEditor)
       editor.destroy()
@@ -394,7 +394,7 @@ describe "Motion Find", ->
       describe "can find one or two char", ->
         it "adjust to next-pre-confirmed", ->
           set                 textC: "|    a    ab    a    cd    a"
-          ensure "f a", {}
+          ensure "f a"
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed")
@@ -404,7 +404,7 @@ describe "Motion Find", ->
           set                   textC: "|    a    ab    a    cd    a"
           ensure "3 f a enter", textC: "    a    ab    |a    cd    a"
           set                   textC: "|    a    ab    a    cd    a"
-          ensure "3 f a", {}
+          ensure "3 f a"
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
           dispatch(element, "vim-mode-plus:find-previous-pre-confirmed")
@@ -412,7 +412,7 @@ describe "Motion Find", ->
 
         it "is useful to skip earlier spot interactivelly", ->
           set  textC: 'text = "this is |\"example\" of use case"'
-          ensure 'c t "', {}
+          ensure 'c t "'
           element = vimState.inputEditor.element
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab
           dispatch(element, "vim-mode-plus:find-next-pre-confirmed") # tab
@@ -460,14 +460,14 @@ describe "Motion Find", ->
 
           ensure "f a",   textC: "|    a    ab    a    cd    a"
           advanceClock(500)
-          ensure          textC: "    |a    ab    a    cd    a"
+          ensure null,    textC: "    |a    ab    a    cd    a"
 
           ensure "f c d", textC: "    a    ab    a    |cd    a"
 
           ensure "f a",   textC: "    a    ab    a    |cd    a"
           advanceClock(500)
-          ensure          textC: "    a    ab    a    cd    |a"
+          ensure null,    textC: "    a    ab    a    cd    |a"
 
           ensure "F b",   textC: "    a    ab    a    cd    |a"
           advanceClock(500)
-          ensure          textC: "    a    a|b    a    cd    a"
+          ensure null,    textC: "    a    a|b    a    cd    a"

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -10,13 +10,13 @@ setEditorWidthInCharacters = (editor, widthInCharacters) ->
   return component.getNextUpdatePromise()
 
 describe "Motion general", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, _vim) ->
       vimState = state # to refer as vimState later.
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
 
   describe "simple motions", ->
     text = null
@@ -75,7 +75,7 @@ describe "Motion general", ->
           ensure 'j', cursor: [2, 2], selectedText: "bcd\nAB"
 
         it "keep same column(goalColumn) even after across the empty line", ->
-          keystroke 'escape'
+          ensure 'escape', {}
           set
             text: """
               abcdefg
@@ -410,7 +410,7 @@ describe "Motion general", ->
 
           getVimState 'sample.go', (state, vimEditor) ->
             {editor, editorElement} = state
-            {set, ensure, keystroke} = vimEditor
+            {set, ensure} = vimEditor
 
           runs ->
             set cursorScreen: [8, 2]
@@ -1507,7 +1507,7 @@ describe "Motion general", ->
           set
             text: startingText
             cursor: startingCursorPosition
-          keystroke '+'
+          ensure '+', {}
           referenceCursorPosition = editor.getCursorScreenPosition()
           set
             text: startingText
@@ -1522,7 +1522,7 @@ describe "Motion general", ->
             text: startingText
             cursor: startingCursorPosition
 
-          keystroke 'd +'
+          ensure 'd +', {}
           referenceText = editor.getText()
           referenceCursorPosition = editor.getCursorScreenPosition()
 
@@ -1759,37 +1759,37 @@ describe "Motion general", ->
 
     it 'moves to the beginning of the line of a mark', ->
       set cursor: [1, 1]
-      keystroke 'm a'
+      ensure 'm a', {}
       set cursor: [0, 0]
       ensure "' a", cursor: [1, 4]
 
     it 'moves literally to a mark', ->
       set cursor: [1, 2]
-      keystroke 'm a'
+      ensure 'm a', {}
       set cursor: [0, 0]
       ensure '` a', cursor: [1, 2]
 
     it 'deletes to a mark by line', ->
       set cursor: [1, 5]
-      keystroke 'm a'
+      ensure 'm a', {}
       set cursor: [0, 0]
       ensure "d ' a", text: '56\n'
 
     it 'deletes before to a mark literally', ->
       set cursor: [1, 5]
-      keystroke 'm a'
+      ensure 'm a', {}
       set cursor: [0, 2]
       ensure 'd ` a', text: '  4\n56\n'
 
     it 'deletes after to a mark literally', ->
       set cursor: [1, 5]
-      keystroke 'm a'
+      ensure 'm a', {}
       set cursor: [2, 1]
       ensure 'd ` a', text: '  12\n    36\n'
 
     it 'moves back to previous', ->
       set cursor: [1, 5]
-      keystroke '` `'
+      ensure '` `', {}
       set cursor: [2, 1]
       ensure '` `', cursor: [1, 5]
 
@@ -1934,7 +1934,7 @@ describe "Motion general", ->
         atom.packages.activatePackage('language-coffee-script')
       getVimState 'sample.coffee', (state, vim) ->
         {editor, editorElement} = state
-        {set, ensure, keystroke} = vim
+        {set, ensure} = vim
 
       runs ->
         atom.keymaps.add "test",
@@ -2039,7 +2039,7 @@ describe "Motion general", ->
 
         getVimState 'sample.go', (state, vimEditor) ->
           {editor, editorElement} = state
-          {set, ensure, keystroke} = vimEditor
+          {set, ensure} = vimEditor
 
       afterEach ->
         atom.packages.deactivatePackage(pack)

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -75,7 +75,7 @@ describe "Motion general", ->
           ensure 'j', cursor: [2, 2], selectedText: "bcd\nAB"
 
         it "keep same column(goalColumn) even after across the empty line", ->
-          ensure 'escape', {}
+          ensure 'escape'
           set
             text: """
               abcdefg
@@ -415,7 +415,7 @@ describe "Motion general", ->
           runs ->
             set cursorScreen: [8, 2]
             # In hardTab indent bufferPosition is not same as screenPosition
-            ensure cursor: [8, 1]
+            ensure null, cursor: [8, 1]
 
         afterEach ->
           atom.packages.deactivatePackage(pack)
@@ -453,7 +453,7 @@ describe "Motion general", ->
           222\n
           """
       originalText = editor.getText()
-      ensure register: {'"': text: undefined}
+      ensure null, register: {'"': text: undefined}
 
     describe "moveSuccessOnLinewise=false motion", ->
       describe "when it can move", ->
@@ -804,7 +804,7 @@ describe "Motion general", ->
         set text: "cet document", cursor: [0, 7]
         ensure 'c g e', cursor: [0, 2], text: "cement", mode: 'insert'
         # TODO: I'm not sure how to check the register after checking the document
-        # ensure register: '"', text: 't docu'
+        # ensure null, register: '"', text: 't docu'
 
       it "changes whitespace properly", ->
         set text: "ce    doc", cursor: [0, 4]
@@ -1364,7 +1364,7 @@ describe "Motion general", ->
         it "selects to the first character of the previous line (directly above)", ->
           ensure 'd -', text: "abcdefg\n"
           # FIXME commented out because the column is wrong due to a bug in `k`; re-enable when `k` is fixed
-          # ensure cursor: [0, 2]
+          # ensure null, cursor: [0, 2]
 
     describe "from the beginning of a line preceded by an indented line", ->
       beforeEach ->
@@ -1507,7 +1507,7 @@ describe "Motion general", ->
           set
             text: startingText
             cursor: startingCursorPosition
-          ensure '+', {}
+          ensure '+'
           referenceCursorPosition = editor.getCursorScreenPosition()
           set
             text: startingText
@@ -1522,7 +1522,7 @@ describe "Motion general", ->
             text: startingText
             cursor: startingCursorPosition
 
-          ensure 'd +', {}
+          ensure 'd +'
           referenceText = editor.getText()
           referenceCursorPosition = editor.getCursorScreenPosition()
 
@@ -1759,44 +1759,44 @@ describe "Motion general", ->
 
     it 'moves to the beginning of the line of a mark', ->
       set cursor: [1, 1]
-      ensure 'm a', {}
+      ensure 'm a'
       set cursor: [0, 0]
       ensure "' a", cursor: [1, 4]
 
     it 'moves literally to a mark', ->
       set cursor: [1, 2]
-      ensure 'm a', {}
+      ensure 'm a'
       set cursor: [0, 0]
       ensure '` a', cursor: [1, 2]
 
     it 'deletes to a mark by line', ->
       set cursor: [1, 5]
-      ensure 'm a', {}
+      ensure 'm a'
       set cursor: [0, 0]
       ensure "d ' a", text: '56\n'
 
     it 'deletes before to a mark literally', ->
       set cursor: [1, 5]
-      ensure 'm a', {}
+      ensure 'm a'
       set cursor: [0, 2]
       ensure 'd ` a', text: '  4\n56\n'
 
     it 'deletes after to a mark literally', ->
       set cursor: [1, 5]
-      ensure 'm a', {}
+      ensure 'm a'
       set cursor: [2, 1]
       ensure 'd ` a', text: '  12\n    36\n'
 
     it 'moves back to previous', ->
       set cursor: [1, 5]
-      ensure '` `', {}
+      ensure '` `'
       set cursor: [2, 1]
       ensure '` `', cursor: [1, 5]
 
   describe "jump command update ` and ' mark", ->
     ensureJumpMark = (value) ->
-      ensure mark: "`": value
-      ensure mark: "'": value
+      ensure null, mark: "`": value
+      ensure null, mark: "'": value
 
     ensureJumpAndBack = (keystroke, option) ->
       afterMove = option.cursor
@@ -1842,8 +1842,8 @@ describe "Motion general", ->
 
     describe "initial state", ->
       it "return [0, 0]", ->
-        ensure mark: "'": [0, 0]
-        ensure mark: "`": [0, 0]
+        ensure null, mark: "'": [0, 0]
+        ensure null, mark: "`": [0, 0]
 
     describe "jump motion in normal-mode", ->
       initial = [3, 3]
@@ -1856,8 +1856,8 @@ describe "Motion general", ->
           component.element.style.height = component.getLineHeight() * editor.getLineCount() + 'px'
           editorElement.measureDimensions()
 
-        ensure mark: "'": [0, 0]
-        ensure mark: "`": [0, 0]
+        ensure null, mark: "'": [0, 0]
+        ensure null, mark: "`": [0, 0]
         set cursor: initial
 
       it "G jump&back", -> ensureJumpAndBack 'G', cursor: [5, 3]

--- a/spec/motion-scroll-spec.coffee
+++ b/spec/motion-scroll-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "Motion Scroll", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
   lines = (n + " " + 'X'.repeat(10) for n in [0...100]).join("\n")
   text = new TextData(lines)
 
@@ -10,7 +10,7 @@ describe "Motion Scroll", ->
     getVimState (state, _vim) ->
       vimState = state # to refer as vimState later.
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
 
     runs ->
       jasmine.attachToDOM(editorElement)

--- a/spec/motion-scroll-spec.coffee
+++ b/spec/motion-scroll-spec.coffee
@@ -93,7 +93,7 @@ describe "Motion Scroll", ->
     beforeEach ->
       settings.set('stayOnVerticalMotion', true)
       set cursor: [42, 10]
-      ensure scrollTop: 400
+      ensure null, scrollTop: 400
 
     it "go to row with keep column and respect cursor.goalColum", ->
       ensure 'ctrl-b', scrollTop: 200, cursor: [22, 10]

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -2,14 +2,14 @@
 settings = require '../lib/settings'
 
 describe "Motion Search", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     jasmine.attachToDOM(getView(atom.workspace))
     getVimState (state, _vim) ->
       vimState = state # to refer as vimState later.
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
 
   describe "the / keybinding", ->
     pane = null
@@ -139,7 +139,7 @@ describe "Motion Search", ->
 
       describe "repeating with search history", ->
         beforeEach ->
-          keystroke '/ def enter'
+          ensure '/ def enter', {}
 
         it "repeats previous search with /<enter>", ->
           ensure '/  enter', cursor: [3, 0]
@@ -182,7 +182,7 @@ describe "Motion Search", ->
 
       describe "repeating", ->
         beforeEach ->
-          keystroke '? def enter'
+          ensure '? def enter', {}
 
         it "repeats previous search as reversed with ?<enter>", ->
           ensure "? enter", cursor: [1, 0]
@@ -216,13 +216,13 @@ describe "Motion Search", ->
         inputEditor = vimState.searchInput.editorElement
 
       it "allows searching history in the search field", ->
-        keystroke '/'
+        ensure '/', {}
         ensureInputEditor 'core:move-up', text: 'abc'
         ensureInputEditor 'core:move-up', text: 'def'
         ensureInputEditor 'core:move-up', text: 'def'
 
       it "resets the search field to empty when scrolling back", ->
-        keystroke '/'
+        ensure '/', {}
         ensureInputEditor 'core:move-up', text: 'abc'
         ensureInputEditor 'core:move-up', text: 'def'
         ensureInputEditor 'core:move-down', text: 'abc'

--- a/spec/motion-search-spec.coffee
+++ b/spec/motion-search-spec.coffee
@@ -139,7 +139,7 @@ describe "Motion Search", ->
 
       describe "repeating with search history", ->
         beforeEach ->
-          ensure '/ def enter', {}
+          ensure '/ def enter'
 
         it "repeats previous search with /<enter>", ->
           ensure '/  enter', cursor: [3, 0]
@@ -182,7 +182,7 @@ describe "Motion Search", ->
 
       describe "repeating", ->
         beforeEach ->
-          ensure '? def enter', {}
+          ensure '? def enter'
 
         it "repeats previous search as reversed with ?<enter>", ->
           ensure "? enter", cursor: [1, 0]
@@ -216,13 +216,13 @@ describe "Motion Search", ->
         inputEditor = vimState.searchInput.editorElement
 
       it "allows searching history in the search field", ->
-        ensure '/', {}
+        ensure '/'
         ensureInputEditor 'core:move-up', text: 'abc'
         ensureInputEditor 'core:move-up', text: 'def'
         ensureInputEditor 'core:move-up', text: 'def'
 
       it "resets the search field to empty when scrolling back", ->
-        ensure '/', {}
+        ensure '/'
         ensureInputEditor 'core:move-up', text: 'abc'
         ensureInputEditor 'core:move-up', text: 'def'
         ensureInputEditor 'core:move-down', text: 'abc'
@@ -242,7 +242,7 @@ describe "Motion Search", ->
           expect(text).toEqual(options.text)
 
         if options.mode?
-          ensure {mode: options.mode}
+          ensure null, {mode: options.mode}
 
       beforeEach ->
         jasmine.attachToDOM(getView(atom.workspace))

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "Occurrence", ->
-  [set, ensure, ensureWait, keystroke, editor, editorElement, vimState, classList] = []
+  [set, ensure, ensureWait, editor, editorElement, vimState, classList] = []
   [searchEditor, searchEditorElement] = []
   inputSearchText = (text) ->
     searchEditor.insertText(text)
@@ -13,7 +13,7 @@ describe "Occurrence", ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, ensureWait, keystroke} = vim
+      {set, ensure, ensureWait} = vim
       classList = editorElement.classList
       searchEditor = vimState.searchInput.editor
       searchEditorElement = vimState.searchInput.editorElement
@@ -179,7 +179,7 @@ describe "Occurrence", ->
             """
         it "not clip if original cursor not intersects any occurence-marker", ->
           ensure 'g o', occurrenceText: ['ooo', 'ooo', 'ooo'], cursor: [1, 2]
-          keystroke 'j', cursor: [2, 2]
+          ensure 'j', cursor: [2, 2]
           ensure "d p",
             textC: """
 
@@ -360,7 +360,7 @@ describe "Occurrence", ->
 
     describe "from normal mode", ->
       it "select occurrence by pattern match", ->
-        keystroke '/'
+        ensure '/', {}
         inputSearchText('\\d{3,4}')
         dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
         ensure 'i e',
@@ -368,7 +368,7 @@ describe "Occurrence", ->
           mode: ['visual', 'characterwise']
 
       it "change occurrence by pattern match", ->
-        keystroke '/'
+        ensure '/', {}
         inputSearchText('^\\w+:')
         dispatchSearchCommand('vim-mode-plus:change-occurrence-from-search')
         ensure 'i e', mode: 'insert'
@@ -384,7 +384,7 @@ describe "Occurrence", ->
     describe "from visual mode", ->
       describe "visual characterwise", ->
         it "change occurrence in narrowed selection", ->
-          keystroke 'v j /'
+          ensure 'v j /', {}
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -397,7 +397,7 @@ describe "Occurrence", ->
 
       describe "visual linewise", ->
         it "change occurrence in narrowed selection", ->
-          keystroke 'V j /'
+          ensure 'V j /', {}
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -411,7 +411,7 @@ describe "Occurrence", ->
       describe "visual blockwise", ->
         it "change occurrence in narrowed selection", ->
           set cursor: [0, 5]
-          keystroke 'ctrl-v 2 j 1 0 l /'
+          ensure 'ctrl-v 2 j 1 0 l /', {}
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -446,7 +446,7 @@ describe "Occurrence", ->
       describe "when no selection is exists", ->
         it "select occurrence in all persistent-selection", ->
           set cursor: [0, 0]
-          keystroke '/'
+          ensure '/', {}
           inputSearchText('xxx')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -461,7 +461,7 @@ describe "Occurrence", ->
       describe "when both exits, operator applied to both", ->
         it "select all occurrence in selection", ->
           set cursor: [0, 0]
-          keystroke 'V 2 j /'
+          ensure 'V 2 j /', {}
           inputSearchText('xxx')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -515,11 +515,12 @@ describe "Occurrence", ->
         ensure 'j f =', cursor: [1, 17]
 
         runs ->
-          keystroke [
+          _keystroke = [
             'g cmd-d' # select-occurrence
             'i f'     # inner-function-text-object
             'm'       # toggle-persistent-selection
           ].join(" ")
+          ensure(_keystroke, {})
 
           textsInBufferRange = vimState.persistentSelection.getMarkerBufferRanges().map (range) ->
             editor.getTextInBufferRange(range)
@@ -527,16 +528,16 @@ describe "Occurrence", ->
           expect(textsInBufferRangeIsAllEqualChar).toBe(true)
           expect(vimState.persistentSelection.getMarkers()).toHaveLength(11)
 
-          keystroke '2 l' # to move to out-side of range-mrker
+          ensure '2 l', {} # to move to out-side of range-mrker
           ensure '/ => enter', cursor: [9, 69]
-          keystroke "m" # clear persistentSelection at cursor which is = sign part of fat arrow.
+          ensure "m", {} # clear persistentSelection at cursor which is = sign part of fat arrow.
           expect(vimState.persistentSelection.getMarkers()).toHaveLength(10)
 
         waitsFor ->
           classList.contains('has-persistent-selection')
 
         runs ->
-          keystroke "ctrl-cmd-g I" # "select-persistent-selection" then "Insert at start of selection"
+          ensure "ctrl-cmd-g I", {} # "select-persistent-selection" then "Insert at start of selection"
 
           editor.insertText('?')
           ensure 'escape',
@@ -699,7 +700,7 @@ describe "Occurrence", ->
 
         describe "add-occurrence-pattern-from-search", ->
           it 'mark as occurrence which matches regex entered in search-ui', ->
-            keystroke '/'
+            ensure '/', {}
             inputSearchText('\\bt\\w+')
             dispatchSearchCommand('vim-mode-plus:add-occurrence-pattern-from-search')
             ensure

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -360,7 +360,7 @@ describe "Occurrence", ->
 
     describe "from normal mode", ->
       it "select occurrence by pattern match", ->
-        ensure '/', {}
+        ensure '/'
         inputSearchText('\\d{3,4}')
         dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
         ensure 'i e',
@@ -368,12 +368,12 @@ describe "Occurrence", ->
           mode: ['visual', 'characterwise']
 
       it "change occurrence by pattern match", ->
-        ensure '/', {}
+        ensure '/'
         inputSearchText('^\\w+:')
         dispatchSearchCommand('vim-mode-plus:change-occurrence-from-search')
         ensure 'i e', mode: 'insert'
         editor.insertText('hello')
-        ensure
+        ensure null,
           text: """
           hello xxx: ooo: 0000
           hello ooo: 22: ooo:
@@ -384,7 +384,7 @@ describe "Occurrence", ->
     describe "from visual mode", ->
       describe "visual characterwise", ->
         it "change occurrence in narrowed selection", ->
-          ensure 'v j /', {}
+          ensure 'v j /'
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -397,7 +397,7 @@ describe "Occurrence", ->
 
       describe "visual linewise", ->
         it "change occurrence in narrowed selection", ->
-          ensure 'V j /', {}
+          ensure 'V j /'
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -411,7 +411,7 @@ describe "Occurrence", ->
       describe "visual blockwise", ->
         it "change occurrence in narrowed selection", ->
           set cursor: [0, 5]
-          ensure 'ctrl-v 2 j 1 0 l /', {}
+          ensure 'ctrl-v 2 j 1 0 l /'
           inputSearchText('o+')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -446,7 +446,7 @@ describe "Occurrence", ->
       describe "when no selection is exists", ->
         it "select occurrence in all persistent-selection", ->
           set cursor: [0, 0]
-          ensure '/', {}
+          ensure '/'
           inputSearchText('xxx')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -461,7 +461,7 @@ describe "Occurrence", ->
       describe "when both exits, operator applied to both", ->
         it "select all occurrence in selection", ->
           set cursor: [0, 0]
-          ensure 'V 2 j /', {}
+          ensure 'V 2 j /'
           inputSearchText('xxx')
           dispatchSearchCommand('vim-mode-plus:select-occurrence-from-search')
           ensure 'U',
@@ -520,7 +520,7 @@ describe "Occurrence", ->
             'i f'     # inner-function-text-object
             'm'       # toggle-persistent-selection
           ].join(" ")
-          ensure(_keystroke, {})
+          ensure(_keystroke)
 
           textsInBufferRange = vimState.persistentSelection.getMarkerBufferRanges().map (range) ->
             editor.getTextInBufferRange(range)
@@ -528,16 +528,16 @@ describe "Occurrence", ->
           expect(textsInBufferRangeIsAllEqualChar).toBe(true)
           expect(vimState.persistentSelection.getMarkers()).toHaveLength(11)
 
-          ensure '2 l', {} # to move to out-side of range-mrker
+          ensure '2 l' # to move to out-side of range-mrker
           ensure '/ => enter', cursor: [9, 69]
-          ensure "m", {} # clear persistentSelection at cursor which is = sign part of fat arrow.
+          ensure "m" # clear persistentSelection at cursor which is = sign part of fat arrow.
           expect(vimState.persistentSelection.getMarkers()).toHaveLength(10)
 
         waitsFor ->
           classList.contains('has-persistent-selection')
 
         runs ->
-          ensure "ctrl-cmd-g I", {} # "select-persistent-selection" then "Insert at start of selection"
+          ensure "ctrl-cmd-g I" # "select-persistent-selection" then "Insert at start of selection"
 
           editor.insertText('?')
           ensure 'escape',
@@ -663,7 +663,7 @@ describe "Occurrence", ->
                 markerLayerUpdated
 
               runs ->
-                ensure occurrenceCount: 0
+                ensure null, occurrenceCount: 0
                 expect(classList.contains('has-occurrence')).toBe(false)
 
       describe "in visual-mode", ->
@@ -700,10 +700,10 @@ describe "Occurrence", ->
 
         describe "add-occurrence-pattern-from-search", ->
           it 'mark as occurrence which matches regex entered in search-ui', ->
-            ensure '/', {}
+            ensure '/'
             inputSearchText('\\bt\\w+')
             dispatchSearchCommand('vim-mode-plus:add-occurrence-pattern-from-search')
-            ensure
+            ensure null,
               occurrenceText: ['text', 'text', 'the', 'text']
 
     describe "mutate preset occurrence", ->
@@ -1171,7 +1171,7 @@ describe "Occurrence", ->
       it "can cancel and confirm on o-modifier", ->
         atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Cancel")
         ensure "c o", mode: "operator-pending", occurrenceText: []
-        ensure mode: "operator-pending", occurrenceText: []
+        ensure null, mode: "operator-pending", occurrenceText: []
         atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Continue")
         ensure "o", mode: "operator-pending", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']
 
@@ -1182,6 +1182,6 @@ describe "Occurrence", ->
       it "can cancel and confirm on `g o`", ->
         atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Cancel")
         ensure "g o", mode: "normal", occurrenceText: []
-        ensure mode: "normal", occurrenceText: []
+        ensure null, mode: "normal", occurrenceText: []
         atom.confirm.andCallFake ({buttons}) -> buttons.indexOf("Continue")
         ensure "g o", mode: "normal", occurrenceText: ['oo', 'oo', 'oo', 'oo', 'oo']

--- a/spec/occurrence-spec.coffee
+++ b/spec/occurrence-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "Occurrence", ->
-  [set, ensure, keystroke, editor, editorElement, vimState, classList] = []
+  [set, ensure, ensureWait, keystroke, editor, editorElement, vimState, classList] = []
   [searchEditor, searchEditorElement] = []
   inputSearchText = (text) ->
     searchEditor.insertText(text)
@@ -13,7 +13,7 @@ describe "Occurrence", ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure, ensureWait, keystroke} = vim
       classList = editorElement.classList
       searchEditor = vimState.searchInput.editor
       searchEditorElement = vimState.searchInput.editorElement
@@ -686,7 +686,7 @@ describe "Occurrence", ->
               mode: ['visual', 'linewise']
               selectedText: textOriginal
               occurrenceText: ['text', 'text', 'text', 'text', 'text', 'text']
-            ensure 'r !',
+            ensureWait 'r !',
               mode: 'normal'
               text: """
               This !!!! have 3 instance of '!!!!' in the whole !!!!

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -24,7 +24,7 @@ describe "Operator ActivateInsertMode family", ->
 
     it "is repeatable", ->
       set cursor: [0, 0]
-      ensure '3 s', {}
+      ensure '3 s'
       editor.insertText 'ab'
       ensure 'escape', text: 'ab345'
       set cursor: [0, 2]
@@ -32,17 +32,17 @@ describe "Operator ActivateInsertMode family", ->
 
     it "is undoable", ->
       set cursor: [0, 0]
-      ensure '3 s', {}
+      ensure '3 s'
       editor.insertText 'ab'
       ensure 'escape', text: 'ab345'
       ensure 'u', text: '012345', selectedText: ''
 
     describe "in visual mode", ->
       beforeEach ->
-        ensure 'v l s', {}
+        ensure 'v l s'
 
       it "deletes the selected characters and enters insert mode", ->
-        ensure
+        ensure null,
           mode: 'insert'
           text: '0345'
           cursor: [0, 1]
@@ -61,14 +61,14 @@ describe "Operator ActivateInsertMode family", ->
         register: {'"': text: 'abcde\n', type: 'linewise'}
 
     it "is repeatable", ->
-      ensure 'S', {}
+      ensure 'S'
       editor.insertText 'abc'
       ensure 'escape', text: '12345\nabc\nABCDE'
       set cursor: [2, 3]
       ensure '.', text: '12345\nabc\nabc'
 
     it "is undoable", ->
-      ensure 'S', {}
+      ensure 'S'
       editor.insertText 'abc'
       ensure 'escape', text: '12345\nabc\nABCDE'
       ensure 'u', text: "12345\nabcde\nABCDE", selectedText: ''
@@ -119,14 +119,14 @@ describe "Operator ActivateInsertMode family", ->
             mode: 'insert'
 
         it "is repeatable", ->
-          ensure 'c c', {}
+          ensure 'c c'
           editor.insertText("abc")
           ensure 'escape', text: "12345\n  abc\nABCDE\n"
           set cursor: [2, 3]
           ensure '.', text: "12345\n  abc\n  abc\n"
 
         it "is undoable", ->
-          ensure 'c c', {}
+          ensure 'c c'
           editor.insertText("abc")
           ensure 'escape', text: "12345\n  abc\nABCDE\n"
           ensure 'u', text: "12345\n  abcde\nABCDE\n", selectedText: ''
@@ -305,8 +305,8 @@ describe "Operator ActivateInsertMode family", ->
         """
 
     it "switches to insert and adds a newline above the current one", ->
-      ensure 'O', {}
-      ensure
+      ensure 'O'
+      ensure null,
         textC_: """
         __abc
         __|
@@ -323,7 +323,7 @@ describe "Operator ActivateInsertMode family", ->
           """
       # set
       #   text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
-      ensure 'O', {}
+      ensure 'O'
       editor.insertText "def"
       ensure 'escape',
         textC_: """
@@ -352,7 +352,7 @@ describe "Operator ActivateInsertMode family", ->
         """
 
     it "is undoable", ->
-      ensure 'O', {}
+      ensure 'O'
       editor.insertText "def"
       ensure 'escape',
         textC_: """
@@ -385,7 +385,7 @@ describe "Operator ActivateInsertMode family", ->
     # to fix it.
     xit "is repeatable", ->
       set text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
-      ensure 'o', {}
+      ensure 'o'
       editor.insertText "def"
       ensure 'escape', text: "  abc\n  012\n  def\n    4spaces\n"
       ensure '.', text: "  abc\n  012\n  def\n  def\n    4spaces\n"
@@ -393,7 +393,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure '.', text: "  abc\n  def\n  def\n  012\n    4spaces\n    def\n"
 
     it "is undoable", ->
-      ensure 'o', {}
+      ensure 'o'
       editor.insertText "def"
       ensure 'escape', text: "abc\n  012\n  def\n"
       ensure 'u', text: "abc\n  012\n"
@@ -421,18 +421,18 @@ describe "Operator ActivateInsertMode family", ->
     describe "at the beginning of the line", ->
       beforeEach ->
         set cursor: [0, 0]
-        ensure 'a', {}
+        ensure 'a'
 
       it "switches to insert mode and shifts to the right", ->
-        ensure cursor: [0, 1], mode: 'insert'
+        ensure null, cursor: [0, 1], mode: 'insert'
 
     describe "at the end of the line", ->
       beforeEach ->
         set cursor: [0, 3]
-        ensure 'a', {}
+        ensure 'a'
 
       it "doesn't linewrap", ->
-        ensure cursor: [0, 3]
+        ensure null, cursor: [0, 3]
 
   describe "the A keybinding", ->
     beforeEach ->
@@ -447,9 +447,9 @@ describe "Operator ActivateInsertMode family", ->
 
       it "repeats always as insert at the end of the line", ->
         set cursor: [0, 0]
-        ensure 'A', {}
+        ensure 'A'
         editor.insertText("abc")
-        ensure 'escape', {}
+        ensure 'escape'
         set cursor: [1, 0]
 
         ensure '.',
@@ -745,13 +745,13 @@ describe "Operator ActivateInsertMode family", ->
           """
 
     it "allows undoing an entire batch of typing", ->
-      ensure 'i', {}
+      ensure 'i'
       editor.insertText("abcXX")
       editor.backspace()
       editor.backspace()
       ensure 'escape', text: "abc123\nabc4567"
 
-      ensure 'i', {}
+      ensure 'i'
       editor.insertText "d"
       editor.insertText "e"
       editor.insertText "f"
@@ -760,7 +760,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure 'u', text: "123\n4567"
 
     it "allows repeating typing", ->
-      ensure 'i', {}
+      ensure 'i'
       editor.insertText("abcXX")
       editor.backspace()
       editor.backspace()
@@ -773,7 +773,7 @@ describe "Operator ActivateInsertMode family", ->
         set text: '', cursor: [0, 0]
 
       it 'deals with auto-matched brackets', ->
-        ensure 'i', {}
+        ensure 'i'
         # this sequence simulates what the bracket-matcher package does
         # when the user types (a)b<enter>
         editor.insertText '()'
@@ -787,7 +787,7 @@ describe "Operator ActivateInsertMode family", ->
           cursor: [2,  0]
 
       it 'deals with autocomplete', ->
-        ensure 'i', {}
+        ensure 'i'
         # this sequence simulates autocompletion of 'add' to 'addFoo'
         editor.insertText 'a'
         editor.insertText 'd'
@@ -807,13 +807,13 @@ describe "Operator ActivateInsertMode family", ->
         cursor: [0, 0]
 
     it "can be undone in one go", ->
-      ensure 'a', {}
+      ensure 'a'
       editor.insertText("abc")
       ensure 'escape', text: "abc"
       ensure 'u', text: ""
 
     it "repeats correctly", ->
-      ensure 'a', {}
+      ensure 'a'
       editor.insertText("abc")
       ensure 'escape',
         text: "abc"
@@ -852,34 +852,34 @@ describe "Operator ActivateInsertMode family", ->
 
       it "can repeat backspace only mutation: case-i", ->
         set cursor: [0, 1]
-        ensure 'i', {}
+        ensure 'i'
         editor.backspace()
         ensure 'escape', text: "23\n123", cursor: [0, 0]
         ensure 'j .', text: "23\n123" # nothing happen
         ensure 'l .', text: "23\n23"
 
       it "can repeat backspace only mutation: case-a", ->
-        ensure 'a', {}
+        ensure 'a'
         editor.backspace()
         ensure 'escape', text: "23\n123", cursor: [0, 0]
         ensure '.', text: "3\n123", cursor: [0, 0]
         ensure 'j . .', text: "3\n3"
 
       it "can repeat delete only mutation: case-i", ->
-        ensure 'i', {}
+        ensure 'i'
         editor.delete()
         ensure 'escape', text: "23\n123"
         ensure 'j .', text: "23\n23"
 
       it "can repeat delete only mutation: case-a", ->
-        ensure 'a', {}
+        ensure 'a'
         editor.delete()
         ensure 'escape', text: "13\n123"
         ensure 'j .', text: "13\n13"
 
       it "can repeat backspace and insert mutation: case-i", ->
         set cursor: [0, 1]
-        ensure 'i', {}
+        ensure 'i'
         editor.backspace()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
@@ -887,21 +887,21 @@ describe "Operator ActivateInsertMode family", ->
         ensure '.', text: "!!!23\n!!!23"
 
       it "can repeat backspace and insert mutation: case-a", ->
-        ensure 'a', {}
+        ensure 'a'
         editor.backspace()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
         ensure 'j 0 .', text: "!!!23\n!!!23"
 
       it "can repeat delete and insert mutation: case-i", ->
-        ensure 'i', {}
+        ensure 'i'
         editor.delete()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
         ensure 'j 0 .', text: "!!!23\n!!!23"
 
       it "can repeat delete and insert mutation: case-a", ->
-        ensure 'a', {}
+        ensure 'a'
         editor.delete()
         editor.insertText("!!!")
         ensure 'escape', text: "1!!!3\n123"
@@ -936,14 +936,14 @@ describe "Operator ActivateInsertMode family", ->
 
   describe 'specify insertion count', ->
     ensureInsertionCount = (key, {insert, text, cursor}) ->
-      ensure key, {}
+      ensure key
       editor.insertText(insert)
       ensure "escape", text: text, cursor: cursor
 
     beforeEach ->
       initialText = "*\n*\n"
       set text: "", cursor: [0, 0]
-      ensure 'i', {}
+      ensure 'i'
       editor.insertText(initialText)
       ensure "escape g g", text: initialText, cursor: [0, 0]
 
@@ -955,7 +955,7 @@ describe "Operator ActivateInsertMode family", ->
       describe "children of Change operation won't repeate insertion count times", ->
         beforeEach ->
           set text: "", cursor: [0, 0]
-          ensure 'i', {}
+          ensure 'i'
           editor.insertText('*')
           ensure 'escape g g', text: '*', cursor: [0, 0]
 

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -3,13 +3,13 @@ settings = require '../lib/settings'
 {inspect} = require 'util'
 
 describe "Operator ActivateInsertMode family", ->
-  [set, ensure, bindEnsureOption, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, bindEnsureOption, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke, bindEnsureOption} = vim
+      {set, ensure, bindEnsureOption} = vim
 
   describe "the s keybinding", ->
     beforeEach ->
@@ -24,7 +24,7 @@ describe "Operator ActivateInsertMode family", ->
 
     it "is repeatable", ->
       set cursor: [0, 0]
-      keystroke '3 s'
+      ensure '3 s', {}
       editor.insertText 'ab'
       ensure 'escape', text: 'ab345'
       set cursor: [0, 2]
@@ -32,14 +32,14 @@ describe "Operator ActivateInsertMode family", ->
 
     it "is undoable", ->
       set cursor: [0, 0]
-      keystroke '3 s'
+      ensure '3 s', {}
       editor.insertText 'ab'
       ensure 'escape', text: 'ab345'
       ensure 'u', text: '012345', selectedText: ''
 
     describe "in visual mode", ->
       beforeEach ->
-        keystroke 'v l s'
+        ensure 'v l s', {}
 
       it "deletes the selected characters and enters insert mode", ->
         ensure
@@ -61,14 +61,14 @@ describe "Operator ActivateInsertMode family", ->
         register: {'"': text: 'abcde\n', type: 'linewise'}
 
     it "is repeatable", ->
-      keystroke 'S'
+      ensure 'S', {}
       editor.insertText 'abc'
       ensure 'escape', text: '12345\nabc\nABCDE'
       set cursor: [2, 3]
       ensure '.', text: '12345\nabc\nabc'
 
     it "is undoable", ->
-      keystroke 'S'
+      ensure 'S', {}
       editor.insertText 'abc'
       ensure 'escape', text: '12345\nabc\nABCDE'
       ensure 'u', text: "12345\nabcde\nABCDE", selectedText: ''
@@ -119,14 +119,14 @@ describe "Operator ActivateInsertMode family", ->
             mode: 'insert'
 
         it "is repeatable", ->
-          keystroke 'c c'
+          ensure 'c c', {}
           editor.insertText("abc")
           ensure 'escape', text: "12345\n  abc\nABCDE\n"
           set cursor: [2, 3]
           ensure '.', text: "12345\n  abc\n  abc\n"
 
         it "is undoable", ->
-          keystroke 'c c'
+          ensure 'c c', {}
           editor.insertText("abc")
           ensure 'escape', text: "12345\n  abc\nABCDE\n"
           ensure 'u', text: "12345\n  abcde\nABCDE\n", selectedText: ''
@@ -305,7 +305,7 @@ describe "Operator ActivateInsertMode family", ->
         """
 
     it "switches to insert and adds a newline above the current one", ->
-      keystroke 'O'
+      ensure 'O', {}
       ensure
         textC_: """
         __abc
@@ -323,7 +323,7 @@ describe "Operator ActivateInsertMode family", ->
           """
       # set
       #   text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
-      keystroke 'O'
+      ensure 'O', {}
       editor.insertText "def"
       ensure 'escape',
         textC_: """
@@ -352,7 +352,7 @@ describe "Operator ActivateInsertMode family", ->
         """
 
     it "is undoable", ->
-      keystroke 'O'
+      ensure 'O', {}
       editor.insertText "def"
       ensure 'escape',
         textC_: """
@@ -385,7 +385,7 @@ describe "Operator ActivateInsertMode family", ->
     # to fix it.
     xit "is repeatable", ->
       set text: "  abc\n  012\n    4spaces\n", cursor: [1, 1]
-      keystroke 'o'
+      ensure 'o', {}
       editor.insertText "def"
       ensure 'escape', text: "  abc\n  012\n  def\n    4spaces\n"
       ensure '.', text: "  abc\n  012\n  def\n  def\n    4spaces\n"
@@ -393,7 +393,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure '.', text: "  abc\n  def\n  def\n  012\n    4spaces\n    def\n"
 
     it "is undoable", ->
-      keystroke 'o'
+      ensure 'o', {}
       editor.insertText "def"
       ensure 'escape', text: "abc\n  012\n  def\n"
       ensure 'u', text: "abc\n  012\n"
@@ -421,7 +421,7 @@ describe "Operator ActivateInsertMode family", ->
     describe "at the beginning of the line", ->
       beforeEach ->
         set cursor: [0, 0]
-        keystroke 'a'
+        ensure 'a', {}
 
       it "switches to insert mode and shifts to the right", ->
         ensure cursor: [0, 1], mode: 'insert'
@@ -429,7 +429,7 @@ describe "Operator ActivateInsertMode family", ->
     describe "at the end of the line", ->
       beforeEach ->
         set cursor: [0, 3]
-        keystroke 'a'
+        ensure 'a', {}
 
       it "doesn't linewrap", ->
         ensure cursor: [0, 3]
@@ -447,9 +447,9 @@ describe "Operator ActivateInsertMode family", ->
 
       it "repeats always as insert at the end of the line", ->
         set cursor: [0, 0]
-        keystroke 'A'
+        ensure 'A', {}
         editor.insertText("abc")
-        keystroke 'escape'
+        ensure 'escape', {}
         set cursor: [1, 0]
 
         ensure '.',
@@ -707,7 +707,7 @@ describe "Operator ActivateInsertMode family", ->
         atom.packages.activatePackage('language-coffee-script')
       getVimState 'sample.coffee', (state, vim) ->
         {editor, editorElement} = state
-        {set, ensure, keystroke} = vim
+        {set, ensure} = vim
 
       runs ->
         atom.keymaps.add "test",
@@ -745,13 +745,13 @@ describe "Operator ActivateInsertMode family", ->
           """
 
     it "allows undoing an entire batch of typing", ->
-      keystroke 'i'
+      ensure 'i', {}
       editor.insertText("abcXX")
       editor.backspace()
       editor.backspace()
       ensure 'escape', text: "abc123\nabc4567"
 
-      keystroke 'i'
+      ensure 'i', {}
       editor.insertText "d"
       editor.insertText "e"
       editor.insertText "f"
@@ -760,7 +760,7 @@ describe "Operator ActivateInsertMode family", ->
       ensure 'u', text: "123\n4567"
 
     it "allows repeating typing", ->
-      keystroke 'i'
+      ensure 'i', {}
       editor.insertText("abcXX")
       editor.backspace()
       editor.backspace()
@@ -773,7 +773,7 @@ describe "Operator ActivateInsertMode family", ->
         set text: '', cursor: [0, 0]
 
       it 'deals with auto-matched brackets', ->
-        keystroke 'i'
+        ensure 'i', {}
         # this sequence simulates what the bracket-matcher package does
         # when the user types (a)b<enter>
         editor.insertText '()'
@@ -787,7 +787,7 @@ describe "Operator ActivateInsertMode family", ->
           cursor: [2,  0]
 
       it 'deals with autocomplete', ->
-        keystroke 'i'
+        ensure 'i', {}
         # this sequence simulates autocompletion of 'add' to 'addFoo'
         editor.insertText 'a'
         editor.insertText 'd'
@@ -807,13 +807,13 @@ describe "Operator ActivateInsertMode family", ->
         cursor: [0, 0]
 
     it "can be undone in one go", ->
-      keystroke 'a'
+      ensure 'a', {}
       editor.insertText("abc")
       ensure 'escape', text: "abc"
       ensure 'u', text: ""
 
     it "repeats correctly", ->
-      keystroke 'a'
+      ensure 'a', {}
       editor.insertText("abc")
       ensure 'escape',
         text: "abc"
@@ -852,34 +852,34 @@ describe "Operator ActivateInsertMode family", ->
 
       it "can repeat backspace only mutation: case-i", ->
         set cursor: [0, 1]
-        keystroke 'i'
+        ensure 'i', {}
         editor.backspace()
         ensure 'escape', text: "23\n123", cursor: [0, 0]
         ensure 'j .', text: "23\n123" # nothing happen
         ensure 'l .', text: "23\n23"
 
       it "can repeat backspace only mutation: case-a", ->
-        keystroke 'a'
+        ensure 'a', {}
         editor.backspace()
         ensure 'escape', text: "23\n123", cursor: [0, 0]
         ensure '.', text: "3\n123", cursor: [0, 0]
         ensure 'j . .', text: "3\n3"
 
       it "can repeat delete only mutation: case-i", ->
-        keystroke 'i'
+        ensure 'i', {}
         editor.delete()
         ensure 'escape', text: "23\n123"
         ensure 'j .', text: "23\n23"
 
       it "can repeat delete only mutation: case-a", ->
-        keystroke 'a'
+        ensure 'a', {}
         editor.delete()
         ensure 'escape', text: "13\n123"
         ensure 'j .', text: "13\n13"
 
       it "can repeat backspace and insert mutation: case-i", ->
         set cursor: [0, 1]
-        keystroke 'i'
+        ensure 'i', {}
         editor.backspace()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
@@ -887,21 +887,21 @@ describe "Operator ActivateInsertMode family", ->
         ensure '.', text: "!!!23\n!!!23"
 
       it "can repeat backspace and insert mutation: case-a", ->
-        keystroke 'a'
+        ensure 'a', {}
         editor.backspace()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
         ensure 'j 0 .', text: "!!!23\n!!!23"
 
       it "can repeat delete and insert mutation: case-i", ->
-        keystroke 'i'
+        ensure 'i', {}
         editor.delete()
         editor.insertText("!!!")
         ensure 'escape', text: "!!!23\n123"
         ensure 'j 0 .', text: "!!!23\n!!!23"
 
       it "can repeat delete and insert mutation: case-a", ->
-        keystroke 'a'
+        ensure 'a', {}
         editor.delete()
         editor.insertText("!!!")
         ensure 'escape', text: "1!!!3\n123"
@@ -936,14 +936,14 @@ describe "Operator ActivateInsertMode family", ->
 
   describe 'specify insertion count', ->
     ensureInsertionCount = (key, {insert, text, cursor}) ->
-      keystroke key
+      ensure key, {}
       editor.insertText(insert)
       ensure "escape", text: text, cursor: cursor
 
     beforeEach ->
       initialText = "*\n*\n"
       set text: "", cursor: [0, 0]
-      keystroke 'i'
+      ensure 'i', {}
       editor.insertText(initialText)
       ensure "escape g g", text: initialText, cursor: [0, 0]
 
@@ -955,7 +955,7 @@ describe "Operator ActivateInsertMode family", ->
       describe "children of Change operation won't repeate insertion count times", ->
         beforeEach ->
           set text: "", cursor: [0, 0]
-          keystroke 'i'
+          ensure 'i', {}
           editor.insertText('*')
           ensure 'escape g g', text: '*', cursor: [0, 0]
 

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -2,18 +2,18 @@
 settings = require '../lib/settings'
 
 describe "Operator general", ->
-  [set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait] = []
+  [set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption] = []
   [editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait} = vim
+      {set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption} = vim
 
   describe "cancelling operations", ->
     it "clear pending operation", ->
-      keystroke '/'
+      ensure '/', {}
       expect(vimState.operationStack.isEmpty()).toBe false
       vimState.searchInput.cancel()
       expect(vimState.operationStack.isEmpty()).toBe true
@@ -1048,7 +1048,7 @@ describe "Operator general", ->
           text: "12345\nabcde\nABCDE\nQWERT"
           cursor: [1, 1]
           register: '"': text: '123'
-        keystroke '2 p'
+        ensure '2 p', {}
 
       it "inserts the same line twice", ->
         ensure text: "12345\nab123123cde\nABCDE\nQWERT"
@@ -1095,7 +1095,7 @@ describe "Operator general", ->
         set text: "012\n", cursor: [0, 0]
         set register: '"': text: '345'
         set register: a: text: 'a'
-        keystroke 'P'
+        ensure 'P', {}
 
       it "inserts the contents of the default register above", ->
         ensure text: "345012\n", cursor: [0, 2]
@@ -1169,7 +1169,7 @@ describe "Operator general", ->
 
     describe "when in visual mode", ->
       beforeEach ->
-        keystroke 'v e'
+        ensure 'v e', {}
 
       it "replaces the entire selection with the given character", ->
         ensureWait 'r x', text: 'xx\nxx\n\n'
@@ -1240,10 +1240,10 @@ describe "Operator general", ->
     it "[normal] can mark multiple positon", ->
       ensureMarkByMode("normal")
     it "[vC] can mark", ->
-      keystroke "v"
+      ensure "v", {}
       ensureMarkByMode(["visual", "characterwise"])
     it "[vL] can mark", ->
-      keystroke "V"
+      ensure "V", {}
       ensureMarkByMode(["visual", "linewise"])
 
   describe 'the R keybinding', ->
@@ -1272,7 +1272,7 @@ describe "Operator general", ->
 
     it 'treats backspace as undo', ->
       editor.insertText "foo"
-      keystroke 'R'
+      ensure 'R', {}
       editor.insertText "a"
       editor.insertText "b"
       ensure text: "12fooab5\n67890"
@@ -1289,9 +1289,9 @@ describe "Operator general", ->
         selectedText: ''
 
     it "can be repeated", ->
-      keystroke 'R'
+      ensure 'R', {}
       editor.insertText "ab"
-      keystroke 'escape'
+      ensure 'escape', {}
       set cursor: [1, 2]
       ensure '.', text: "12ab5\n67ab0", cursor: [1, 3]
       set cursor: [0, 4]
@@ -1301,11 +1301,11 @@ describe "Operator general", ->
       # FIXME don't know how to test this (also, depends on PR #568)
 
     it "repeats correctly when backspace was used in the text", ->
-      keystroke 'R'
+      ensure 'R', {}
       editor.insertText "a"
-      keystroke 'backspace'
+      ensure 'backspace', {}
       editor.insertText "b"
-      keystroke 'escape'
+      ensure 'escape', {}
       set cursor: [1, 2]
       ensure '.', text: "12b45\n67b90", cursor: [1, 2]
       set cursor: [0, 4]

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -13,7 +13,7 @@ describe "Operator general", ->
 
   describe "cancelling operations", ->
     it "clear pending operation", ->
-      ensure '/', {}
+      ensure '/'
       expect(vimState.operationStack.isEmpty()).toBe false
       vimState.searchInput.cancel()
       expect(vimState.operationStack.isEmpty()).toBe true
@@ -550,7 +550,7 @@ describe "Operator general", ->
       beforeEach ->
         settings.set('useClipboardAsDefaultRegister', true)
         atom.clipboard.write('___________')
-        ensure register: '"': text: '___________'
+        ensure null, register: '"': text: '___________'
 
       describe "read/write to clipboard through register", ->
         it "writes to clipboard with default register", ->
@@ -954,7 +954,7 @@ describe "Operator general", ->
             }
             """
           dispatch(editor.element, 'vim-mode-plus:put-after-with-auto-indent')
-          ensure
+          ensure null,
             textC_: """
             if () {
               |345
@@ -976,7 +976,7 @@ describe "Operator general", ->
             }
             """
           dispatch(editor.element, 'vim-mode-plus:put-after-with-auto-indent')
-          ensure
+          ensure null,
             textC: """
             if (1) {
               if (2) {
@@ -1005,7 +1005,7 @@ describe "Operator general", ->
 
           set register: '"': {text: registerContent, type: 'linewise'}
           dispatch(editor.element, 'vim-mode-plus:put-after-with-auto-indent')
-          ensure
+          ensure null,
             textC: """
             if (1) {
               if (2) {
@@ -1026,7 +1026,7 @@ describe "Operator general", ->
 
           set register: '"': {text: registerContent, type: 'linewise'}
           dispatch(editor.element, 'vim-mode-plus:put-after-with-auto-indent')
-          ensure
+          ensure null,
             textC_: """
             if (1) {
               if (2) {
@@ -1048,10 +1048,10 @@ describe "Operator general", ->
           text: "12345\nabcde\nABCDE\nQWERT"
           cursor: [1, 1]
           register: '"': text: '123'
-        ensure '2 p', {}
+        ensure '2 p'
 
       it "inserts the same line twice", ->
-        ensure text: "12345\nab123123cde\nABCDE\nQWERT"
+        ensure null, text: "12345\nab123123cde\nABCDE\nQWERT"
 
       describe "when undone", ->
         it "removes both lines", ->
@@ -1095,10 +1095,10 @@ describe "Operator general", ->
         set text: "012\n", cursor: [0, 0]
         set register: '"': text: '345'
         set register: a: text: 'a'
-        ensure 'P', {}
+        ensure 'P'
 
       it "inserts the contents of the default register above", ->
-        ensure text: "345012\n", cursor: [0, 2]
+        ensure null, text: "345012\n", cursor: [0, 2]
 
   describe "the . keybinding", ->
     beforeEach ->
@@ -1169,7 +1169,7 @@ describe "Operator general", ->
 
     describe "when in visual mode", ->
       beforeEach ->
-        ensure 'v e', {}
+        ensure 'v e'
 
       it "replaces the entire selection with the given character", ->
         ensureWait 'r x', text: 'xx\nxx\n\n'
@@ -1240,10 +1240,10 @@ describe "Operator general", ->
     it "[normal] can mark multiple positon", ->
       ensureMarkByMode("normal")
     it "[vC] can mark", ->
-      ensure "v", {}
+      ensure "v"
       ensureMarkByMode(["visual", "characterwise"])
     it "[vL] can mark", ->
-      ensure "V", {}
+      ensure "V"
       ensureMarkByMode(["visual", "linewise"])
 
   describe 'the R keybinding', ->
@@ -1272,14 +1272,14 @@ describe "Operator general", ->
 
     it 'treats backspace as undo', ->
       editor.insertText "foo"
-      ensure 'R', {}
+      ensure 'R'
       editor.insertText "a"
       editor.insertText "b"
-      ensure text: "12fooab5\n67890"
+      ensure null, text: "12fooab5\n67890"
 
       ensure 'backspace', text: "12fooa45\n67890"
       editor.insertText "c"
-      ensure text: "12fooac5\n67890"
+      ensure null, text: "12fooac5\n67890"
       ensure 'backspace backspace',
         text: "12foo345\n67890"
         selectedText: ''
@@ -1289,9 +1289,9 @@ describe "Operator general", ->
         selectedText: ''
 
     it "can be repeated", ->
-      ensure 'R', {}
+      ensure 'R'
       editor.insertText "ab"
-      ensure 'escape', {}
+      ensure 'escape'
       set cursor: [1, 2]
       ensure '.', text: "12ab5\n67ab0", cursor: [1, 3]
       set cursor: [0, 4]
@@ -1301,11 +1301,11 @@ describe "Operator general", ->
       # FIXME don't know how to test this (also, depends on PR #568)
 
     it "repeats correctly when backspace was used in the text", ->
-      ensure 'R', {}
+      ensure 'R'
       editor.insertText "a"
-      ensure 'backspace', {}
+      ensure 'backspace'
       editor.insertText "b"
-      ensure 'escape', {}
+      ensure 'escape'
       set cursor: [1, 2]
       ensure '.', text: "12b45\n67b90", cursor: [1, 2]
       set cursor: [0, 4]
@@ -1326,7 +1326,7 @@ describe "Operator general", ->
       it "replace character unless input isnt new line(\\n)", ->
         ensure 'R', mode: ['insert', 'replace']
         editor.insertText "a\nb\nc"
-        ensure
+        ensure null,
           text: """
             a
             b
@@ -1338,7 +1338,7 @@ describe "Operator general", ->
         ensure 'R', mode: ['insert', 'replace']
         set cursor: [0, 1]
         editor.insertText "a\nb\nc"
-        ensure
+        ensure null,
           text: """
             0a
             b
@@ -1396,7 +1396,7 @@ describe "Operator general", ->
       it "repeate multiline text case-1", ->
         ensure 'R', mode: ['insert', 'replace']
         editor.insertText "abc\ndef"
-        ensure
+        ensure null,
           text: """
             abc
             def
@@ -1425,7 +1425,7 @@ describe "Operator general", ->
       it "repeate multiline text case-2", ->
         ensure 'R', mode: ['insert', 'replace']
         editor.insertText "abc\nd"
-        ensure
+        ensure null,
           text: """
             abc
             d4

--- a/spec/operator-increase-spec.coffee
+++ b/spec/operator-increase-spec.coffee
@@ -354,7 +354,7 @@ describe "Operator Increase", ->
           set text: "1 0 0 0 0", cursor: [0, 0]
           ensure "v $", selectedText: '1 0 0 0 0'
         it "put cursor on start position when finished and repeatable (case: selection is not reversed)", ->
-          ensure selectionIsReversed: false
+          ensure null, selectionIsReversed: false
           ensure 'g ctrl-a', text: "1 2 3 4 5", cursor: [0, 0], mode: 'normal'
           ensure '.', text: "6 7 8 9 10" , cursor: [0, 0]
         it "put cursor on start position when finished and repeatable (case: selection is reversed)", ->

--- a/spec/operator-increase-spec.coffee
+++ b/spec/operator-increase-spec.coffee
@@ -2,13 +2,13 @@
 settings = require '../lib/settings'
 
 describe "Operator Increase", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
   describe "the ctrl-a/ctrl-x keybindings", ->
     beforeEach ->

--- a/spec/operator-modifier-spec.coffee
+++ b/spec/operator-modifier-spec.coffee
@@ -2,13 +2,13 @@
 settings = require '../lib/settings'
 
 describe "Operator modifier", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
     runs ->
       jasmine.attachToDOM(editorElement)

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -681,7 +681,7 @@ describe "Operator TransformString", ->
             (mn|o) pqr\n
             """
             selectedTextOrdered: ["b", "h", "n"]
-          ensure "S escape",
+          ensureWait "S escape",
             mode: ["visual", "characterwise"]
             textC: """
             (ab|c) def
@@ -828,19 +828,15 @@ describe "Operator TransformString", ->
 
         describe "char is in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
-            ensureWait 'y s i w (', text: "( apple )\norange\nlemmon"
-            ensureWait "j"
-            ensureWait 'y s i w {', text: "( apple )\n{ orange }\nlemmon"
-            ensureWait "j"
-            ensureWait 'y s i w [', text: "( apple )\n{ orange }\n[ lemmon ]"
+            ensureWait 'y s i w (',   text: "( apple )\norange\nlemmon"
+            ensureWait 'j y s i w {', text: "( apple )\n{ orange }\nlemmon"
+            ensureWait 'j y s i w [', text: "( apple )\n{ orange }\n[ lemmon ]"
 
         describe "char is not in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
-            ensureWait 'y s i w )', text: "(apple)\norange\nlemmon"
-            ensureWait "j"
-            ensureWait 'y s i w }', text: "(apple)\n{orange}\nlemmon"
-            ensureWait "j"
-            ensureWait 'y s i w ]', text: "(apple)\n{orange}\n[lemmon]"
+            ensureWait 'y s i w )',   text: "(apple)\norange\nlemmon"
+            ensureWait 'j y s i w }', text: "(apple)\n{orange}\nlemmon"
+            ensureWait 'j y s i w ]', text: "(apple)\n{orange}\n[lemmon]"
 
         describe "it distinctively handle aliased keymap", ->
           beforeEach -> set textC: "|abc"
@@ -908,8 +904,7 @@ describe "Operator TransformString", ->
           """
       it "surround text for each word in visual selection", ->
         settings.set("stayOnSelectTextObject", true)
-        ensure 'v i p'
-        ensureWait 'm s "',
+        ensureWait 'v i p m s "',
           textC: """
 
           "apple"
@@ -993,17 +988,14 @@ describe "Operator TransformString", ->
             {orange}
             """
       it "change surrounded chars", ->
-        ensureWait "2 j"
-        ensureWait 'c S < "',
+        ensureWait 'j j c S < "',
           text: """
             (apple)
             (grape)
             "lemmon"
             {orange}
             """
-        ensureWait "j"
-        ensureWait "l"
-        ensureWait 'c S { !',
+        ensureWait 'j l c S { !',
           text: """
             (apple)
             (grape)
@@ -1059,11 +1051,11 @@ describe "Operator TransformString", ->
             'y s w': 'vim-mode-plus:surround-word'
 
       it "surround a word with ( and repeatable", ->
-        ensureWait 'y s w (',               textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensureWait 'j'; ensureWait '.', textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'y s w (', textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j .',     textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
       it "surround a word with { and repeatable", ->
-        ensureWait 'y s w {',               textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensureWait 'j'; ensureWait '.', textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'y s w {', textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j .',     textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
 
     describe 'delete-surround-any-pair', ->
       beforeEach ->
@@ -1126,9 +1118,9 @@ describe "Operator TransformString", ->
             """
 
       it "change any surrounded pair found and repeatable", ->
-        ensureWait 'c s <',                   textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
-        ensureWait 'j'; ensureWait '.',   textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
-        ensureWait '2 j'; ensureWait '.', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
+        ensureWait 'c s <', textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
+        ensureWait 'j .',   textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
+        ensureWait '2 j .', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
 
     describe 'change-surround-any-pair-allow-forwarding', ->
       beforeEach ->
@@ -1147,8 +1139,7 @@ describe "Operator TransformString", ->
           |___<inner>
           ___(inner)
           """
-        ensureWait 'j'
-        ensureWait '.',
+        ensureWait 'j .',
           textC: """
           ___<inner>
           |___<inner>

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -2,14 +2,14 @@
 settings = require '../lib/settings'
 
 describe "Operator TransformString", ->
-  [set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait] = []
+  [set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption] = []
   [editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait} = vim
+      {set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption} = vim
 
   describe 'the ~ keybinding', ->
     beforeEach ->
@@ -319,14 +319,14 @@ describe "Operator TransformString", ->
 
       describe "when followed by a =", ->
         beforeEach ->
-          keystroke '= ='
+          ensure '= =', {}
 
         it "indents the current line", ->
           expect(editor.indentationForBufferRow(1)).toBe 0
 
       describe "when followed by a repeating =", ->
         beforeEach ->
-          keystroke '2 = ='
+          ensure '2 = =', {}
 
         it "autoindents multiple lines at once", ->
           ensure text: "foo\nbar\nbaz", cursor: [1, 0]
@@ -908,7 +908,8 @@ describe "Operator TransformString", ->
           """
       it "surround text for each word in visual selection", ->
         settings.set("stayOnSelectTextObject", true)
-        ensureWait 'v i p m s "',
+        ensure 'v i p', {}
+        ensureWait 'm s "',
           textC: """
 
           "apple"
@@ -1564,7 +1565,7 @@ describe "Operator TransformString", ->
               s = `abc def hij`
             }
             """
-        keystroke 'j w'
+        ensure 'j w', {}
         ensure 'g , i (',
           textC: """
             hello = () => {

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -319,17 +319,17 @@ describe "Operator TransformString", ->
 
       describe "when followed by a =", ->
         beforeEach ->
-          ensure '= =', {}
+          ensure '= ='
 
         it "indents the current line", ->
           expect(editor.indentationForBufferRow(1)).toBe 0
 
       describe "when followed by a repeating =", ->
         beforeEach ->
-          ensure '2 = =', {}
+          ensure '2 = ='
 
         it "autoindents multiple lines at once", ->
-          ensure text: "foo\nbar\nbaz", cursor: [1, 0]
+          ensure null, text: "foo\nbar\nbaz", cursor: [1, 0]
 
         describe "undo behavior", ->
           it "indents both lines", ->
@@ -829,17 +829,17 @@ describe "Operator TransformString", ->
         describe "char is in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
             ensureWait 'y s i w (', text: "( apple )\norange\nlemmon"
-            ensureWait "j", {}
+            ensureWait "j"
             ensureWait 'y s i w {', text: "( apple )\n{ orange }\nlemmon"
-            ensureWait "j", {}
+            ensureWait "j"
             ensureWait 'y s i w [', text: "( apple )\n{ orange }\n[ lemmon ]"
 
         describe "char is not in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
             ensureWait 'y s i w )', text: "(apple)\norange\nlemmon"
-            ensureWait "j", {}
+            ensureWait "j"
             ensureWait 'y s i w }', text: "(apple)\n{orange}\nlemmon"
-            ensureWait "j", {}
+            ensureWait "j"
             ensureWait 'y s i w ]', text: "(apple)\n{orange}\n[lemmon]"
 
         describe "it distinctively handle aliased keymap", ->
@@ -908,7 +908,7 @@ describe "Operator TransformString", ->
           """
       it "surround text for each word in visual selection", ->
         settings.set("stayOnSelectTextObject", true)
-        ensure 'v i p', {}
+        ensure 'v i p'
         ensureWait 'm s "',
           textC: """
 
@@ -993,7 +993,7 @@ describe "Operator TransformString", ->
             {orange}
             """
       it "change surrounded chars", ->
-        ensureWait "2 j", {}
+        ensureWait "2 j"
         ensureWait 'c S < "',
           text: """
             (apple)
@@ -1001,8 +1001,8 @@ describe "Operator TransformString", ->
             "lemmon"
             {orange}
             """
-        ensureWait "j", {}
-        ensureWait "l", {}
+        ensureWait "j"
+        ensureWait "l"
         ensureWait 'c S { !',
           text: """
             (apple)
@@ -1060,10 +1060,10 @@ describe "Operator TransformString", ->
 
       it "surround a word with ( and repeatable", ->
         ensureWait 'y s w (',               textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensureWait 'j', {}; ensureWait '.', textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j'; ensureWait '.', textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
       it "surround a word with { and repeatable", ->
         ensureWait 'y s w {',               textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensureWait 'j', {}; ensureWait '.', textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j'; ensureWait '.', textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
 
     describe 'delete-surround-any-pair', ->
       beforeEach ->
@@ -1127,8 +1127,8 @@ describe "Operator TransformString", ->
 
       it "change any surrounded pair found and repeatable", ->
         ensureWait 'c s <',                   textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
-        ensureWait 'j', {}; ensureWait '.',   textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
-        ensureWait '2 j', {}; ensureWait '.', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
+        ensureWait 'j'; ensureWait '.',   textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
+        ensureWait '2 j'; ensureWait '.', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
 
     describe 'change-surround-any-pair-allow-forwarding', ->
       beforeEach ->
@@ -1147,7 +1147,7 @@ describe "Operator TransformString", ->
           |___<inner>
           ___(inner)
           """
-        ensureWait 'j', {}
+        ensureWait 'j'
         ensureWait '.',
           textC: """
           ___<inner>
@@ -1565,7 +1565,7 @@ describe "Operator TransformString", ->
               s = `abc def hij`
             }
             """
-        ensure 'j w', {}
+        ensure 'j w'
         ensure 'g , i (',
           textC: """
             hello = () => {

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -2,13 +2,14 @@
 settings = require '../lib/settings'
 
 describe "Operator TransformString", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait] = []
+  [editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure, ensureWait, bindEnsureOption, bindEnsureWaitOption, keystroke, keystrokeWait} = vim
 
   describe 'the ~ keybinding', ->
     beforeEach ->
@@ -624,7 +625,7 @@ describe "Operator TransformString", ->
         ensure '2 h .', text_: "( [{abc}] )"
         ensure '2 h .', text_: "([{abc}])"
 
-  describe 'surround', ->
+  describe 'surround family', ->
     beforeEach ->
       keymapsForSurround = {
         'atom-text-editor.vim-mode-plus.normal-mode':
@@ -712,7 +713,7 @@ describe "Operator TransformString", ->
           ensure "c S (",
             selectedTextOrdered: ["(abc)", "(ghi)", "(mno)"] # early select(for better UX) effect.
 
-          ensure "escape", # On choosing deleting pair-char
+          ensureWait "escape", # On choosing deleting pair-char
             mode: "normal"
             textC: """
             (a|bc) def
@@ -726,9 +727,9 @@ describe "Operator TransformString", ->
             'atom-text-editor.vim-mode-plus.normal-mode':
               'y s w': 'vim-mode-plus:surround-word'
 
-        it "[from normal] keep multpcursor on cancel", ->
-          ensure "y s w", selectedTextOrdered: ["abc", "ghi", "mno"] # early select(for better UX) effect.
-          ensure "escape",
+        it "[from normal] keep multi cursor on cancel", ->
+          ensure "y s w", selectedTextOrdered: ["abc", "ghi", "mno"] # select target immediately
+          ensureWait "escape",
             mode: "normal"
             textC: """
             (a|bc) def
@@ -737,49 +738,44 @@ describe "Operator TransformString", ->
             """
 
     describe 'alias keymap for surround, change-surround, delete-surround', ->
-      it "surround by aliased char", ->
-        set textC: "|abc"; ensure 'y s i w b', text: "(abc)"
-        set textC: "|abc"; ensure 'y s i w B', text: "{abc}"
-        set textC: "|abc"; ensure 'y s i w r', text: "[abc]"
-        set textC: "|abc"; ensure 'y s i w a', text: "<abc>"
-      it "delete surround by aliased char", ->
-        set textC: "|(abc)"; ensure 'd S b', text: "abc"
-        set textC: "|{abc}"; ensure 'd S B', text: "abc"
-        set textC: "|[abc]"; ensure 'd S r', text: "abc"
-        set textC: "|<abc>"; ensure 'd S a', text: "abc"
-      it "change surround by aliased char", ->
-        set textC: "|(abc)"; ensure 'c S b B', text: "{abc}"
-        set textC: "|(abc)"; ensure 'c S b r', text: "[abc]"
-        set textC: "|(abc)"; ensure 'c S b a', text: "<abc>"
+      describe "surround by aliased char", ->
+        it "c1", -> set textC: "|abc"; ensureWait 'y s i w b', text: "(abc)"
+        it "c2", -> set textC: "|abc"; ensureWait 'y s i w B', text: "{abc}"
+        it "c3", -> set textC: "|abc"; ensureWait 'y s i w r', text: "[abc]"
+        it "c4", -> set textC: "|abc"; ensureWait 'y s i w a', text: "<abc>"
+      describe "delete surround by aliased char", ->
+        it "c1", -> set textC: "|(abc)"; ensure 'd S b', text: "abc"
+        it "c2", -> set textC: "|{abc}"; ensure 'd S B', text: "abc"
+        it "c3", -> set textC: "|[abc]"; ensure 'd S r', text: "abc"
+        it "c4", -> set textC: "|<abc>"; ensure 'd S a', text: "abc"
+      describe "change surround by aliased char", ->
+        it "c1", -> set textC: "|(abc)"; ensureWait 'c S b B', text: "{abc}"
+        it "c2", -> set textC: "|(abc)"; ensureWait 'c S b r', text: "[abc]"
+        it "c3", -> set textC: "|(abc)"; ensureWait 'c S b a', text: "<abc>"
 
-        set textC: "|{abc}"; ensure 'c S B b', text: "(abc)"
-        set textC: "|{abc}"; ensure 'c S B r', text: "[abc]"
-        set textC: "|{abc}"; ensure 'c S B a', text: "<abc>"
+        it "c4", -> set textC: "|{abc}"; ensureWait 'c S B b', text: "(abc)"
+        it "c5", -> set textC: "|{abc}"; ensureWait 'c S B r', text: "[abc]"
+        it "c6", -> set textC: "|{abc}"; ensureWait 'c S B a', text: "<abc>"
 
-        set textC: "|[abc]"; ensure 'c S r b', text: "(abc)"
-        set textC: "|[abc]"; ensure 'c S r B', text: "{abc}"
-        set textC: "|[abc]"; ensure 'c S r a', text: "<abc>"
+        it "c7", -> set textC: "|[abc]"; ensureWait 'c S r b', text: "(abc)"
+        it "c8", -> set textC: "|[abc]"; ensureWait 'c S r B', text: "{abc}"
+        it "c9", -> set textC: "|[abc]"; ensureWait 'c S r a', text: "<abc>"
 
-        set textC: "|<abc>"; ensure 'c S a b', text: "(abc)"
-        set textC: "|<abc>"; ensure 'c S a B', text: "{abc}"
-        set textC: "|<abc>"; ensure 'c S a r', text: "[abc]"
+        it "c10", -> set textC: "|<abc>"; ensureWait 'c S a b', text: "(abc)"
+        it "c11", -> set textC: "|<abc>"; ensureWait 'c S a B', text: "{abc}"
+        it "c12", -> set textC: "|<abc>"; ensureWait 'c S a r', text: "[abc]"
 
     describe 'surround', ->
-      it "surround text object with ( and repeatable", ->
-        ensure 'y s i w (',
-          textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensure 'j .',
-          text: "(apple)\n(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
-      it "surround text object with { and repeatable", ->
-        ensure 'y s i w {',
-          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensure 'j .',
-          textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
-      it "surround current-line", ->
-        ensure 'y s s {',
-          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensure 'j .',
-          textC: "{apple}\n|{pairs: [brackets]}\npairs: [brackets]\n( multi\n  line )"
+      describe 'basic behavior', ->
+        it "surround text object with ( and repeatable", ->
+          ensureWait 'y s i w (', textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+          ensureWait 'j .',       textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
+        it "surround text object with { and repeatable", ->
+          ensureWait 'y s i w {', textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+          ensureWait 'j .',       textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        it "surround current-line", ->
+          ensureWait 'y s s {', textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+          ensureWait 'j .',     textC: "{apple}\n|{pairs: [brackets]}\npairs: [brackets]\n( multi\n  line )"
 
       describe 'adjustIndentation when surround linewise target', ->
         beforeEach ->
@@ -797,7 +793,7 @@ describe "Operator TransformString", ->
               grammar: 'source.js'
 
         it "adjustIndentation surrounded text ", ->
-          ensure 'y s i f {',
+          ensureWait 'y s i f {',
             textC: """
               function hello() {
               |  {
@@ -813,7 +809,7 @@ describe "Operator TransformString", ->
           set text: "s _____ e", cursor: [0, 0]
         describe "with 'f' motion", ->
           it "surround with 'f' motion", ->
-            ensure 'y s f e (', text: "(s _____ e)", cursor: [0, 0]
+            ensureWait 'y s f e (', text: "(s _____ e)", cursor: [0, 0]
 
         describe "with '`' motion", ->
           beforeEach ->
@@ -822,7 +818,7 @@ describe "Operator TransformString", ->
             set cursor: [0, 0]
 
           it "surround with '`' motion", ->
-            ensure 'y s ` a (', text: "(s _____ )e", cursor: [0, 0]
+            ensureWait 'y s ` a (', text: "(s _____ )e", cursor: [0, 0]
 
       describe 'charactersToAddSpaceOnSurround setting', ->
         beforeEach ->
@@ -832,45 +828,42 @@ describe "Operator TransformString", ->
 
         describe "char is in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
-            ensure 'y s i w (', text: "( apple )\norange\nlemmon"
-            keystroke 'j'
-            ensure 'y s i w {', text: "( apple )\n{ orange }\nlemmon"
-            keystroke 'j'
-            ensure 'y s i w [', text: "( apple )\n{ orange }\n[ lemmon ]"
+            ensureWait 'y s i w (', text: "( apple )\norange\nlemmon"
+            ensureWait "j", {}
+            ensureWait 'y s i w {', text: "( apple )\n{ orange }\nlemmon"
+            ensureWait "j", {}
+            ensureWait 'y s i w [', text: "( apple )\n{ orange }\n[ lemmon ]"
 
         describe "char is not in charactersToAddSpaceOnSurround", ->
           it "add additional space inside pair char when surround", ->
-            ensure 'y s i w )', text: "(apple)\norange\nlemmon"
-            keystroke 'j'
-            ensure 'y s i w }', text: "(apple)\n{orange}\nlemmon"
-            keystroke 'j'
-            ensure 'y s i w ]', text: "(apple)\n{orange}\n[lemmon]"
+            ensureWait 'y s i w )', text: "(apple)\norange\nlemmon"
+            ensureWait "j", {}
+            ensureWait 'y s i w }', text: "(apple)\n{orange}\nlemmon"
+            ensureWait "j", {}
+            ensureWait 'y s i w ]', text: "(apple)\n{orange}\n[lemmon]"
 
         describe "it distinctively handle aliased keymap", ->
+          beforeEach -> set textC: "|abc"
           describe "normal pair-chars are set to add space", ->
-            beforeEach ->
-              settings.set('charactersToAddSpaceOnSurround', ['(', '{', '[', '<'])
-            it "distinctively handle", ->
-              set textC: "|abc"; ensure 'y s i w (', text: "( abc )"
-              set textC: "|abc"; ensure 'y s i w b', text: "(abc)"
-              set textC: "|abc"; ensure 'y s i w {', text: "{ abc }"
-              set textC: "|abc"; ensure 'y s i w B', text: "{abc}"
-              set textC: "|abc"; ensure 'y s i w [', text: "[ abc ]"
-              set textC: "|abc"; ensure 'y s i w r', text: "[abc]"
-              set textC: "|abc"; ensure 'y s i w <', text: "< abc >"
-              set textC: "|abc"; ensure 'y s i w a', text: "<abc>"
+            beforeEach -> settings.set('charactersToAddSpaceOnSurround', ['(', '{', '[', '<'])
+            it "c1", -> ensureWait 'y s i w (', text: "( abc )"
+            it "c2", -> ensureWait 'y s i w b', text: "(abc)"
+            it "c3", -> ensureWait 'y s i w {', text: "{ abc }"
+            it "c4", -> ensureWait 'y s i w B', text: "{abc}"
+            it "c5", -> ensureWait 'y s i w [', text: "[ abc ]"
+            it "c6", -> ensureWait 'y s i w r', text: "[abc]"
+            it "c7", -> ensureWait 'y s i w <', text: "< abc >"
+            it "c8", -> ensureWait 'y s i w a', text: "<abc>"
           describe "aliased pair-chars are set to add space", ->
-            beforeEach ->
-              settings.set('charactersToAddSpaceOnSurround', ['b', 'B', 'r', 'a'])
-            it "distinctively handle", ->
-              set textC: "|abc"; ensure 'y s i w (', text: "(abc)"
-              set textC: "|abc"; ensure 'y s i w b', text: "( abc )"
-              set textC: "|abc"; ensure 'y s i w {', text: "{abc}"
-              set textC: "|abc"; ensure 'y s i w B', text: "{ abc }"
-              set textC: "|abc"; ensure 'y s i w [', text: "[abc]"
-              set textC: "|abc"; ensure 'y s i w r', text: "[ abc ]"
-              set textC: "|abc"; ensure 'y s i w <', text: "<abc>"
-              set textC: "|abc"; ensure 'y s i w a', text: "< abc >"
+            beforeEach -> settings.set('charactersToAddSpaceOnSurround', ['b', 'B', 'r', 'a'])
+            it "c1", -> ensureWait 'y s i w (', text: "(abc)"
+            it "c2", -> ensureWait 'y s i w b', text: "( abc )"
+            it "c3", -> ensureWait 'y s i w {', text: "{abc}"
+            it "c4", -> ensureWait 'y s i w B', text: "{ abc }"
+            it "c5", -> ensureWait 'y s i w [', text: "[abc]"
+            it "c6", -> ensureWait 'y s i w r', text: "[ abc ]"
+            it "c7", -> ensureWait 'y s i w <', text: "<abc>"
+            it "c8", -> ensureWait 'y s i w a', text: "< abc >"
 
     describe 'map-surround', ->
       beforeEach ->
@@ -893,10 +886,10 @@ describe "Operator TransformString", ->
             'm s':  'vim-mode-plus:map-surround'
 
       it "surround text for each word in target case-1", ->
-        ensure 'm s i p (',
-          textC: """
+        ensureWait 'm s i p (',
+          text: """
 
-          |(apple)
+          (apple)
           (pairs) (tomato)
           (orange)
           (milk)
@@ -904,7 +897,7 @@ describe "Operator TransformString", ->
           """
       it "surround text for each word in target case-2", ->
         set cursor: [2, 1]
-        ensure 'm s i l <',
+        ensureWait 'm s i l <',
           textC: """
 
           apple
@@ -913,10 +906,9 @@ describe "Operator TransformString", ->
           milk
 
           """
-      # TODO#698 FIX when finished
       it "surround text for each word in visual selection", ->
         settings.set("stayOnSelectTextObject", true)
-        ensure 'v i p m s "',
+        ensureWait 'v i p m s "',
           textC: """
 
           "apple"
@@ -985,14 +977,14 @@ describe "Operator TransformString", ->
             """
           cursor: [0, 1]
       it "change surrounded chars and repeatable", ->
-        ensure 'c S ( [',
+        ensureWait 'c S ( [',
           text: """
             [apple]
             (grape)
             <lemmon>
             {orange}
             """
-        ensure 'j l .',
+        ensureWait 'j l .',
           text: """
             [apple]
             [grape]
@@ -1000,14 +992,17 @@ describe "Operator TransformString", ->
             {orange}
             """
       it "change surrounded chars", ->
-        ensure 'j j c S < "',
+        ensureWait "2 j", {}
+        ensureWait 'c S < "',
           text: """
             (apple)
             (grape)
             "lemmon"
             {orange}
             """
-        ensure 'j l c S { !',
+        ensureWait "j", {}
+        ensureWait "l", {}
+        ensureWait 'c S { !',
           text: """
             (apple)
             (grape)
@@ -1024,7 +1019,7 @@ describe "Operator TransformString", ->
               hello: world
             }
             """
-        ensure 'c S { (',
+        ensureWait 'c S { (',
           text: """
             highlightRanges @editor, range, (
               timeout: timeout
@@ -1037,25 +1032,24 @@ describe "Operator TransformString", ->
           settings.set('charactersToAddSpaceOnSurround', ['(', '{', '['])
 
         describe 'when input char is in charactersToAddSpaceOnSurround', ->
-          describe 'single line text', ->
-            it "add single space around pair regardless of exsiting inner text", ->
-              set textC: "|(apple)";     ensure 'c S ( {', text: "{ apple }"
-              set textC: "|( apple )";   ensure 'c S ( {', text: "{ apple }"
-              set textC: "|(  apple  )"; ensure 'c S ( {', text: "{ apple }"
+          describe '[single line text] add single space around pair regardless of exsiting inner text', ->
+            it "case1", -> set textC: "|(apple)";     ensureWait 'c S ( {', text: "{ apple }"
+            it "case2", -> set textC: "|( apple )";   ensureWait 'c S ( {', text: "{ apple }"
+            it "case3", -> set textC: "|(  apple  )"; ensureWait 'c S ( {', text: "{ apple }"
 
-          describe 'multi line text', ->
-            it "don't sadd single space around pair", ->
-              set textC: "|(\napple\n)"; ensure "c S ( {", text: "{\napple\n}"
+          describe "[multi line text] don't add single space around pair", ->
+            it "don't add single space around pair", ->
+              set textC: "|(\napple\n)"; ensureWait "c S ( {", text: "{\napple\n}"
 
         describe 'when first input char is not in charactersToAddSpaceOnSurround', ->
-          it "remove surrounding space of inner text for identical pair-char", ->
-            set textC: "|(apple)";     ensure "c S ( }", text: "{apple}"
-            set textC: "|( apple )";   ensure "c S ( }", text: "{apple}"
-            set textC: "|(  apple  )"; ensure "c S ( }", text: "{apple}"
-          it "doesn't remove surrounding space of inner text for non-identical pair-char", ->
-            set textC: '|"apple"';     ensure 'c S " `', text: "`apple`"
-            set textC: '|"  apple  "'; ensure 'c S " `', text: "`  apple  `"
-            set textC: '|"  apple  "'; ensure 'c S " \'', text: "'  apple  '"
+          describe "remove surrounding space of inner text for identical pair-char", ->
+            it "case1", -> set textC: "|(apple)";     ensureWait "c S ( }", text: "{apple}"
+            it "case2", -> set textC: "|( apple )";   ensureWait "c S ( }", text: "{apple}"
+            it "case3", -> set textC: "|(  apple  )"; ensureWait "c S ( }", text: "{apple}"
+          describe "doesn't remove surrounding space of inner text for non-identical pair-char", ->
+            it "case1", -> set textC: '|"apple"';     ensureWait 'c S " `', text: "`apple`"
+            it "case2", -> set textC: '|"  apple  "'; ensureWait 'c S " `', text: "`  apple  `"
+            it "case3", -> set textC: '|"  apple  "'; ensureWait 'c S " \'', text: "'  apple  '"
 
     describe 'surround-word', ->
       beforeEach ->
@@ -1064,15 +1058,11 @@ describe "Operator TransformString", ->
             'y s w': 'vim-mode-plus:surround-word'
 
       it "surround a word with ( and repeatable", ->
-        ensure 'y s w (',
-          textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensure 'j .',
-          textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'y s w (',               textC: "|(apple)\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j', {}; ensureWait '.', textC: "(apple)\n|(pairs): [brackets]\npairs: [brackets]\n( multi\n  line )"
       it "surround a word with { and repeatable", ->
-        ensure 'y s w {',
-          textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
-        ensure 'j .',
-          textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'y s w {',               textC: "|{apple}\npairs: [brackets]\npairs: [brackets]\n( multi\n  line )"
+        ensureWait 'j', {}; ensureWait '.', textC: "{apple}\n|{pairs}: [brackets]\npairs: [brackets]\n( multi\n  line )"
 
     describe 'delete-surround-any-pair', ->
       beforeEach ->
@@ -1086,24 +1076,18 @@ describe "Operator TransformString", ->
             """
 
       it "delete surrounded any pair found and repeatable", ->
-        ensure 'd s',
-          text: 'apple\n(pairs: brackets)\n{pairs "s" [brackets]}\n( multi\n  line )'
-        ensure '.',
-          text: 'apple\npairs: brackets\n{pairs "s" [brackets]}\n( multi\n  line )'
+        ensure 'd s', text: 'apple\n(pairs: brackets)\n{pairs "s" [brackets]}\n( multi\n  line )'
+        ensure '.',   text: 'apple\npairs: brackets\n{pairs "s" [brackets]}\n( multi\n  line )'
 
       it "delete surrounded any pair found with skip pair out of cursor and repeatable", ->
         set cursor: [2, 14]
-        ensure 'd s',
-          text: 'apple\n(pairs: [brackets])\n{pairs "s" brackets}\n( multi\n  line )'
-        ensure '.',
-          text: 'apple\n(pairs: [brackets])\npairs "s" brackets\n( multi\n  line )'
-        ensure '.', # do nothing any more
-          text: 'apple\n(pairs: [brackets])\npairs "s" brackets\n( multi\n  line )'
+        ensure 'd s', text: 'apple\n(pairs: [brackets])\n{pairs "s" brackets}\n( multi\n  line )'
+        ensure '.',   text: 'apple\n(pairs: [brackets])\npairs "s" brackets\n( multi\n  line )'
+        ensure '.',   text: 'apple\n(pairs: [brackets])\npairs "s" brackets\n( multi\n  line )' # do nothing any more
 
       it "delete surrounded chars expanded to multi-line", ->
         set cursor: [3, 1]
-        ensure 'd s',
-          text: 'apple\n(pairs: [brackets])\n{pairs "s" [brackets]}\n multi\n  line '
+        ensure 'd s', text: 'apple\n(pairs: [brackets])\n{pairs "s" [brackets]}\n multi\n  line '
 
     describe 'delete-surround-any-pair-allow-forwarding', ->
       beforeEach ->
@@ -1141,9 +1125,9 @@ describe "Operator TransformString", ->
             """
 
       it "change any surrounded pair found and repeatable", ->
-        ensure 'c s <', textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
-        ensure 'j .', textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
-        ensure 'j j .', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
+        ensureWait 'c s <',                   textC: "|<apple>\n(grape)\n<lemmon>\n{orange}"
+        ensureWait 'j', {}; ensureWait '.',   textC: "<apple>\n|<grape>\n<lemmon>\n{orange}"
+        ensureWait '2 j', {}; ensureWait '.', textC: "<apple>\n<grape>\n<lemmon>\n|<orange>"
 
     describe 'change-surround-any-pair-allow-forwarding', ->
       beforeEach ->
@@ -1157,12 +1141,13 @@ describe "Operator TransformString", ->
           |___(inner)
           ___(inner)
           """
-        ensure 'c s <',
+        ensureWait 'c s <',
           textC: """
           |___<inner>
           ___(inner)
           """
-        ensure 'j .',
+        ensureWait 'j', {}
+        ensureWait '.',
           textC: """
           ___<inner>
           |___<inner>

--- a/spec/performance-spec.coffee
+++ b/spec/performance-spec.coffee
@@ -3,13 +3,13 @@ _ = require 'underscore-plus'
 {getVimState} = require './spec-helper'
 
 xdescribe "visual-mode performance", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, _vim) ->
       vimState = state # to refer as vimState later.
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
 
   afterEach ->
     vimState.resetNormalMode()
@@ -23,8 +23,8 @@ xdescribe "visual-mode performance", ->
       switch scenario
         when 'vmp'
           moveByVMP = ->
-            _.times moveCount, -> keystroke 'l'
-            _.times moveCount, -> keystroke 'h'
+            _.times moveCount, -> ensure 'l', {}
+            _.times moveCount, -> ensure 'h', {}
           _.times 10, -> measureWithTimeEnd(moveByVMP)
         when 'sel'
           moveBySelect = ->

--- a/spec/performance-spec.coffee
+++ b/spec/performance-spec.coffee
@@ -23,8 +23,8 @@ xdescribe "visual-mode performance", ->
       switch scenario
         when 'vmp'
           moveByVMP = ->
-            _.times moveCount, -> ensure 'l', {}
-            _.times moveCount, -> ensure 'h', {}
+            _.times moveCount, -> ensure 'l'
+            _.times moveCount, -> ensure 'h'
           _.times 10, -> measureWithTimeEnd(moveByVMP)
         when 'sel'
           moveBySelect = ->

--- a/spec/persistent-selection-spec.coffee
+++ b/spec/persistent-selection-spec.coffee
@@ -22,7 +22,7 @@ describe "Persistent Selection", ->
         when 2 then [_keystroke, options] = args
 
       if _keystroke?
-        ensure(_keystroke, {})
+        ensure(_keystroke)
 
       markers = vimState.persistentSelection.getMarkers()
       if options.length?
@@ -33,7 +33,7 @@ describe "Persistent Selection", ->
         expect(text).toEqual(options.text)
 
       if options.mode?
-        ensure mode: options.mode
+        ensure null, mode: options.mode
 
     beforeEach ->
       atom.keymaps.add "test",
@@ -148,9 +148,9 @@ describe "Persistent Selection", ->
         runs ->
           ensure 'g cmd-d',
             selectedText: ['ooo', 'ooo', 'ooo', 'ooo', 'ooo', 'ooo' ]
-          ensure 'c', {}
+          ensure 'c'
           editor.insertText '!!!'
-          ensure
+          ensure null,
             text: """
             !!! xxx !!!
             xxx !!! xxx

--- a/spec/persistent-selection-spec.coffee
+++ b/spec/persistent-selection-spec.coffee
@@ -2,13 +2,13 @@
 settings = require '../lib/settings'
 
 describe "Persistent Selection", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, _vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = _vim
+      {set, ensure} = _vim
     runs ->
       jasmine.attachToDOM(editorElement)
 
@@ -22,7 +22,7 @@ describe "Persistent Selection", ->
         when 2 then [_keystroke, options] = args
 
       if _keystroke?
-        keystroke(_keystroke)
+        ensure(_keystroke, {})
 
       markers = vimState.persistentSelection.getMarkers()
       if options.length?
@@ -148,7 +148,7 @@ describe "Persistent Selection", ->
         runs ->
           ensure 'g cmd-d',
             selectedText: ['ooo', 'ooo', 'ooo', 'ooo', 'ooo', 'ooo' ]
-          keystroke 'c'
+          ensure 'c', {}
           editor.insertText '!!!'
           ensure
             text: """

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -42,12 +42,12 @@ describe "Prefixes", ->
     describe "the a register", ->
       it "saves a value for future reading", ->
         set    register: a: text: 'new content'
-        ensure register: a: text: 'new content'
+        ensure null, register: a: text: 'new content'
 
       it "overwrites a value previously in the register", ->
         set    register: a: text: 'content'
         set    register: a: text: 'new content'
-        ensure register: a: text: 'new content'
+        ensure null, register: a: text: 'new content'
 
     describe "with yank command", ->
       beforeEach ->
@@ -77,7 +77,7 @@ describe "Prefixes", ->
 
       describe "when specified register have no text", ->
         it "can paste from a register", ->
-          ensure mode: "normal"
+          ensure null, mode: "normal"
           ensure '" a p',
             textC: """
             anew conten|tbc
@@ -102,28 +102,28 @@ describe "Prefixes", ->
     describe "the B register", ->
       it "saves a value for future reading", ->
         set    register: B: text: 'new content'
-        ensure register: b: text: 'new content'
-        ensure register: B: text: 'new content'
+        ensure null, register: b: text: 'new content'
+        ensure null, register: B: text: 'new content'
 
       it "appends to a value previously in the register", ->
         set    register: b: text: 'content'
         set    register: B: text: 'new content'
-        ensure register: b: text: 'contentnew content'
+        ensure null, register: b: text: 'contentnew content'
 
       it "appends linewise to a linewise value previously in the register", ->
         set    register: b: text: 'content\n', type: 'linewise'
         set    register: B: text: 'new content'
-        ensure register: b: text: 'content\nnew content\n'
+        ensure null, register: b: text: 'content\nnew content\n'
 
       it "appends linewise to a character value previously in the register", ->
         set    register: b: text: 'content'
         set    register: B: text: 'new content\n', type: 'linewise'
-        ensure register: b: text: 'content\nnew content\n'
+        ensure null, register: b: text: 'content\nnew content\n'
 
     describe "the * register", ->
       describe "reading", ->
         it "is the same the system clipboard", ->
-          ensure register: '*': text: 'initial clipboard content', type: 'characterwise'
+          ensure null, register: '*': text: 'initial clipboard content', type: 'characterwise'
 
       describe "writing", ->
         beforeEach ->
@@ -139,7 +139,7 @@ describe "Prefixes", ->
     describe "the + register", ->
       describe "reading", ->
         it "is the same the system clipboard", ->
-          ensure register:
+          ensure null, register:
             '*': text: 'initial clipboard content', type: 'characterwise'
 
       describe "writing", ->
@@ -152,12 +152,12 @@ describe "Prefixes", ->
     describe "the _ register", ->
       describe "reading", ->
         it "is always the empty string", ->
-          ensure register: '_': text: ''
+          ensure null, register: '_': text: ''
 
       describe "writing", ->
         it "throws away anything written to it", ->
           set register:    '_': text: 'new content'
-          ensure register: '_': text: ''
+          ensure null, register: '_': text: ''
 
     describe "the % register", ->
       beforeEach ->
@@ -165,17 +165,17 @@ describe "Prefixes", ->
 
       describe "reading", ->
         it "returns the filename of the current editor", ->
-          ensure register: '%': text: '/Users/atom/known_value.txt'
+          ensure null, register: '%': text: '/Users/atom/known_value.txt'
 
       describe "writing", ->
         it "throws away anything written to it", ->
           set    register: '%': text: 'new content'
-          ensure register: '%': text: '/Users/atom/known_value.txt'
+          ensure null, register: '%': text: '/Users/atom/known_value.txt'
 
     describe "the numbered 0-9 register", ->
       describe "0", ->
         it "keep most recent yank-ed text", ->
-          ensure register: '"': {text: 'initial clipboard content'}, '0': {text: undefined}
+          ensure null, register: '"': {text: 'initial clipboard content'}, '0': {text: undefined}
           set textC: "|000"
           ensure "y w", register: '"': {text: "000"}, '0': {text: "000"}
           ensure "y l", register: '"': {text: "0"}, '0': {text: "0"}
@@ -354,7 +354,7 @@ describe "Prefixes", ->
     describe "per selection clipboard", ->
       ensurePerSelectionRegister = (texts...) ->
         for selection, i in editor.getSelections()
-          ensure register: '*': {text: texts[i], selection: selection}
+          ensure null, register: '*': {text: texts[i], selection: selection}
 
       beforeEach ->
         settings.set 'useClipboardAsDefaultRegister', true
@@ -372,7 +372,7 @@ describe "Prefixes", ->
           expect(clipboardBySelection.size).toBe(0)
           expect(subscriptionBySelection.size).toBe(0)
 
-          ensure "y i w", {}
+          ensure "y i w"
           ensurePerSelectionRegister('012', 'abc', 'def')
 
           expect(clipboardBySelection.size).toBe(3)
@@ -383,7 +383,7 @@ describe "Prefixes", ->
 
       describe "Yank", ->
         it "save text to per selection register", ->
-          ensure "y i w", {}
+          ensure "y i w"
           ensurePerSelectionRegister('012', 'abc', 'def')
 
       describe "Delete family", ->
@@ -458,7 +458,7 @@ describe "Prefixes", ->
         textC: "a|bc"
 
     describe "when false(default)", ->
-      it "default",  -> ensure        register: {'"': text: originalText}
+      it "default",  -> ensure null,  register: {'"': text: originalText}
       it 'c update', -> ensure 'c l', register: {'"': text: 'b'}
       it 'C update', -> ensure 'C',   register: {'"': text: 'bc'}
       it 'x update', -> ensure 'x',   register: {'"': text: 'b'}
@@ -494,7 +494,7 @@ describe "Prefixes", ->
             # "substitute*"
           ]
 
-        it "default",      -> ensure        register: {'"': text: originalText}
+        it "default",      -> ensure null,  register: {'"': text: originalText}
         it 'c NOT update', -> ensure 'c l', register: {'"': text: originalText}
         it 'C NOT update', -> ensure 'C',   register: {'"': text: originalText}
         it 'x NOT update', -> ensure 'x',   register: {'"': text: originalText}
@@ -514,7 +514,7 @@ describe "Prefixes", ->
             "substitute" # s
           ]
 
-        it "default",      -> ensure        register: {'"': text: originalText}
+        it "default",      -> ensure null,  register: {'"': text: originalText}
         it 'c update',     -> ensure 'c l', register: {'"': text: 'b'}
         it 'C NOT update', -> ensure 'C',   register: {'"': text: originalText}
         it 'x NOT update', -> ensure 'x',   register: {'"': text: originalText}
@@ -535,7 +535,7 @@ describe "Prefixes", ->
             # "yank*"
           ]
 
-        it "default",               -> ensure            register: {'"': text: originalText}
+        it "default",               -> ensure null,      register: {'"': text: originalText}
         it 'c NOT update',          -> ensure 'c l',     register: {'"': text: originalText}
         it 'c update if specified', -> ensure '" a c l', register: {'a': text: "b"}
         it 'c NOT update',          -> ensure 'c l',     register: {'"': text: originalText}

--- a/spec/prefix-spec.coffee
+++ b/spec/prefix-spec.coffee
@@ -2,13 +2,13 @@
 settings = require '../lib/settings'
 
 describe "Prefixes", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
   describe "Repeat", ->
     describe "with operations", ->
@@ -372,7 +372,7 @@ describe "Prefixes", ->
           expect(clipboardBySelection.size).toBe(0)
           expect(subscriptionBySelection.size).toBe(0)
 
-          keystroke "y i w"
+          ensure "y i w", {}
           ensurePerSelectionRegister('012', 'abc', 'def')
 
           expect(clipboardBySelection.size).toBe(3)
@@ -383,7 +383,7 @@ describe "Prefixes", ->
 
       describe "Yank", ->
         it "save text to per selection register", ->
-          keystroke "y i w"
+          ensure "y i w", {}
           ensurePerSelectionRegister('012', 'abc', 'def')
 
       describe "Delete family", ->

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -63,37 +63,37 @@ describe "Scrolling", ->
 
     describe "the z<CR> keybinding", ->
       it "moves the screen to position cursor at the top of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z enter', {}
+        ensure 'z enter'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zt keybinding", ->
       it "moves the screen to position cursor at the top of the window and leave cursor in the same column", ->
-        ensure 'z t', {}
+        ensure 'z t'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z. keybinding", ->
       it "moves the screen to position cursor at the center of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z .', {}
+        ensure 'z .'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zz keybinding", ->
       it "moves the screen to position cursor at the center of the window and leave cursor in the same column", ->
-        ensure 'z z', {}
+        ensure 'z z'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z- keybinding", ->
       it "moves the screen to position cursor at the bottom of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z -', {}
+        ensure 'z -'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zb keybinding", ->
       it "moves the screen to position cursor at the bottom of the window and leave cursor in the same column", ->
-        ensure 'z b', {}
+        ensure 'z b'
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
@@ -116,7 +116,7 @@ describe "Scrolling", ->
 
       zsPos = (pos) ->
         editor.setCursorBufferPosition([0, pos])
-        ensure 'z s', {}
+        ensure 'z s'
         editorElement.getScrollLeft()
 
       beforeEach ->
@@ -158,7 +158,7 @@ describe "Scrolling", ->
     describe "the ze keybinding", ->
       zePos = (pos) ->
         editor.setCursorBufferPosition([0, pos])
-        ensure 'z e', {}
+        ensure 'z e'
         editorElement.getScrollLeft()
 
       startPosition = null

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -1,13 +1,13 @@
 {getVimState} = require './spec-helper'
 
 describe "Scrolling", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
       jasmine.attachToDOM(editorElement)
 
   describe "scrolling keybindings", ->
@@ -63,37 +63,37 @@ describe "Scrolling", ->
 
     describe "the z<CR> keybinding", ->
       it "moves the screen to position cursor at the top of the window and moves cursor to first non-blank in the line", ->
-        keystroke 'z enter'
+        ensure 'z enter', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zt keybinding", ->
       it "moves the screen to position cursor at the top of the window and leave cursor in the same column", ->
-        keystroke 'z t'
+        ensure 'z t', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z. keybinding", ->
       it "moves the screen to position cursor at the center of the window and moves cursor to first non-blank in the line", ->
-        keystroke 'z .'
+        ensure 'z .', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zz keybinding", ->
       it "moves the screen to position cursor at the center of the window and leave cursor in the same column", ->
-        keystroke 'z z'
+        ensure 'z z', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
     describe "the z- keybinding", ->
       it "moves the screen to position cursor at the bottom of the window and moves cursor to first non-blank in the line", ->
-        keystroke 'z -'
+        ensure 'z -', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
 
     describe "the zb keybinding", ->
       it "moves the screen to position cursor at the bottom of the window and leave cursor in the same column", ->
-        keystroke 'z b'
+        ensure 'z b', {}
         expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
         expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
 
@@ -116,7 +116,7 @@ describe "Scrolling", ->
 
       zsPos = (pos) ->
         editor.setCursorBufferPosition([0, pos])
-        keystroke 'z s'
+        ensure 'z s', {}
         editorElement.getScrollLeft()
 
       beforeEach ->
@@ -158,7 +158,7 @@ describe "Scrolling", ->
     describe "the ze keybinding", ->
       zePos = (pos) ->
         editor.setCursorBufferPosition([0, pos])
-        keystroke 'z e'
+        ensure 'z e', {}
         editorElement.getScrollLeft()
 
       startPosition = null

--- a/spec/spec-helper-spec.coffee
+++ b/spec/spec-helper-spec.coffee
@@ -24,20 +24,20 @@ describe "mini DSL used in vim-mode-plus's spec", ->
     describe "| represent cursor", ->
       beforeEach ->
         set textC: "|abc"
-        ensure text: "abc", cursor: [0, 0] # explanatory purpose
+        ensure null, text: "abc", cursor: [0, 0] # explanatory purpose
 
       it "toggle and move right", ->
         ensure "~", textC: "A|bc"
-        ensure text: "Abc", cursor: [0, 1] # explanatory purpose
+        ensure null, text: "Abc", cursor: [0, 1] # explanatory purpose
 
     describe "! represent cursor", ->
       beforeEach ->
         set textC: "!abc"
-        ensure text: "abc", cursor: [0, 0] # explanatory purpose
+        ensure null, text: "abc", cursor: [0, 0] # explanatory purpose
 
       it "toggle and move right", ->
         ensure "~", textC: "A!bc"
-        ensure text: "Abc", cursor: [0, 1] # explanatory purpose
+        ensure null, text: "Abc", cursor: [0, 1] # explanatory purpose
 
     describe "| and ! is exchangable", ->
       it "both are OK", ->
@@ -56,29 +56,29 @@ describe "mini DSL used in vim-mode-plus's spec", ->
           |1: line1
           """
 
-        ensure cursor: [[0, 0], [1, 0]]
+        ensure null, cursor: [[0, 0], [1, 0]]
         expect(editor.getLastCursor().getBufferPosition()).toEqual([1, 0])
 
     describe "with ! cursor", ->
       it "! become last cursor", ->
         set textC: "|012|345|678"
-        ensure textC: "|012|345|678"
-        ensure cursor: [[0, 0], [0, 3], [0, 6]]
+        ensure null, textC: "|012|345|678"
+        ensure null, cursor: [[0, 0], [0, 3], [0, 6]]
         expect(editor.getLastCursor().getBufferPosition()).toEqual([0, 6])
 
         set textC: "!012|345|678"
-        ensure textC: "!012|345|678"
-        ensure cursor: [[0, 3], [0, 6], [0, 0]]
+        ensure null, textC: "!012|345|678"
+        ensure null, cursor: [[0, 3], [0, 6], [0, 0]]
         expect(editor.getLastCursor().getBufferPosition()).toEqual([0, 0])
 
         set textC: "|012!345|678"
-        ensure textC: "|012!345|678"
-        ensure cursor: [[0, 0], [0, 6], [0, 3]]
+        ensure null, textC: "|012!345|678"
+        ensure null, cursor: [[0, 0], [0, 6], [0, 3]]
         expect(editor.getLastCursor().getBufferPosition()).toEqual([0, 3])
 
         set textC: "|012|345!678"
-        ensure textC: "|012|345!678"
-        ensure cursor: [[0, 0], [0, 3], [0, 6]]
+        ensure null, textC: "|012|345!678"
+        ensure null, cursor: [[0, 0], [0, 3], [0, 6]]
         expect(editor.getLastCursor().getBufferPosition()).toEqual([0, 6])
 
     describe "without ! cursor", ->
@@ -90,7 +90,7 @@ describe "mini DSL used in vim-mode-plus's spec", ->
           opqrstu\n
           """
 
-        ensure
+        ensure null,
           text: """
           abcdefg
           hijklmn
@@ -106,7 +106,7 @@ describe "mini DSL used in vim-mode-plus's spec", ->
           opqrstu\n
           """
 
-        ensure
+        ensure null,
           text: """
           AbCdeFg
           hiJklmn

--- a/spec/spec-helper-spec.coffee
+++ b/spec/spec-helper-spec.coffee
@@ -2,13 +2,13 @@
 settings = require '../lib/settings'
 
 describe "mini DSL used in vim-mode-plus's spec", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
     runs ->
       jasmine.attachToDOM(editorElement)

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -312,7 +312,7 @@ class VimEditor
   _keystroke: (keys, options={}) =>
     target = @editorElement
     keystrokesToExecute = keys.split(/\s+/)
-    lastKeystrokeIndex = keystrokesToExecute.length - 2
+    lastKeystrokeIndex = keystrokesToExecute.length - 1
 
     for key, i in keystrokesToExecute
       waitsForFinish = (i is lastKeystrokeIndex) and options.waitsForFinish

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -274,8 +274,10 @@ class VimEditor
   # Public
   ensure: (args...) =>
     switch args.length
-      when 1 then [options] = args
-      when 2 then [keystroke, options] = args
+      when 1
+        [options] = args
+      when 2
+        [keystroke, options] = args
 
     unless typeof(options) is 'object'
       throw new Error("Invalid options for 'ensure': must be 'object' but got '#{typeof(options)}'")
@@ -290,7 +292,7 @@ class VimEditor
     runSmart = (fn) -> if keystrokeOptions.waitsForFinish then runs(fn) else fn()
 
     runSmart =>
-      @keystroke(keystroke, keystrokeOptions) unless _.isEmpty(keystroke)
+      @_keystroke(keystroke, keystrokeOptions) unless _.isEmpty(keystroke)
 
     runSmart =>
       for name in ensureOptionsOrdered when options[name]?
@@ -319,12 +321,12 @@ class VimEditor
   bindEnsureWaitOption: (optionsBase) =>
     @bindEnsureOption(optionsBase, true)
 
-  keystroke: (keys, options={}) =>
+  _keystroke: (keys, options={}) =>
     if options.waitsForFinish
       finished = false
       @vimState.onDidFinishOperation -> finished = true
       delete options.waitsForFinish
-      @keystroke(keys, options)
+      @_keystroke(keys, options)
       waitsFor -> finished
       return
 
@@ -353,8 +355,9 @@ class VimEditor
     if options.partialMatchTimeout
       advanceClock(atom.keymaps.getPartialMatchTimeout())
 
-  keystrokeWait: (keys, options={}) =>
-    @keystroke keys, Object.assign(waitsForFinish: true)
+  keystroke: ->
+    # DONT remove this method since field extraction is still used in vmp plugins
+    throw new Error('Dont use `keystroke("x y z")`, instead use `ensure("x y z", {})`')
 
   # Ensure each options from here
   # -----------------------------

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -272,13 +272,7 @@ class VimEditor
     {partialMatchTimeout, waitsForFinish}
 
   # Public
-  ensure: (args...) =>
-    switch args.length
-      when 1
-        [options] = args
-      when 2
-        [keystroke, options] = args
-
+  ensure: (keystroke, options={}) =>
     unless typeof(options) is 'object'
       throw new Error("Invalid options for 'ensure': must be 'object' but got '#{typeof(options)}'")
     if keystroke? and not (typeof(keystroke) is 'string' or Array.isArray(keystroke))
@@ -299,12 +293,8 @@ class VimEditor
         method = 'ensure' + _.capitalize(_.camelize(name))
         this[method](options[name])
 
-  ensureWait: (args...) =>
-    switch args.length
-      when 1 then [options] = args
-      when 2 then [keystroke, options] = args
-    options.waitsForFinish = true
-    @ensure(args...)
+  ensureWait: (keystroke, options={}) =>
+    @ensure(keystroke, Object.assign(options, waitsForFinish: true))
 
   bindEnsureOption: (optionsBase, wait=false) =>
     (keystroke, options) =>
@@ -357,7 +347,7 @@ class VimEditor
 
   keystroke: ->
     # DONT remove this method since field extraction is still used in vmp plugins
-    throw new Error('Dont use `keystroke("x y z")`, instead use `ensure("x y z", {})`')
+    throw new Error('Dont use `keystroke("x y z")`, instead use `ensure("x y z")`')
 
   # Ensure each options from here
   # -----------------------------

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -303,10 +303,8 @@ class VimEditor
         throw new Error("conflict with bound options #{inspect(intersectingOptions)}")
 
       options = _.defaults(_.clone(options), optionsBase)
-      if wait
-        @ensureWait(keystroke, options)
-      else
-        @ensure(keystroke, options)
+      options.waitsForFinish = true if wait
+      @ensure(keystroke, options)
 
   bindEnsureWaitOption: (optionsBase) =>
     @bindEnsureOption(optionsBase, true)

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -29,7 +29,7 @@ describe "TextObject", ->
       it "select that TextObject", ->
         set cursor: [8, 7]
         dispatch(editorElement, 'vim-mode-plus:inner-word')
-        ensure selectedText: 'QuickSort'
+        ensure null, selectedText: 'QuickSort'
 
   describe "Word", ->
     describe "inner-word", ->
@@ -145,7 +145,7 @@ describe "TextObject", ->
         ensure 'v a W', selectedBufferRange: [[0, 0], [0, 5]]
 
   describe "Subword", ->
-    escape = -> ensure('escape', {})
+    escape = -> ensure('escape')
     beforeEach ->
       atom.keymaps.add "test",
         'atom-text-editor.vim-mode-plus.operator-pending-mode, atom-text-editor.vim-mode-plus.visual-mode':
@@ -219,7 +219,7 @@ describe "TextObject", ->
             """
       it "can expand selection", ->
         set text: complexText, cursor: [2, 8]
-        ensure 'v', {}
+        ensure 'v'
         ensure 'i s', selectedText: """1s-1e"""
         ensure 'i s', selectedText: """2s(1s-1e)2e"""
         ensure 'i s', selectedText: """3s\n----"2s(1s-1e)2e"\n---3e"""
@@ -248,7 +248,7 @@ describe "TextObject", ->
             """
       it "can expand selection", ->
         set text: complexText, cursor: [2, 8]
-        ensure 'v', {}
+        ensure 'v'
         ensure 'a s', selectedText: """(1s-1e)"""
         ensure 'a s', selectedText: """\"2s(1s-1e)2e\""""
         ensure 'a s', selectedText: """{3s\n----"2s(1s-1e)2e"\n---3e}"""
@@ -267,7 +267,7 @@ describe "TextObject", ->
         ensure '.', text: """--"" ``  'efg'--"""
         ensure '.', text: """--"" ``  ''--"""
       it "can select next quote", ->
-        ensure 'v', {}
+        ensure 'v'
         ensure 'i q', selectedText: 'abc'
         ensure 'i q', selectedText: 'def'
         ensure 'i q', selectedText: 'efg'
@@ -277,7 +277,7 @@ describe "TextObject", ->
         ensure '.'  , text: """--   'efg'--"""
         ensure '.'  , text: """--   --"""
       it "can select next quote", ->
-        ensure 'v', {}
+        ensure 'v'
         ensure 'a q', selectedText: '"abc"'
         ensure 'a q', selectedText: '`def`'
         ensure 'a q', selectedText: "'efg'"
@@ -634,7 +634,7 @@ describe "TextObject", ->
               3
             }
             """
-          ensure mode: 'normal'
+          ensure null, mode: 'normal'
 
         it "from vC, final-mode is 'characterwise'", ->
           ensure 'v',
@@ -728,7 +728,7 @@ describe "TextObject", ->
 
             hello
             """
-          ensure mode: 'normal'
+          ensure null, mode: 'normal'
 
         it "from vC, final-mode is 'characterwise'", ->
           ensure 'v',
@@ -924,14 +924,14 @@ describe "TextObject", ->
     describe "inner", ->
       it "select forwarding range within enclosed range(if exists)", ->
         set cursor: [2, 0]
-        ensure 'v', {}
+        ensure 'v'
         ensure ';', selectedText: "222"
         ensure ';', selectedText: "333"
         ensure ';', selectedText: "444()444"
     describe "a", ->
       it "select forwarding range within enclosed range(if exists)", ->
         set cursor: [2, 0]
-        ensure 'v', {}
+        ensure 'v'
         ensure ':', selectedText: '"222"'
         ensure ':', selectedText: "{333}"
         ensure ':', selectedText: "(\n444()444\n)"
@@ -1453,7 +1453,7 @@ describe "TextObject", ->
 
       it "can expand selection", ->
         set cursor: [23, 0]
-        ensure 'v', {}
+        ensure 'v'
         ensure 'i z', selectedBufferRange: rangeForRows(23, 23)
         ensure 'i z', selectedBufferRange: rangeForRows(19, 23)
         ensure 'i z', selectedBufferRange: rangeForRows(10, 25)
@@ -1496,7 +1496,7 @@ describe "TextObject", ->
 
       it 'can expand selection', ->
         set cursor: [23, 0]
-        ensure 'v', {}
+        ensure 'v'
         ensure 'a z', selectedBufferRange: rangeForRows(22, 23)
         ensure 'a z', selectedBufferRange: rangeForRows(18, 23)
         ensure 'a z', selectedBufferRange: rangeForRows(9, 25)
@@ -2029,7 +2029,7 @@ describe "TextObject", ->
             3 xxx abc
             4 abc\n
             """
-        ensure 'escape', {}
+        ensure 'escape'
         set cursor: [4, 0]
         ensure 'c g N',
           cursor: [3, 6]

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "TextObject", ->
-  [set, ensure, ensureWait, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, ensureWait, editor, editorElement, vimState] = []
 
   getCheckFunctionFor = (textObject) ->
     (initialPoint, keystroke, options) ->
@@ -13,7 +13,7 @@ describe "TextObject", ->
     getVimState (state, vimEditor) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, ensureWait, keystroke} = vimEditor
+      {set, ensure, ensureWait} = vimEditor
 
   describe "TextObject", ->
     beforeEach ->
@@ -21,7 +21,7 @@ describe "TextObject", ->
         atom.packages.activatePackage('language-coffee-script')
       getVimState 'sample.coffee', (state, vimEditor) ->
         {editor, editorElement} = state
-        {set, ensure, keystroke} = vimEditor
+        {set, ensure} = vimEditor
     afterEach ->
       atom.packages.deactivatePackage('language-coffee-script')
 
@@ -145,7 +145,7 @@ describe "TextObject", ->
         ensure 'v a W', selectedBufferRange: [[0, 0], [0, 5]]
 
   describe "Subword", ->
-    escape = -> keystroke('escape')
+    escape = -> ensure('escape', {})
     beforeEach ->
       atom.keymaps.add "test",
         'atom-text-editor.vim-mode-plus.operator-pending-mode, atom-text-editor.vim-mode-plus.visual-mode':
@@ -219,7 +219,7 @@ describe "TextObject", ->
             """
       it "can expand selection", ->
         set text: complexText, cursor: [2, 8]
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'i s', selectedText: """1s-1e"""
         ensure 'i s', selectedText: """2s(1s-1e)2e"""
         ensure 'i s', selectedText: """3s\n----"2s(1s-1e)2e"\n---3e"""
@@ -248,7 +248,7 @@ describe "TextObject", ->
             """
       it "can expand selection", ->
         set text: complexText, cursor: [2, 8]
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'a s', selectedText: """(1s-1e)"""
         ensure 'a s', selectedText: """\"2s(1s-1e)2e\""""
         ensure 'a s', selectedText: """{3s\n----"2s(1s-1e)2e"\n---3e}"""
@@ -267,7 +267,7 @@ describe "TextObject", ->
         ensure '.', text: """--"" ``  'efg'--"""
         ensure '.', text: """--"" ``  ''--"""
       it "can select next quote", ->
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'i q', selectedText: 'abc'
         ensure 'i q', selectedText: 'def'
         ensure 'i q', selectedText: 'efg'
@@ -277,7 +277,7 @@ describe "TextObject", ->
         ensure '.'  , text: """--   'efg'--"""
         ensure '.'  , text: """--   --"""
       it "can select next quote", ->
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'a q', selectedText: '"abc"'
         ensure 'a q', selectedText: '`def`'
         ensure 'a q', selectedText: "'efg'"
@@ -924,14 +924,14 @@ describe "TextObject", ->
     describe "inner", ->
       it "select forwarding range within enclosed range(if exists)", ->
         set cursor: [2, 0]
-        keystroke 'v'
+        ensure 'v', {}
         ensure ';', selectedText: "222"
         ensure ';', selectedText: "333"
         ensure ';', selectedText: "444()444"
     describe "a", ->
       it "select forwarding range within enclosed range(if exists)", ->
         set cursor: [2, 0]
-        keystroke 'v'
+        ensure 'v', {}
         ensure ':', selectedText: '"222"'
         ensure ':', selectedText: "{333}"
         ensure ':', selectedText: "(\n444()444\n)"
@@ -1414,7 +1414,7 @@ describe "TextObject", ->
         atom.packages.activatePackage('language-coffee-script')
       getVimState 'sample.coffee', (vimState, vim) ->
         {editor, editorElement} = vimState
-        {set, ensure, keystroke} = vim
+        {set, ensure} = vim
     afterEach ->
       atom.packages.deactivatePackage('language-coffee-script')
 
@@ -1438,7 +1438,7 @@ describe "TextObject", ->
         atom.packages.activatePackage('language-coffee-script')
       getVimState 'sample.coffee', (vimState, vim) ->
         {editor, editorElement} = vimState
-        {set, ensure, keystroke} = vim
+        {set, ensure} = vim
     afterEach ->
       atom.packages.deactivatePackage('language-coffee-script')
 
@@ -1453,7 +1453,7 @@ describe "TextObject", ->
 
       it "can expand selection", ->
         set cursor: [23, 0]
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'i z', selectedBufferRange: rangeForRows(23, 23)
         ensure 'i z', selectedBufferRange: rangeForRows(19, 23)
         ensure 'i z', selectedBufferRange: rangeForRows(10, 25)
@@ -1476,7 +1476,7 @@ describe "TextObject", ->
             atom.packages.activatePackage('language-javascript')
           getVimState 'sample.js', (state, vimEditor) ->
             {editor, editorElement} = state
-            {set, ensure, keystroke} = vimEditor
+            {set, ensure} = vimEditor
         afterEach ->
           atom.packages.deactivatePackage('language-javascript')
 
@@ -1496,7 +1496,7 @@ describe "TextObject", ->
 
       it 'can expand selection', ->
         set cursor: [23, 0]
-        keystroke 'v'
+        ensure 'v', {}
         ensure 'a z', selectedBufferRange: rangeForRows(22, 23)
         ensure 'a z', selectedBufferRange: rangeForRows(18, 23)
         ensure 'a z', selectedBufferRange: rangeForRows(9, 25)
@@ -2029,7 +2029,7 @@ describe "TextObject", ->
             3 xxx abc
             4 abc\n
             """
-        keystroke 'escape'
+        ensure 'escape', {}
         set cursor: [4, 0]
         ensure 'c g N',
           cursor: [3, 6]

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -2,7 +2,7 @@
 settings = require '../lib/settings'
 
 describe "TextObject", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, ensureWait, keystroke, editor, editorElement, vimState] = []
 
   getCheckFunctionFor = (textObject) ->
     (initialPoint, keystroke, options) ->
@@ -13,7 +13,7 @@ describe "TextObject", ->
     getVimState (state, vimEditor) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vimEditor
+      {set, ensure, ensureWait, keystroke} = vimEditor
 
   describe "TextObject", ->
     beforeEach ->
@@ -291,46 +291,46 @@ describe "TextObject", ->
 
       describe "quote is un-balanced", ->
         it "case1", ->
-          set                 textC_: '_|_"____"____"'
-          ensure 'g r i " +', textC_: '__"|++++"____"'
+          set                     textC_: '_|_"____"____"'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"'
         it "case2", ->
-          set                 textC_: '__"__|__"____"'
-          ensure 'g r i " +', textC_: '__"|++++"____"'
+          set                     textC_: '__"__|__"____"'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"'
         it "case3", ->
-          set                 textC_: '__"____"__|__"'
-          ensure 'g r i " +', textC_: '__"____"|++++"'
+          set                     textC_: '__"____"__|__"'
+          ensureWait 'g r i " +', textC_: '__"____"|++++"'
         it "case4", ->
-          set                 textC_: '__|"____"____"'
-          ensure 'g r i " +', textC_: '__"|++++"____"'
+          set                     textC_: '__|"____"____"'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"'
         it "case5", ->
-          set                 textC_: '__"____|"____"'
-          ensure 'g r i " +', textC_: '__"|++++"____"'
+          set                     textC_: '__"____|"____"'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"'
         it "case6", ->
-          set                 textC_: '__"____"____|"'
-          ensure 'g r i " +', textC_: '__"____"|++++"'
+          set                     textC_: '__"____"____|"'
+          ensureWait 'g r i " +', textC_: '__"____"|++++"'
 
       describe "quote is balanced", ->
         it "case1", ->
-          set                 textC_: '_|_"===="____"==="'
-          ensure 'g r i " +', textC_: '__"|++++"____"==="'
+          set                     textC_: '_|_"===="____"==="'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"==="'
         it "case2", ->
-          set                 textC_: '__"==|=="____"==="'
-          ensure 'g r i " +', textC_: '__"|++++"____"==="'
+          set                     textC_: '__"==|=="____"==="'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"==="'
         it "case3", ->
-          set                 textC_: '__"===="__|__"==="'
-          ensure 'g r i " +', textC_: '__"===="|++++"==="'
+          set                     textC_: '__"===="__|__"==="'
+          ensureWait 'g r i " +', textC_: '__"===="|++++"==="'
         it "case4", ->
-          set                 textC_: '__"===="____"=|=="'
-          ensure 'g r i " +', textC_: '__"===="____"|+++"'
+          set                     textC_: '__"===="____"=|=="'
+          ensureWait 'g r i " +', textC_: '__"===="____"|+++"'
         it "case5", ->
-          set                 textC_: '__|"===="____"==="'
-          ensure 'g r i " +', textC_: '__"|++++"____"==="'
+          set                     textC_: '__|"===="____"==="'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"==="'
         it "case6", ->
-          set                 textC_: '__"====|"____"==="'
-          ensure 'g r i " +', textC_: '__"|++++"____"==="'
+          set                     textC_: '__"====|"____"==="'
+          ensureWait 'g r i " +', textC_: '__"|++++"____"==="'
         it "case7", ->
-          set                 textC_: '__"===="____|"==="'
-          ensure 'g r i " +', textC_: '__"===="____"|+++"'
+          set                     textC_: '__"===="____|"==="'
+          ensureWait 'g r i " +', textC_: '__"===="____"|+++"'
 
     describe "inner-double-quote", ->
       beforeEach ->

--- a/spec/vim-mode-plus-spec.coffee
+++ b/spec/vim-mode-plus-spec.coffee
@@ -2,13 +2,13 @@
 
 packageName = 'vim-mode-plus'
 describe "vim-mode-plus", ->
-  [set, ensure, keystroke, editor, editorElement, vimState, workspaceElement] = []
+  [set, ensure, editor, editorElement, vimState, workspaceElement] = []
 
   beforeEach ->
     getVimState (_vimState, vim) ->
       vimState = _vimState
       {editor, editorElement} = _vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
     workspaceElement = getView(atom.workspace)
 

--- a/spec/vim-mode-plus-spec.coffee
+++ b/spec/vim-mode-plus-spec.coffee
@@ -17,7 +17,7 @@ describe "vim-mode-plus", ->
 
   describe ".activate", ->
     it "puts the editor in normal-mode initially by default", ->
-      ensure mode: 'normal'
+      ensure null, mode: 'normal'
 
     it "shows the current vim mode in the status bar", ->
       statusBarTile = null

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -3,13 +3,13 @@ _ = require 'underscore-plus'
 settings = require '../lib/settings'
 
 describe "VimState", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
 
   beforeEach ->
     getVimState (state, vim) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vim
+      {set, ensure} = vim
 
   describe "initialization", ->
     it "puts the editor in normal-mode initially by default", ->
@@ -38,32 +38,32 @@ describe "VimState", ->
   describe "normal-mode", ->
     describe "when entering an insertable character", ->
       beforeEach ->
-        keystroke '\\'
+        ensure '\\', {}
 
       it "stops propagation", ->
         ensure text: ''
 
     describe "when entering an operator", ->
       beforeEach ->
-        keystroke 'd'
+        ensure 'd', {}
 
       describe "with an operator that can't be composed", ->
         beforeEach ->
-          keystroke 'x'
+          ensure 'x', {}
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
 
       describe "the escape keybinding", ->
         beforeEach ->
-          keystroke 'escape'
+          ensure 'escape', {}
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
 
       describe "the ctrl-c keybinding", ->
         beforeEach ->
-          keystroke 'ctrl-c'
+          ensure 'ctrl-c', {}
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
@@ -83,7 +83,7 @@ describe "VimState", ->
             abc
             """
           cursor: [0, 0]
-        keystroke 'v'
+        ensure 'v', {}
 
       it "puts the editor into visual characterwise mode", ->
         ensure
@@ -185,7 +185,7 @@ describe "VimState", ->
       ensure 'l', cursor: [0, 3], mode: 'insert'
 
   describe "insert-mode", ->
-    beforeEach -> keystroke 'i'
+    beforeEach -> ensure 'i', {}
 
     describe "with content", ->
       beforeEach ->
@@ -302,7 +302,7 @@ describe "VimState", ->
 
       describe "on a line with content", ->
         it "allows the cursor to be placed on the \n character", ->
-          keystroke 'R'
+          ensure 'R', {}
           set cursor: [0, 6]
           ensure cursor: [0, 6]
 
@@ -321,7 +321,7 @@ describe "VimState", ->
         one two three
         """
         cursor: [0, 4]
-      keystroke 'v'
+      ensure 'v', {}
 
     it "selects the character under the cursor", ->
       ensure
@@ -374,7 +374,7 @@ describe "VimState", ->
 
       xit "harmonizes selection directions", ->
         set cursor: [0, 0]
-        keystroke 'e e'
+        ensure 'e e', {}
         set addCursor: [0, Infinity]
         ensure 'h h',
           selectedBufferRange: [
@@ -554,19 +554,19 @@ describe "VimState", ->
 
     it "basic marking functionality", ->
       set cursor: [1, 1]
-      keystroke 'm t'
+      ensure 'm t', {}
       set cursor: [2, 2]
       ensure '` t', cursor: [1, 1]
 
     it "real (tracking) marking functionality", ->
       set cursor: [2, 2]
-      keystroke 'm q'
+      ensure 'm q', {}
       set cursor: [1, 2]
       ensure 'o escape ` q', cursor: [3, 2]
 
     it "real (tracking) marking functionality", ->
       set cursor: [2, 2]
-      keystroke 'm q'
+      ensure 'm q', {}
       set cursor: [1, 2]
       ensure 'd d escape ` q', cursor: [1, 2]
 

--- a/spec/vim-state-spec.coffee
+++ b/spec/vim-state-spec.coffee
@@ -13,12 +13,12 @@ describe "VimState", ->
 
   describe "initialization", ->
     it "puts the editor in normal-mode initially by default", ->
-      ensure mode: 'normal'
+      ensure null, mode: 'normal'
 
     it "puts the editor in insert-mode if startInInsertMode is true", ->
       settings.set 'startInInsertMode', true
       getVimState (state, vim) ->
-        vim.ensure mode: 'insert'
+        vim.ensure null, mode: 'insert'
 
   describe "::destroy", ->
     it "re-enables text input on the editor", ->
@@ -27,7 +27,7 @@ describe "VimState", ->
       expect(editorElement.component.isInputEnabled()).toBeTruthy()
 
     it "removes the mode classes from the editor", ->
-      ensure mode: 'normal'
+      ensure null, mode: 'normal'
       vimState.destroy()
       expect(editorElement.classList.contains("normal-mode")).toBeFalsy()
 
@@ -38,32 +38,32 @@ describe "VimState", ->
   describe "normal-mode", ->
     describe "when entering an insertable character", ->
       beforeEach ->
-        ensure '\\', {}
+        ensure '\\'
 
       it "stops propagation", ->
-        ensure text: ''
+        ensure null, text: ''
 
     describe "when entering an operator", ->
       beforeEach ->
-        ensure 'd', {}
+        ensure 'd'
 
       describe "with an operator that can't be composed", ->
         beforeEach ->
-          ensure 'x', {}
+          ensure 'x'
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
 
       describe "the escape keybinding", ->
         beforeEach ->
-          ensure 'escape', {}
+          ensure 'escape'
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
 
       describe "the ctrl-c keybinding", ->
         beforeEach ->
-          ensure 'ctrl-c', {}
+          ensure 'ctrl-c'
 
         it "clears the operator stack", ->
           expect(vimState.operationStack.isEmpty()).toBe(true)
@@ -73,7 +73,7 @@ describe "VimState", ->
         set
           text: "one-two-three"
           addCursor: [0, 3]
-        ensure numCursors: 2
+        ensure null, numCursors: 2
         ensure 'escape', numCursors: 1
 
     describe "the v keybinding", ->
@@ -83,10 +83,10 @@ describe "VimState", ->
             abc
             """
           cursor: [0, 0]
-        ensure 'v', {}
+        ensure 'v'
 
       it "puts the editor into visual characterwise mode", ->
-        ensure
+        ensure null,
           mode: ['visual', 'characterwise']
 
     describe "the V keybinding", ->
@@ -113,11 +113,11 @@ describe "VimState", ->
         set text: "abc def", cursor: [0, 0]
 
       it "puts the editor into visual mode", ->
-        ensure mode: 'normal'
+        ensure null, mode: 'normal'
 
         advanceClock(200)
         atom.commands.dispatch(editorElement, "core:select-right")
-        ensure
+        ensure null,
           mode: ['visual', 'characterwise']
           selectedBufferRange: [[0, 0], [0, 1]]
 
@@ -129,7 +129,7 @@ describe "VimState", ->
 
       it 'handles native selection such as core:select-all', ->
         atom.commands.dispatch(editorElement, 'core:select-all')
-        ensure selectedBufferRange: [[0, 0], [0, 7]]
+        ensure null, selectedBufferRange: [[0, 0], [0, 7]]
 
     describe "the i keybinding", ->
       it "puts the editor into insert mode", ->
@@ -145,14 +145,14 @@ describe "VimState", ->
 
       describe "on a line with content", ->
         it "[Changed] won't adjust cursor position if outer command place the cursor on end of line('\\n') character", ->
-          ensure mode: 'normal'
+          ensure null, mode: 'normal'
           atom.commands.dispatch(editorElement, "editor:move-to-end-of-line")
-          ensure cursor: [0, 6]
+          ensure null, cursor: [0, 6]
 
       describe "on an empty line", ->
         it "allows the cursor to be placed on the \n character", ->
           set cursor: [1, 0]
-          ensure cursor: [1, 0]
+          ensure null, cursor: [1, 0]
 
     describe 'with character-input operations', ->
       beforeEach ->
@@ -185,7 +185,7 @@ describe "VimState", ->
       ensure 'l', cursor: [0, 3], mode: 'insert'
 
   describe "insert-mode", ->
-    beforeEach -> ensure 'i', {}
+    beforeEach -> ensure 'i'
 
     describe "with content", ->
       beforeEach ->
@@ -204,7 +204,7 @@ describe "VimState", ->
       describe "on a line with content", ->
         it "allows the cursor to be placed on the \n character", ->
           set cursor: [0, 6]
-          ensure cursor: [0, 6]
+          ensure null, cursor: [0, 6]
 
     it "puts the editor into normal mode when <escape> is pressed", ->
       escape 'escape',
@@ -261,8 +261,8 @@ describe "VimState", ->
           pane.activateItem(otherEditor)
           expect(pane.getActiveItem()).toBe(otherEditor)
 
-          ensure mode: 'insert'
-          otherVim.ensure mode: 'insert'
+          ensure null, mode: 'insert'
+          otherVim.ensure null, mode: 'insert'
 
       describe "automaticallyEscapeInsertModeOnActivePaneItemChange = true", ->
         beforeEach ->
@@ -281,8 +281,8 @@ describe "VimState", ->
 
           runs ->
             expect(pane.getActiveItem()).toBe(otherEditor)
-            ensure mode: 'normal'
-            otherVim.ensure mode: 'insert'
+            ensure null, mode: 'normal'
+            otherVim.ensure null, mode: 'insert'
 
   describe "replace-mode", ->
     describe "with content", ->
@@ -302,9 +302,9 @@ describe "VimState", ->
 
       describe "on a line with content", ->
         it "allows the cursor to be placed on the \n character", ->
-          ensure 'R', {}
+          ensure 'R'
           set cursor: [0, 6]
-          ensure cursor: [0, 6]
+          ensure null, cursor: [0, 6]
 
     it "puts the editor into normal mode when <escape> is pressed", ->
       ensure 'R escape',
@@ -321,10 +321,10 @@ describe "VimState", ->
         one two three
         """
         cursor: [0, 4]
-      ensure 'v', {}
+      ensure 'v'
 
     it "selects the character under the cursor", ->
-      ensure
+      ensure null,
         selectedBufferRange: [[0, 4], [0, 5]]
         selectedText: 't'
 
@@ -334,7 +334,7 @@ describe "VimState", ->
         mode: 'normal'
 
     it "puts the editor into normal mode when <escape> is pressed on selection is reversed", ->
-      ensure selectedText: 't'
+      ensure null, selectedText: 't'
       ensure 'h h',
         selectedText: 'e t'
         selectionIsReversed: true
@@ -374,7 +374,7 @@ describe "VimState", ->
 
       xit "harmonizes selection directions", ->
         set cursor: [0, 0]
-        ensure 'e e', {}
+        ensure 'e e'
         set addCursor: [0, Infinity]
         ensure 'h h',
           selectedBufferRange: [
@@ -554,19 +554,19 @@ describe "VimState", ->
 
     it "basic marking functionality", ->
       set cursor: [1, 1]
-      ensure 'm t', {}
+      ensure 'm t'
       set cursor: [2, 2]
       ensure '` t', cursor: [1, 1]
 
     it "real (tracking) marking functionality", ->
       set cursor: [2, 2]
-      ensure 'm q', {}
+      ensure 'm q'
       set cursor: [1, 2]
       ensure 'o escape ` q', cursor: [3, 2]
 
     it "real (tracking) marking functionality", ->
       set cursor: [2, 2]
-      ensure 'm q', {}
+      ensure 'm q'
       set cursor: [1, 2]
       ensure 'd d escape ` q', cursor: [1, 2]
 
@@ -588,7 +588,7 @@ describe "VimState", ->
 
     describe "normal-mode", ->
       it "is not narrowed", ->
-        ensure
+        ensure null,
           mode: ['normal']
           selectionIsNarrowed: false
     describe "visual-mode.characterwise", ->

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -150,7 +150,7 @@ describe "Visual Blockwise", ->
         cursor: [[2, 5], [3, 5], [4, 5], [5, 5] ]
         text: textAfterDeleted
       editor.insertText("!!!")
-      ensure
+      ensure null,
         mode: 'insert'
         cursor: [[2, 8], [3, 8], [4, 8], [5, 8]]
         text: textAfterInserted
@@ -181,9 +181,9 @@ describe "Visual Blockwise", ->
     beforeEach ->
       selectBlockwise()
     it "enter insert mode with each cursors position set to start of selection", ->
-      ensure 'I', {}
+      ensure 'I'
       editor.insertText "!!!"
-      ensure
+      ensure null,
         text: """
           01234567890123456789
           1-------------------
@@ -205,9 +205,9 @@ describe "Visual Blockwise", ->
     beforeEach ->
       selectBlockwise()
     it "enter insert mode with each cursors position set to end of selection", ->
-      ensure 'A', {}
+      ensure 'A'
       editor.insertText "!!!"
-      ensure
+      ensure null,
         text: """
           01234567890123456789
           1-------------------
@@ -230,16 +230,16 @@ describe "Visual Blockwise", ->
 
     describe 'o', ->
       it "change blockwiseHead to opposite side and reverse selection", ->
-        ensure 'o', {}
+        ensure 'o'
         ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
-        ensure 'o', {}
+        ensure 'o'
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
     describe 'capital O', ->
       it "reverse each selection", ->
-        ensure 'O', {}
+        ensure 'O'
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: true
-        ensure 'O', {}
+        ensure 'O'
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
 
   describe "shift from characterwise to blockwise", ->
@@ -579,26 +579,26 @@ describe "Visual Blockwise", ->
       describe "selection is not reversed", ->
         it 'restore previous selection case-1', ->
           set cursor: [2, 5]
-          ensure 'ctrl-v 1 0 l', {}
+          ensure 'ctrl-v 1 0 l'
           ensureRestored '3 j',
             selectedText: blockTexts[2..5]
             mode: ['visual', 'blockwise']
         it 'restore previous selection case-2', ->
           set cursor: [5, 5]
-          ensure 'ctrl-v 1 0 l', {}
+          ensure 'ctrl-v 1 0 l'
           ensureRestored '3 k',
             selectedTextOrdered: blockTexts[2..5]
             mode: ['visual', 'blockwise']
       describe "selection is reversed", ->
         it 'restore previous selection case-1', ->
           set cursor: [2, 15]
-          ensure 'ctrl-v 1 0 h', {}
+          ensure 'ctrl-v 1 0 h'
           ensureRestored '3 j',
             selectedText: blockTexts[2..5]
             mode: ['visual', 'blockwise']
         it 'restore previous selection case-2', ->
           set cursor: [5, 15]
-          ensure 'ctrl-v 1 0 h', {}
+          ensure 'ctrl-v 1 0 h'
           ensureRestored '3 k',
             selectedTextOrdered: blockTexts[2..5]
             mode: ['visual', 'blockwise']

--- a/spec/visual-blockwise-spec.coffee
+++ b/spec/visual-blockwise-spec.coffee
@@ -1,7 +1,7 @@
 {getVimState, TextData} = require './spec-helper'
 
 describe "Visual Blockwise", ->
-  [set, ensure, keystroke, editor, editorElement, vimState] = []
+  [set, ensure, editor, editorElement, vimState] = []
   textInitial = """
     01234567890123456789
     1-------------------
@@ -101,7 +101,7 @@ describe "Visual Blockwise", ->
     getVimState (state, vimEditor) ->
       vimState = state
       {editor, editorElement} = vimState
-      {set, ensure, keystroke} = vimEditor
+      {set, ensure} = vimEditor
 
     runs ->
       set text: textInitial
@@ -181,7 +181,7 @@ describe "Visual Blockwise", ->
     beforeEach ->
       selectBlockwise()
     it "enter insert mode with each cursors position set to start of selection", ->
-      keystroke 'I'
+      ensure 'I', {}
       editor.insertText "!!!"
       ensure
         text: """
@@ -205,7 +205,7 @@ describe "Visual Blockwise", ->
     beforeEach ->
       selectBlockwise()
     it "enter insert mode with each cursors position set to end of selection", ->
-      keystroke 'A'
+      ensure 'A', {}
       editor.insertText "!!!"
       ensure
         text: """
@@ -230,16 +230,16 @@ describe "Visual Blockwise", ->
 
     describe 'o', ->
       it "change blockwiseHead to opposite side and reverse selection", ->
-        keystroke 'o'
+        ensure 'o', {}
         ensureBlockwiseSelection head: 'top', tail: 'bottom', headReversed: true
 
-        keystroke 'o'
+        ensure 'o', {}
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
     describe 'capital O', ->
       it "reverse each selection", ->
-        keystroke 'O'
+        ensure 'O', {}
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: true
-        keystroke 'O'
+        ensure 'O', {}
         ensureBlockwiseSelection head: 'bottom', tail: 'top', headReversed: false
 
   describe "shift from characterwise to blockwise", ->
@@ -579,26 +579,26 @@ describe "Visual Blockwise", ->
       describe "selection is not reversed", ->
         it 'restore previous selection case-1', ->
           set cursor: [2, 5]
-          keystroke 'ctrl-v 1 0 l'
+          ensure 'ctrl-v 1 0 l', {}
           ensureRestored '3 j',
             selectedText: blockTexts[2..5]
             mode: ['visual', 'blockwise']
         it 'restore previous selection case-2', ->
           set cursor: [5, 5]
-          keystroke 'ctrl-v 1 0 l'
+          ensure 'ctrl-v 1 0 l', {}
           ensureRestored '3 k',
             selectedTextOrdered: blockTexts[2..5]
             mode: ['visual', 'blockwise']
       describe "selection is reversed", ->
         it 'restore previous selection case-1', ->
           set cursor: [2, 15]
-          keystroke 'ctrl-v 1 0 h'
+          ensure 'ctrl-v 1 0 h', {}
           ensureRestored '3 j',
             selectedText: blockTexts[2..5]
             mode: ['visual', 'blockwise']
         it 'restore previous selection case-2', ->
           set cursor: [5, 15]
-          keystroke 'ctrl-v 1 0 h'
+          ensure 'ctrl-v 1 0 h', {}
           ensureRestored '3 k',
             selectedTextOrdered: blockTexts[2..5]
             mode: ['visual', 'blockwise']


### PR DESCRIPTION
Currently, `surround` and `replace`, `replace-character`(`r`) have `supportEarlySelect = true`.

This was introduced in #622 to give better UI feedback to user to make surround operation easy.

- Old: Select target earlily **before** calling `execute()`.
- New: Read user input **after** calling `execute()` and target selected(require  async execute).

`Operator.prototype.execute()` already allowed to return Promise since very long time ago(added to support `TransformStringByExternalCommand`).
