### PR TITLE
bundle replace-with-execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 1.14.0:
+- Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.13.0...v1.14.0)
+- Fix: `transform-string-by-select-list` throw exception when executed in `visual-mode`.
+  - Regression by operator execution model redesign from v1.13.0.
+- New: `replace-with-execution`, `replace-with-execution-keep-original-text`
+  - No default keymap, but available from `transform-string-by-select-list`(`ctrl-s` on macOS).
+  - What this command do?
+    - `replace-with-execution`: Execute selected text as external command, then replace selection with result(= stdout).
+    - `replace-with-execution-keep-original-text`: Same except it insert result after selected text.
+  - Both commands are provided as external `replace-with-execution` vmp-plugin package(I maintained it).
+  - Now decided to include into vmp-core.
+  - Why was provided separately is async execution model was experimental before.
+  - Now async execution is used in many operators, so I have no reason to maintain it separately.
+
 # 1.13.0:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.12.1...v1.13.0)
 - Improve: Better multi cursors support for `toggle-persist-selection`.

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -327,6 +327,14 @@ ConvertToHardTab:
   commandScope: "atom-text-editor"
 TransformStringByExternalCommand:
   file: "./operator-transform-string"
+ReplaceWithExecution:
+  file: "./operator-transform-string"
+  commandName: "vim-mode-plus:replace-with-execution"
+  commandScope: "atom-text-editor"
+ReplaceWithExecutionKeepOriginalText:
+  file: "./operator-transform-string"
+  commandName: "vim-mode-plus:replace-with-execution-keep-original-text"
+  commandScope: "atom-text-editor"
 TransformStringBySelectList:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:transform-string-by-select-list"

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -436,6 +436,20 @@ ReplaceWithExecutionKeepOriginalText.register()
 
 // -------------------------
 class TransformStringBySelectList extends TransformString {
+  isReady() {
+    return false
+  }
+
+  initialize() {
+    const items = this.constructor.getSelectListItems()
+    this.focusSelectList({items})
+
+    this.vimState.onDidConfirmSelectList(item => {
+      this.vimState.reset()
+      this.vimState.operationStack.run(item.klass, {target: this.target})
+    })
+  }
+
   static getSelectListItems() {
     if (!this.selectListItems) {
       this.selectListItems = this.stringTransformers.map(klass => ({
@@ -446,29 +460,6 @@ class TransformStringBySelectList extends TransformString {
       }))
     }
     return this.selectListItems
-  }
-
-  getItems() {
-    return this.constructor.getSelectListItems()
-  }
-
-  initialize() {
-    this.vimState.onDidConfirmSelectList(item => {
-      const transformer = item.klass
-      if (transformer.prototype.target) {
-        this.target = transformer.prototype.target
-      }
-      this.vimState.reset()
-      if (this.target) {
-        this.vimState.operationStack.run(transformer, {target: this.target})
-      } else {
-        this.vimState.operationStack.run(transformer)
-      }
-    })
-
-    this.focusSelectList({items: this.getItems()})
-
-    super.initialize()
   }
 
   execute() {

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -343,45 +343,46 @@ class TransformStringByExternalCommand extends TransformString {
   autoIndent = true
   command = "" // e.g. command: 'sort'
   args = [] // e.g args: ['-rn']
-  stdoutBySelection = null
 
-  execute() {
-    this.normalizeSelectionsIfNecessary()
-    if (this.selectTarget()) {
-      return new Promise(resolve => this.collect(resolve)).then(() => {
-        for (const selection of this.editor.getSelections()) {
-          const text = this.getNewText(selection.getText(), selection)
-          selection.insertText(text, {autoIndent: this.autoIndent})
-        }
-        this.restoreCursorPositionsIfNecessary()
-        this.activateMode("normal")
-      })
-    }
+  // NOTE: Unlike other class, first arg is `stdout` of external commands.
+  getNewText(text, selection) {
+    return text || selection.getText()
+  }
+  getCommand(selection) {
+    return {command: this.command, args: this.args}
+  }
+  getStdin(selection) {
+    return selection.getText()
   }
 
-  collect(resolve) {
-    this.stdoutBySelection = new Map()
-    let processFinished = 0,
-      processRunning = 0
-    for (const selection of this.editor.getSelections()) {
-      const {command, args} = this.getCommand(selection) || {}
-      if (command == null || args == null) return
+  async execute() {
+    this.normalizeSelectionsIfNecessary()
+    this.createBufferCheckpoint("undo")
 
-      processRunning++
-      this.runExternalCommand({
-        command: command,
-        args: args,
-        stdin: this.getStdin(selection),
-        stdout: output => this.stdoutBySelection.set(selection, output),
-        exit: code => {
-          processFinished++
-          if (processRunning === processFinished) resolve()
-        },
-      })
+    if (this.selectTarget()) {
+      for (const selection of this.editor.getSelections()) {
+        const {command, args} = this.getCommand(selection) || {}
+        if (command == null || args == null) continue
+
+        const stdout = await this.runExternalCommand({command, args, stdin: this.getStdin(selection)})
+        selection.insertText(this.getNewText(stdout, selection), {autoIndent: this.autoIndent})
+      }
+      this.mutationManager.setCheckpoint("did-finish")
+      this.restoreCursorPositionsIfNecessary()
+      this.groupChangesSinceBufferCheckpoint("undo")
     }
+    this.emitDidFinishMutation()
+    this.activateMode("normal")
   }
 
   runExternalCommand(options) {
+    let output = ""
+    options.stdout = data => (output += data)
+
+    let resolveOutput
+    const exitPromise = new Promise(resolve => (resolveOutput = resolve))
+    options.exit = () => resolveOutput(output)
+
     const {stdin} = options
     delete options.stdin
     const bufferedProcess = new BufferedProcess(options)
@@ -398,24 +399,40 @@ class TransformStringByExternalCommand extends TransformString {
       bufferedProcess.process.stdin.write(stdin)
       bufferedProcess.process.stdin.end()
     }
-  }
-
-  getNewText(text, selection) {
-    return this.getStdout(selection) || text
-  }
-
-  // For easily extend by vmp plugin.
-  getCommand(selection) {
-    return {command: this.command, args: this.args}
-  }
-  getStdin(selection) {
-    return selection.getText()
-  }
-  getStdout(selection) {
-    return this.stdoutBySelection.get(selection)
+    return exitPromise
   }
 }
 TransformStringByExternalCommand.register(false)
+
+const LineEndingRegExp = /(?:\n|\r\n)$/
+
+class ReplaceWithExecution extends TransformStringByExternalCommand {
+  getCommand(selection) {
+    const text = selection.getText().trim()
+    if (text) {
+      const [command, ...args] = text.split(/\s+/)
+      return {command, args: args.filter(arg => arg)}
+    }
+  }
+
+  getStdin(selection) {
+    return null
+  }
+
+  getNewText(text, selection) {
+    return LineEndingRegExp.test(selection.getText()) ? text : text.replace(LineEndingRegExp, "")
+  }
+}
+ReplaceWithExecution.register()
+
+// date
+class ReplaceWithExecutionKeepOriginalText extends ReplaceWithExecution {
+  getNewText(text, selection) {
+    const selectedText = selection.getText()
+    return selectedText + (LineEndingRegExp.test(selectedText) ? text : "\n" + text)
+  }
+}
+ReplaceWithExecutionKeepOriginalText.register()
 
 // -------------------------
 class TransformStringBySelectList extends TransformString {
@@ -944,6 +961,7 @@ const classesToRegisterToSelectList = [
   Reverse, Rotate, RotateBackwards, Sort, SortCaseInsensitively, SortByNumber,
   NumberingLines,
   DuplicateWithCommentOutOriginal,
+  ReplaceWithExecution, ReplaceWithExecutionKeepOriginalText,
 ]
 for (const klass of classesToRegisterToSelectList) {
   klass.registerToSelectList()

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -420,16 +420,18 @@ class ReplaceWithExecution extends TransformStringByExternalCommand {
   }
 
   getNewText(text, selection) {
-    return LineEndingRegExp.test(selection.getText()) ? text : text.replace(LineEndingRegExp, "")
+    text = text.replace(LineEndingRegExp, "")
+    return LineEndingRegExp.test(selection.getText()) ? text + "\n" : text
   }
 }
 ReplaceWithExecution.register()
 
-// date
 class ReplaceWithExecutionKeepOriginalText extends ReplaceWithExecution {
   getNewText(text, selection) {
-    const selectedText = selection.getText()
-    return selectedText + (LineEndingRegExp.test(selectedText) ? text : "\n" + text)
+    text = text.replace(LineEndingRegExp, "")
+    const endRow = selection.getBufferRowRange()[1]
+    selection.cursor.setBufferPosition([endRow, Infinity])
+    return "\n" + text
   }
 }
 ReplaceWithExecutionKeepOriginalText.register()

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1866,3 +1866,21 @@ describe "Operator TransformString", ->
           4: Apple
           5: Pen\n
           """
+
+  describe "ReplaceWithExecution", ->
+    beforeEach ->
+      atom.keymaps.add "test",
+        'atom-text-editor.vim-mode-plus.normal-mode, atom-text-editor.vim-mode-plus.visual-mode':
+          'ctrl-r': 'vim-mode-plus:replace-with-execution'
+          'ctrl-R': 'vim-mode-plus:replace-with-execution-keep-original-text'
+        , 100
+
+      set textC: "|echo ABC\n"
+
+    describe "replace with execution result", ->
+      it "normal", -> ensureWait 'ctrl-r $', text: "ABC\n", mode: 'normal'
+      it "visual", -> ensureWait 'V ctrl-r', text: "ABC\n", mode: 'normal'
+
+    describe "replace with execution result with keep original text", ->
+      it "normal", -> ensureWait 'ctrl-R $', text: "echo ABC\nABC\n", mode: 'normal'
+      it "visual", -> ensureWait 'V ctrl-R', text: "echo ABC\nABC\n", mode: 'normal'


### PR DESCRIPTION
Bundle feature provided as vmp-plugin.

### Why?

Async execution was supported just for this command(`TransformStringByExternalCommand`), and was experimental.

But now async execution model is no experimental and used by many core operators(like `surround`).
So I can say "OK, will maintain this feature".

Will deprecate https://atom.io/packages/vim-mode-plus-replace-with-execution.
