### PR TITLE
:gift: redraw cursor line at upper-middle by `z u`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.13.0: WIP
+- Breaking: rename confusing `ScrollCursorToTop` commands.
+  - `z enter`: `ScrollCursorToTop` to `RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine`
+  - `z t`: `ScrollCursorToTopLeave` to `RedrawCursorLineAtTop`
+  - `z .`: `ScrollCursorToMiddle` to `RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine`
+  - `z z`: `ScrollCursorToMiddleLeave` to `RedrawCursorLineAtMiddle`
+  - `z -`: `ScrollCursorToBottom` to `RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine`
+  - `z b`: `ScrollCursorToBottomLeave` to `RedrawCursorLineAtBottom`
+- New: `z X` faimly to redraw cursor line at upper middle.
+  - `z u`: `RedrawCursorLineAtUpperMiddle`
+  - `z space`: `RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine`
+
 # 1.12.1:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.12.0...v1.12.1)
 - Improve: `duplicate-with-comment-out-original` flashes correct range(only changed range).

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -292,14 +292,18 @@
   'shift-tab': 'vim-mode-plus:move-to-previous-occurrence'
 
 'atom-text-editor.vim-mode-plus:not(.insert-mode):not(.operator-pending-mode)':
-  'z enter': 'vim-mode-plus:scroll-cursor-to-top'
-  'z t': 'vim-mode-plus:scroll-cursor-to-top-leave'
-  'z .': 'vim-mode-plus:scroll-cursor-to-middle'
-  'z z': 'vim-mode-plus:scroll-cursor-to-middle-leave'
-  'z space': 'vim-mode-plus:scroll-cursor-to-upper-middle'
-  'z u': 'vim-mode-plus:scroll-cursor-to-upper-middle-leave'
-  'z -': 'vim-mode-plus:scroll-cursor-to-bottom'
-  'z b': 'vim-mode-plus:scroll-cursor-to-bottom-leave'
+  'z t': 'vim-mode-plus:redraw-cursor-line-at-top'
+  'z enter': 'vim-mode-plus:redraw-cursor-line-at-top-and-move-to-first-character-of-line'
+
+  'z u': 'vim-mode-plus:redraw-cursor-line-at-upper-middle'
+  'z space': 'vim-mode-plus:redraw-cursor-line-at-upper-middle-and-move-to-first-character-of-line'
+
+  'z z': 'vim-mode-plus:redraw-cursor-line-at-middle'
+  'z .': 'vim-mode-plus:redraw-cursor-line-at-middle-and-move-to-first-character-of-line'
+
+  'z b': 'vim-mode-plus:redraw-cursor-line-at-bottom'
+  'z -': 'vim-mode-plus:redraw-cursor-line-at-bottom-and-move-to-first-character-of-line'
+
   'z s': 'vim-mode-plus:scroll-cursor-to-left'
   'z e': 'vim-mode-plus:scroll-cursor-to-right'
 

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -296,6 +296,8 @@
   'z t': 'vim-mode-plus:scroll-cursor-to-top-leave'
   'z .': 'vim-mode-plus:scroll-cursor-to-middle'
   'z z': 'vim-mode-plus:scroll-cursor-to-middle-leave'
+  'z space': 'vim-mode-plus:scroll-cursor-to-upper-middle'
+  'z u': 'vim-mode-plus:scroll-cursor-to-upper-middle-leave'
   'z -': 'vim-mode-plus:scroll-cursor-to-bottom'
   'z b': 'vim-mode-plus:scroll-cursor-to-bottom-leave'
   'z s': 'vim-mode-plus:scroll-cursor-to-left'

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -1237,39 +1237,39 @@ ScrollUp:
   file: "./misc-command"
   commandName: "vim-mode-plus:scroll-up"
   commandScope: "atom-text-editor"
-ScrollCursor:
+RedrawCursorLine:
   file: "./misc-command"
-ScrollCursorToTop:
+RedrawCursorLineAtTop:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-top"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-top"
   commandScope: "atom-text-editor"
-ScrollCursorToTopLeave:
+RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-top-leave"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-top-and-move-to-first-character-of-line"
   commandScope: "atom-text-editor"
-ScrollCursorToMiddle:
+RedrawCursorLineAtUpperMiddle:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-middle"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-upper-middle"
   commandScope: "atom-text-editor"
-ScrollCursorToMiddleLeave:
+RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-middle-leave"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-upper-middle-and-move-to-first-character-of-line"
   commandScope: "atom-text-editor"
-ScrollCursorToUpperMiddle:
+RedrawCursorLineAtMiddle:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-upper-middle"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-middle"
   commandScope: "atom-text-editor"
-ScrollCursorToUpperMiddleLeave:
+RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-upper-middle-leave"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-middle-and-move-to-first-character-of-line"
   commandScope: "atom-text-editor"
-ScrollCursorToBottom:
+RedrawCursorLineAtBottom:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-bottom"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-bottom"
   commandScope: "atom-text-editor"
-ScrollCursorToBottomLeave:
+RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-cursor-to-bottom-leave"
+  commandName: "vim-mode-plus:redraw-cursor-line-at-bottom-and-move-to-first-character-of-line"
   commandScope: "atom-text-editor"
 ScrollCursorToLeft:
   file: "./misc-command"

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -1255,6 +1255,14 @@ ScrollCursorToMiddleLeave:
   file: "./misc-command"
   commandName: "vim-mode-plus:scroll-cursor-to-middle-leave"
   commandScope: "atom-text-editor"
+ScrollCursorToUpperMiddle:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:scroll-cursor-to-upper-middle"
+  commandScope: "atom-text-editor"
+ScrollCursorToUpperMiddleLeave:
+  file: "./misc-command"
+  commandName: "vim-mode-plus:scroll-cursor-to-upper-middle-leave"
+  commandScope: "atom-text-editor"
 ScrollCursorToBottom:
   file: "./misc-command"
   commandName: "vim-mode-plus:scroll-cursor-to-bottom"

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -362,7 +362,7 @@ class ScrollUp extends MiscCommand {
 }
 ScrollUp.register()
 
-// Adjust scrollTop to change where curos is shown in viewport.
+// Redraw cursor-line come to at xxx in viewport.
 // +--------------+------------------+---------+
 // | where        | move to 1st char | no move |
 // +--------------+------------------+---------+
@@ -374,13 +374,12 @@ ScrollUp.register()
 
 class ScrollCursor extends MiscCommand {
   moveToFirstCharacterOfLine = false
-  where = null
-
+  
   execute() {
     const scrollTop = this.getScrollTop()
     this.editorElement.setScrollTop(scrollTop)
-    if (this.editorElement.getScrollTop() !== scrollTop) {
-      this.recommendToEnableScrollPastEndIfNecessary()
+    if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
+      this.recommendToEnableScrollPastEnd()
     }
     if (this.moveToFirstCharacterOfLine) this.editor.moveToFirstCharacterOfLine()
   }
@@ -395,32 +394,30 @@ class ScrollCursor extends MiscCommand {
     })
   }
 
-  recommendToEnableScrollPastEndIfNecessary() {
-    if (this.editor.getLastVisibleScreenRow() === this.editor.getLastScreenRow() && !this.editor.getScrollPastEnd()) {
-      const message = [
-        "vim-mode-plus",
-        "- Failed to set scrollTop. Require `editor.scrollPastEnd` setting to be `true`.",
-        '- You can enable it from `"Settings" > "Editor" > "Scroll Past End"`.',
-        "- Or **do you allow vmp enable it for you now?**",
-      ].join("\n")
+  recommendToEnableScrollPastEnd() {
+    const message = [
+      "vim-mode-plus",
+      "- Failed to set scrollTop. Require `editor.scrollPastEnd` setting to be `true`.",
+      '- You can enable it from `"Settings" > "Editor" > "Scroll Past End"`.',
+      "- Or **do you allow vmp enable it for you now?**",
+    ].join("\n")
 
-      const notification = atom.notifications.addInfo(message, {
-        dismissable: true,
-        buttons: [
-          {
-            text: "No thanks.",
-            onDidClick: () => notification.dismiss(),
+    const notification = atom.notifications.addInfo(message, {
+      dismissable: true,
+      buttons: [
+        {
+          text: "No thanks.",
+          onDidClick: () => notification.dismiss(),
+        },
+        {
+          text: "OK. Enable it now!!",
+          onDidClick: () => {
+            atom.config.set(`editor.scrollPastEnd`, true)
+            notification.dismiss()
           },
-          {
-            text: "OK. Enable it now!!",
-            onDidClick: () => {
-              atom.config.set(`editor.scrollPastEnd`, true)
-              notification.dismiss()
-            },
-          },
-        ],
-      })
-    }
+        },
+      ],
+    })
   }
 }
 ScrollCursor.register(false)

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -363,18 +363,22 @@ class ScrollUp extends MiscCommand {
 ScrollUp.register()
 
 // Redraw cursor-line come to at xxx in viewport.
-// +--------------+------------------+---------+
-// | where        | move to 1st char | no move |
-// +--------------+------------------+---------+
-// | top          | `z enter`        | `z t`   |
-// | upper-middle | `z space`        | `z u`   |
-// | middle       | `z .`            | `z z`   |
-// | bottom       | `z -`            | `z b`   |
-// +--------------+------------------+---------+
+// +------------------------------------------+---------+
+// | RedrawCursorLineAt{XXX}                  | keymap  |
+// |------------------------------------------+---------|
+// | Top                                      | z t     |
+// | TopAndMoveToFirstCharacterOfLine         | z enter |
+// | UpperMiddle                              | z u     |
+// | UpperMiddleAndMoveToFirstCharacterOfLine | z space |
+// | Middle                                   | z z     |
+// | MiddleAndMoveToFirstCharacterOfLine      | z .     |
+// | Bottom                                   | z b     |
+// | BottomAndMoveToFirstCharacterOfLine      | z -     |
+// +----------------------------------------------------+
 
-class ScrollCursor extends MiscCommand {
+class RedrawCursorLine extends MiscCommand {
   moveToFirstCharacterOfLine = false
-  
+
   execute() {
     const scrollTop = this.getScrollTop()
     this.editorElement.setScrollTop(scrollTop)
@@ -420,59 +424,59 @@ class ScrollCursor extends MiscCommand {
     })
   }
 }
-ScrollCursor.register(false)
-
-// top: z enter
-class ScrollCursorToTop extends ScrollCursor {
-  coefficient = 0
-  moveToFirstCharacterOfLine = true
-}
-ScrollCursorToTop.register()
+RedrawCursorLine.register(false)
 
 // top: zt
-class ScrollCursorToTopLeave extends ScrollCursor {
+class RedrawCursorLineAtTop extends RedrawCursorLine {
   coefficient = 0
 }
-ScrollCursorToTopLeave.register()
+RedrawCursorLineAtTop.register()
 
-// middle: z.
-class ScrollCursorToMiddle extends ScrollCursor {
-  coefficient = 0.5
+// top: z enter
+class RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
+  coefficient = 0
   moveToFirstCharacterOfLine = true
 }
-ScrollCursorToMiddle.register()
-
-// middle: zz
-class ScrollCursorToMiddleLeave extends ScrollCursor {
-  coefficient = 0.5
-}
-ScrollCursorToMiddleLeave.register()
-
-// upper-middle: z space
-class ScrollCursorToUpperMiddle extends ScrollCursor {
-  coefficient = 0.25
-  moveToFirstCharacterOfLine = true
-}
-ScrollCursorToUpperMiddle.register()
+RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine.register()
 
 // upper-middle: zu
-class ScrollCursorToUpperMiddleLeave extends ScrollCursor {
+class RedrawCursorLineAtUpperMiddle extends RedrawCursorLine {
   coefficient = 0.25
 }
-ScrollCursorToUpperMiddleLeave.register()
+RedrawCursorLineAtUpperMiddle.register()
+
+// upper-middle: z space
+class RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
+  coefficient = 0.25
+  moveToFirstCharacterOfLine = true
+}
+RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine.register()
+
+// middle: zz
+class RedrawCursorLineAtMiddle extends RedrawCursorLine {
+  coefficient = 0.5
+}
+RedrawCursorLineAtMiddle.register()
+
+// middle: z.
+class RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
+  coefficient = 0.5
+  moveToFirstCharacterOfLine = true
+}
+RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine.register()
+
+// bottom: zb
+class RedrawCursorLineAtBottom extends RedrawCursorLine {
+  coefficient = 1
+}
+RedrawCursorLineAtBottom.register()
 
 // bottom: z-
-class ScrollCursorToBottom extends ScrollCursor {
+class RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
   coefficient = 1
   moveToFirstCharacterOfLine = true
 }
-ScrollCursorToBottom.register()
-
-// bottom: zb
-class ScrollCursorToBottomLeave extends ScrollCursor {
-  coefficient = 1
-}
-ScrollCursorToBottomLeave.register()
+RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine.register()
 
 // Horizontal Scroll without changing cursor position
 // -------------------------

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -363,46 +363,43 @@ class ScrollUp extends MiscCommand {
 ScrollUp.register()
 
 // Adjust scrollTop to change where curos is shown in viewport.
-// +--------+------------------+---------+
-// | where  | move to 1st char | no move |
-// +--------+------------------+---------+
-// | top    | `z enter`        | `z t`   |
-// | middle | `z .`            | `z z`   |
-// | bottom | `z -`            | `z b`   |
-// +--------+------------------+---------+
+// +--------------+------------------+---------+
+// | where        | move to 1st char | no move |
+// +--------------+------------------+---------+
+// | top          | `z enter`        | `z t`   |
+// | upper-middle | `z space`        | `z u`   |
+// | middle       | `z .`            | `z z`   |
+// | bottom       | `z -`            | `z b`   |
+// +--------------+------------------+---------+
+
 class ScrollCursor extends MiscCommand {
   moveToFirstCharacterOfLine = false
   where = null
 
   execute() {
-    this.editorElement.setScrollTop(this.getScrollTop())
+    const scrollTop = this.getScrollTop()
+    this.editorElement.setScrollTop(scrollTop)
+    if (this.editorElement.getScrollTop() !== scrollTop) {
+      this.recommendToEnableScrollPastEndIfNecessary()
+    }
     if (this.moveToFirstCharacterOfLine) this.editor.moveToFirstCharacterOfLine()
   }
 
   getScrollTop() {
-    const screenPosition = this.editor.getCursorScreenPosition()
-    const {top} = this.editorElement.pixelPositionForScreenPosition(screenPosition)
-    switch (this.where) {
-      case "top":
-        this.recommendToEnableScrollPastEndIfNecessary()
-        return top - this.getOffSetPixelHeight()
-      case "middle":
-        return top - this.editorElement.getHeight() / 2
-      case "bottom":
-        return top - (this.editorElement.getHeight() - this.getOffSetPixelHeight(1))
-    }
-  }
-
-  getOffSetPixelHeight(lineDelta = 0) {
-    const scrolloff = 2 // atom default. Better to use editor.getVerticalScrollMargin()?
-    return this.editor.getLineHeightInPixels() * (scrolloff + lineDelta)
+    const {top} = this.editorElement.pixelPositionForScreenPosition(this.editor.getCursorScreenPosition())
+    const editorHeight = this.editorElement.getHeight()
+    const lineHeightInPixel = this.editor.getLineHeightInPixels()
+    return this.utils.limitNumber(top - editorHeight * this.coefficient, {
+      min: top - editorHeight + lineHeightInPixel * 3,
+      max: top - lineHeightInPixel * 2,
+    })
   }
 
   recommendToEnableScrollPastEndIfNecessary() {
     if (this.editor.getLastVisibleScreenRow() === this.editor.getLastScreenRow() && !this.editor.getScrollPastEnd()) {
       const message = [
         "vim-mode-plus",
-        "- For `z t` and `z enter` works properly in every situation, `editor.scrollPastEnd` setting need to be `true`.",
+        "- Failed to set scrollTop. Require `editor.scrollPastEnd` setting to be `true`.",
         '- You can enable it from `"Settings" > "Editor" > "Scroll Past End"`.',
         "- Or **do you allow vmp enable it for you now?**",
       ].join("\n")
@@ -430,40 +427,53 @@ ScrollCursor.register(false)
 
 // top: z enter
 class ScrollCursorToTop extends ScrollCursor {
-  where = "top"
+  coefficient = 0
   moveToFirstCharacterOfLine = true
 }
 ScrollCursorToTop.register()
 
 // top: zt
 class ScrollCursorToTopLeave extends ScrollCursor {
-  where = "top"
+  coefficient = 0
 }
 ScrollCursorToTopLeave.register()
 
 // middle: z.
 class ScrollCursorToMiddle extends ScrollCursor {
-  where = "middle"
+  coefficient = 0.5
   moveToFirstCharacterOfLine = true
 }
 ScrollCursorToMiddle.register()
 
 // middle: zz
 class ScrollCursorToMiddleLeave extends ScrollCursor {
-  where = "middle"
+  coefficient = 0.5
 }
 ScrollCursorToMiddleLeave.register()
 
+// upper-middle: z space
+class ScrollCursorToUpperMiddle extends ScrollCursor {
+  coefficient = 0.25
+  moveToFirstCharacterOfLine = true
+}
+ScrollCursorToUpperMiddle.register()
+
+// upper-middle: zu
+class ScrollCursorToUpperMiddleLeave extends ScrollCursor {
+  coefficient = 0.25
+}
+ScrollCursorToUpperMiddleLeave.register()
+
 // bottom: z-
 class ScrollCursorToBottom extends ScrollCursor {
-  where = "bottom"
+  coefficient = 1
   moveToFirstCharacterOfLine = true
 }
 ScrollCursorToBottom.register()
 
 // bottom: zb
 class ScrollCursorToBottomLeave extends ScrollCursor {
-  where = "bottom"
+  coefficient = 1
 }
 ScrollCursorToBottomLeave.register()
 

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -376,7 +376,7 @@ class RedrawCursorLine extends MiscCommand {
   moveToFirstCharacterOfLine = false
 
   execute() {
-    const scrollTop = this.getScrollTop()
+    const scrollTop = Math.round(this.getScrollTop())
     this.editorElement.setScrollTop(scrollTop)
     if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
       this.recommendToEnableScrollPastEnd()

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -362,19 +362,15 @@ class ScrollUp extends MiscCommand {
 }
 ScrollUp.register()
 
-// Redraw cursor-line come to at xxx in viewport.
-// +------------------------------------------+---------+
-// | RedrawCursorLineAt{XXX}                  | keymap  |
-// |------------------------------------------+---------|
-// | Top                                      | z t     |
-// | TopAndMoveToFirstCharacterOfLine         | z enter |
-// | UpperMiddle                              | z u     |
-// | UpperMiddleAndMoveToFirstCharacterOfLine | z space |
-// | Middle                                   | z z     |
-// | MiddleAndMoveToFirstCharacterOfLine      | z .     |
-// | Bottom                                   | z b     |
-// | BottomAndMoveToFirstCharacterOfLine      | z -     |
-// +----------------------------------------------------+
+// RedrawCursorLineAt{XXX} in viewport.
+// +-------------------------------------------+
+// | where        | no move | move to 1st char |
+// |--------------+---------+------------------|
+// | top          | z t     | z enter          |
+// | upper-middle | z u     | z space          |
+// | middle       | z z     | z .              |
+// | bottom       | z b     | z -              |
+// +-------------------------------------------+
 
 class RedrawCursorLine extends MiscCommand {
   moveToFirstCharacterOfLine = false

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -47,7 +47,15 @@ describe "Scrolling", ->
         expect(editor.getFirstVisibleScreenRow()).toBe 1
         expect(editor.getLastVisibleScreenRow()).toBe 6
 
-  describe "scroll cursor keybindings", ->
+  describe "redraw-cursor-line keybindings", ->
+    _ensure = (keystroke, {scrollTop, moveToFirstChar}) ->
+      ensure(keystroke)
+      expect(editorElement.setScrollTop).toHaveBeenCalledWith(scrollTop)
+      if moveToFirstChar
+        expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
+      else
+        expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
+
     beforeEach ->
       editor.setText [1..200].join("\n")
       editorElement.style.lineHeight = "20px"
@@ -61,41 +69,18 @@ describe "Scrolling", ->
       spyOn(editor, 'getLastVisibleScreenRow').andReturn(110)
       spyOn(editorElement, 'pixelPositionForScreenPosition').andReturn({top: 1000, left: 0})
 
-    describe "the z<CR> keybinding", ->
-      it "moves the screen to position cursor at the top of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z enter'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
-        expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
-
-    describe "the zt keybinding", ->
-      it "moves the screen to position cursor at the top of the window and leave cursor in the same column", ->
-        ensure 'z t'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(960)
-        expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
-
-    describe "the z. keybinding", ->
-      it "moves the screen to position cursor at the center of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z .'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
-        expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
-
-    describe "the zz keybinding", ->
-      it "moves the screen to position cursor at the center of the window and leave cursor in the same column", ->
-        ensure 'z z'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(900)
-        expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
-
-    describe "the z- keybinding", ->
-      it "moves the screen to position cursor at the bottom of the window and moves cursor to first non-blank in the line", ->
-        ensure 'z -'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
-        expect(editor.moveToFirstCharacterOfLine).toHaveBeenCalled()
-
-    describe "the zb keybinding", ->
-      it "moves the screen to position cursor at the bottom of the window and leave cursor in the same column", ->
-        ensure 'z b'
-        expect(editorElement.setScrollTop).toHaveBeenCalledWith(860)
-        expect(editor.moveToFirstCharacterOfLine).not.toHaveBeenCalled()
+    describe "at top", ->
+      it "without move cursor", ->   _ensure 'z t',     scrollTop: 960, moveToFirstChar: false
+      it "with move to 1st char", -> _ensure 'z enter', scrollTop: 960, moveToFirstChar: true
+    describe "at upper-middle", ->
+      it "without move cursor", ->   _ensure 'z u',     scrollTop: 950, moveToFirstChar: false
+      it "with move to 1st char", -> _ensure 'z space', scrollTop: 950, moveToFirstChar: true
+    describe "at middle", ->
+      it "without move cursor", ->   _ensure 'z z',     scrollTop: 900, moveToFirstChar: false
+      it "with move to 1st char", -> _ensure 'z .',     scrollTop: 900, moveToFirstChar: true
+    describe "at bottom", ->
+      it "without move cursor", ->   _ensure 'z b',     scrollTop: 860, moveToFirstChar: false
+      it "with move to 1st char", -> _ensure 'z -',     scrollTop: 860, moveToFirstChar: true
 
   describe "horizontal scroll cursor keybindings", ->
     beforeEach ->


### PR DESCRIPTION
Introduce `upper-middle` with `z space` and `z u`.
:bomb: Also rename confusing `ScrollCursor{XXX}` command name to `RedrawCursorLineAt{XXX}`

- `z u` conflicting pureVim's `zuXXX` spell-check related feature. But OK now, I have no plan to introduce these into vmp.

```
RedrawCursorLineAt{XXX} in viewport.
+-------------------------------------------+
| where        | no move | move to 1st char |
|--------------+---------+------------------|
| top          | z t     | z enter          |
| upper-middle | z u     | z space          |
| middle       | z z     | z .              |
| bottom       | z b     | z -              |
+-------------------------------------------+
```


