### PR TITLE
Quarter-scroll, smoothScrollOnMiniScroll, tunable amountOfRowsOnMiniScroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.15.0: WIP
+- Breaking: Rename confusing `ScrollXXX`(It easily confused with scroll motions(`ctrl-f` etc..)
+  - `ScrollDown`(`ctrl-e`) to `MiniScrollDown`
+  - `ScrollUp`(`ctrl-y`) to `MiniScrollUp`
+- New: New config options to tune `MiniScroll`(`ctrl-y`, `ctrl-e`)
+  - `smoothScrollOnMiniScroll`: default `false`
+  - `smoothScrollOnMiniScrollDuration`: default `200`
+  - `defaultScrollRowsOnMiniScroll`: default `1`
+- New, Experimental: New scroll motion to scroll 1/4.
+  - `ScrollQuarterScreenDown`: `g ctrl-d`
+  - `ScrollQuarterScreenUp`: `g ctrl-u`
+  - Smooth scroll options are NOT explicitly provided, it use `ScrollHalf`'s config.
+
 # 1.14.1:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.14.0...v1.14.1)
 - Fix: Remove spec for now removed feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 - Breaking: Rename confusing `ScrollXXX`(It easily confused with scroll motions(`ctrl-f` etc..)
   - `ScrollDown`(`ctrl-e`) to `MiniScrollDown`
   - `ScrollUp`(`ctrl-y`) to `MiniScrollUp`
-- New: New config options to tune `MiniScroll`(`ctrl-y`, `ctrl-e`)
+- New: Smooth scroll option plus more for `MiniScroll`(`ctrl-y`, `ctrl-e`)
   - `smoothScrollOnMiniScroll`: default `false`
   - `smoothScrollOnMiniScrollDuration`: default `200`
   - `defaultScrollRowsOnMiniScroll`: default `1`
+- New: Smooth scroll option for `redraw-cursor-line` commands.
+  - `redraw-cursor-line` is `z` begging command like `z t`, `z u`, `z z`, `z b` etc..
+  - Default disabled, I need this when I do demo. With smooth scroll on `z u`, less chance to leave behind audiences.
+  - `smoothScrollOnRedrawCursorLine`: default `false`
+  - `smoothScrollOnRedrawCursorLineDuration`: default `300`
 - New, Experimental: New scroll motion to scroll 1/4.
   - `ScrollQuarterScreenDown`: `g ctrl-d`
   - `ScrollQuarterScreenUp`: `g ctrl-u`

--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -111,12 +111,17 @@
   'g $': 'vim-mode-plus:move-to-last-character-of-screen-line'
 
   # scroll
-  'ctrl-u': 'vim-mode-plus:scroll-half-screen-up'
-  'ctrl-b': 'vim-mode-plus:scroll-full-screen-up'
-  'ctrl-d': 'vim-mode-plus:scroll-half-screen-down'
   'ctrl-f': 'vim-mode-plus:scroll-full-screen-down'
-  'ctrl-e': 'vim-mode-plus:scroll-down'
-  'ctrl-y': 'vim-mode-plus:scroll-up'
+  'ctrl-b': 'vim-mode-plus:scroll-full-screen-up'
+
+  'ctrl-d': 'vim-mode-plus:scroll-half-screen-down'
+  'ctrl-u': 'vim-mode-plus:scroll-half-screen-up'
+
+  'g ctrl-d': 'vim-mode-plus:scroll-quarter-screen-down'
+  'g ctrl-u': 'vim-mode-plus:scroll-quarter-screen-up'
+
+  'ctrl-e': 'vim-mode-plus:mini-scroll-down'
+  'ctrl-y': 'vim-mode-plus:mini-scroll-up'
 
   'G': 'vim-mode-plus:move-to-last-line'
   'g g': 'vim-mode-plus:move-to-first-line'

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -735,6 +735,14 @@ ScrollHalfScreenUp:
   file: "./motion"
   commandName: "vim-mode-plus:scroll-half-screen-up"
   commandScope: "atom-text-editor"
+ScrollQuarterScreenDown:
+  file: "./motion"
+  commandName: "vim-mode-plus:scroll-quarter-screen-down"
+  commandScope: "atom-text-editor"
+ScrollQuarterScreenUp:
+  file: "./motion"
+  commandName: "vim-mode-plus:scroll-quarter-screen-up"
+  commandScope: "atom-text-editor"
 Find:
   file: "./motion"
   commandName: "vim-mode-plus:find"
@@ -1233,13 +1241,13 @@ ReplaceModeBackspace:
   file: "./misc-command"
   commandName: "vim-mode-plus:replace-mode-backspace"
   commandScope: "atom-text-editor.vim-mode-plus.insert-mode.replace"
-ScrollDown:
+MiniScrollDown:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-down"
+  commandName: "vim-mode-plus:mini-scroll-down"
   commandScope: "atom-text-editor"
-ScrollUp:
+MiniScrollUp:
   file: "./misc-command"
-  commandName: "vim-mode-plus:scroll-up"
+  commandName: "vim-mode-plus:mini-scroll-up"
   commandScope: "atom-text-editor"
 RedrawCursorLine:
   file: "./misc-command"

--- a/lib/flash-manager.js
+++ b/lib/flash-manager.js
@@ -11,7 +11,6 @@ const timeoutByFlashType = {
   "undo-redo": 500,
   "undo-redo-multiple-changes": 500,
   "undo-redo-multiple-delete": 500,
-  "screen-line": 500,
 }
 
 function addDemoSuffix(decoration) {
@@ -52,15 +51,6 @@ module.exports = class FlashManager {
       // Reflect to element before adding next css class. Important to **re-start** keyframe animation.
       this.vimState.editor.component.updateSync()
     }
-  }
-
-  flashScreenRow(row) {
-    const type = "screen-line"
-    this.destroyPreviousMarkerForTypeIfNecessary(type)
-    const marker = this.editor.markScreenPosition([row, 0])
-    this.markersByType.set(type, [marker])
-    const decoration = this.editor.decorateMarker(marker, {type: "line", class: "vim-mode-plus-flash " + type})
-    this.destroyMarkersAfter([marker], timeoutByFlashType[type])
   }
 
   flash(ranges, {type}) {

--- a/lib/flash-manager.js
+++ b/lib/flash-manager.js
@@ -11,6 +11,7 @@ const timeoutByFlashType = {
   "undo-redo": 500,
   "undo-redo-multiple-changes": 500,
   "undo-redo-multiple-delete": 500,
+  "screen-line": 500,
 }
 
 function addDemoSuffix(decoration) {
@@ -45,16 +46,28 @@ module.exports = class FlashManager {
     }, timeout)
   }
 
-  flash(ranges, {type}) {
-    ranges = (Array.isArray(ranges) ? ranges : [ranges]).filter(isNotEmpty)
-    if (!ranges.length) return
-
+  destroyPreviousMarkerForTypeIfNecessary(type) {
     if (this.markersByType.has(type)) {
       this.markersByType.get(type).forEach(marker => marker.destroy())
       // Reflect to element before adding next css class. Important to **re-start** keyframe animation.
       this.vimState.editor.component.updateSync()
     }
+  }
 
+  flashScreenRow(row) {
+    const type = "screen-line"
+    this.destroyPreviousMarkerForTypeIfNecessary(type)
+    const marker = this.editor.markScreenPosition([row, 0])
+    this.markersByType.set(type, [marker])
+    const decoration = this.editor.decorateMarker(marker, {type: "line", class: "vim-mode-plus-flash " + type})
+    this.destroyMarkersAfter([marker], timeoutByFlashType[type])
+  }
+
+  flash(ranges, {type}) {
+    ranges = (Array.isArray(ranges) ? ranges : [ranges]).filter(isNotEmpty)
+    if (!ranges.length) return
+
+    this.destroyPreviousMarkerForTypeIfNecessary(type)
     const markers = ranges.map(range => this.editor.markBufferRange(range, {invalidate: "touch"}))
     // hold as state to clear all markers onDidStopChangingActivePaneItem. t9md/vim-mode-plus#846.
     this.markersByType.set(type, markers)

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -344,7 +344,7 @@ class MiniScrollDown extends MiscCommand {
   execute() {
     const amountOfScreenRows = this.direction === "down" ? this.getCount() : -this.getCount()
     const duration = this.getConfig("smoothScrollOnMiniScroll") ? this.getConfig("smoothScrollOnMiniScrollDuration") : 0
-    this.vimState.requestScroll(amountOfScreenRows, {duration, onFinish: this.keepCursorOnScreen.bind(this)})
+    this.vimState.requestScroll({amountOfScreenRows, duration, onFinish: this.keepCursorOnScreen.bind(this)})
   }
 }
 MiniScrollDown.register()
@@ -369,10 +369,15 @@ class RedrawCursorLine extends MiscCommand {
 
   execute() {
     const scrollTop = Math.round(this.getScrollTop())
-    this.editorElement.setScrollTop(scrollTop)
-    if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
-      this.recommendToEnableScrollPastEnd()
+    const onFinish = () => {
+      if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
+        this.recommendToEnableScrollPastEnd()
+      }
     }
+    const duration = this.getConfig("smoothScrollOnRedrawCursorLine")
+      ? this.getConfig("smoothScrollOnRedrawCursorLineDuration")
+      : 0
+    this.vimState.requestScroll({scrollTop, duration, onFinish})
     if (this.moveToFirstCharacterOfLine) this.editor.moveToFirstCharacterOfLine()
   }
 
@@ -389,8 +394,8 @@ class RedrawCursorLine extends MiscCommand {
   recommendToEnableScrollPastEnd() {
     const message = [
       "vim-mode-plus",
-      "- Failed to set scrollTop. Require `editor.scrollPastEnd` setting to be `true`.",
-      '- You can enable it from `"Settings" > "Editor" > "Scroll Past End"`.',
+      "- Failed to scroll. To successfully scroll, `editor.scrollPastEnd` need to be enabled.",
+      '- You can do it from `"Settings" > "Editor" > "Scroll Past End"`.',
       "- Or **do you allow vmp enable it for you now?**",
     ].join("\n")
 

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -324,40 +324,36 @@ class ReplaceModeBackspace extends MiscCommand {
 ReplaceModeBackspace.register()
 
 // ctrl-e scroll lines downwards
-class ScrollDown extends MiscCommand {
-  execute() {
-    const count = this.getCount()
-    const oldFirstRow = this.editor.getFirstVisibleScreenRow()
-    this.editor.setFirstVisibleScreenRow(oldFirstRow + count)
-    const newFirstRow = this.editor.getFirstVisibleScreenRow()
+class MiniScrollDown extends MiscCommand {
+  defaultCount = this.getConfig("defaultScrollRowsOnMiniScroll")
+  direction = "down"
 
+  keepCursorOnScreen(scrollRows) {
+    const cursor = this.editor.getLastCursor()
+    const row = cursor.getScreenRow()
     const offset = 2
-    const {row, column} = this.editor.getCursorScreenPosition()
-    if (row < newFirstRow + offset) {
-      const newPoint = [row + count, column]
-      this.editor.setCursorScreenPosition(newPoint, {autoscroll: false})
+    const validScreenRow =
+      this.direction === "down"
+        ? this.utils.limitNumber(row, {min: this.editor.getFirstVisibleScreenRow() + offset})
+        : this.utils.limitNumber(row, {max: this.editor.getLastVisibleScreenRow() - offset})
+    if (row !== validScreenRow) {
+      this.utils.setBufferRow(cursor, this.editor.bufferRowForScreenRow(validScreenRow), {autoscroll: false})
     }
   }
+
+  execute() {
+    const amountOfScreenRows = this.direction === "down" ? this.getCount() : -this.getCount()
+    const duration = this.getConfig("smoothScrollOnMiniScroll") ? this.getConfig("smoothScrollOnMiniScrollDuration") : 0
+    this.vimState.requestScroll(amountOfScreenRows, {duration, onFinish: this.keepCursorOnScreen.bind(this)})
+  }
 }
-ScrollDown.register()
+MiniScrollDown.register()
 
 // ctrl-y scroll lines upwards
-class ScrollUp extends MiscCommand {
-  execute() {
-    const count = this.getCount()
-    const oldFirstRow = this.editor.getFirstVisibleScreenRow()
-    this.editor.setFirstVisibleScreenRow(oldFirstRow - count)
-    const newLastRow = this.editor.getLastVisibleScreenRow()
-
-    const offset = 2
-    const {row, column} = this.editor.getCursorScreenPosition()
-    if (row >= newLastRow - offset) {
-      const newPoint = [row - count, column]
-      this.editor.setCursorScreenPosition(newPoint, {autoscroll: false})
-    }
-  }
+class MiniScrollUp extends MiniScrollDown {
+  direction = "up"
 }
-ScrollUp.register()
+MiniScrollUp.register()
 
 // RedrawCursorLineAt{XXX} in viewport.
 // +-------------------------------------------+
@@ -368,7 +364,6 @@ ScrollUp.register()
 // | middle       | z z     | z .              |
 // | bottom       | z b     | z -              |
 // +-------------------------------------------+
-
 class RedrawCursorLine extends MiscCommand {
   moveToFirstCharacterOfLine = false
 

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -851,7 +851,6 @@ MoveToRelativeLineMinimumTwo.register(false)
 class MoveToTopOfScreen extends Motion {
   wise = "linewise"
   jump = true
-  scrolloff = 2
   defaultCount = 0
   verticalMotion = true
   where = "top"
@@ -866,13 +865,14 @@ class MoveToTopOfScreen extends Motion {
     const firstVisibleRow = this.editor.getFirstVisibleScreenRow()
     const lastVisibleRow = limitNumber(this.editor.getLastVisibleScreenRow(), {max: this.getVimLastScreenRow()})
 
+    const baseOffset = 2
     if (this.where === "top") {
-      const offset = firstVisibleRow === 0 ? 0 : this.scrolloff
+      const offset = firstVisibleRow === 0 ? 0 : baseOffset
       return limitNumber(firstVisibleRow + this.getCount(-1), {min: firstVisibleRow + offset, max: lastVisibleRow})
     } else if (this.where === "middle") {
       return firstVisibleRow + Math.floor((lastVisibleRow - firstVisibleRow) / 2)
     } else if (this.where === "bottom") {
-      const offset = lastVisibleRow === this.getVimLastScreenRow() ? 0 : this.scrolloff + 1
+      const offset = lastVisibleRow === this.getVimLastScreenRow() ? 0 : baseOffset + 1
       return limitNumber(lastVisibleRow - this.getCount(-1), {min: firstVisibleRow, max: lastVisibleRow - offset})
     }
   }
@@ -897,6 +897,7 @@ MoveToBottomOfScreen.register()
 // -------------------------
 // [FIXME] count behave differently from original Vim.
 class Scroll extends Motion {
+  static scrollTask = null
   verticalMotion = true
 
   isSmoothScrollEnabled() {
@@ -911,58 +912,22 @@ class Scroll extends Motion {
       : this.getConfig("smoothScrollOnHalfScrollMotionDuration")
   }
 
-  getPixelRectTopForSceenRow(row) {
-    const point = new Point(row, 0)
-    return this.editor.element.pixelRectForScreenRange(new Range(point, point)).top
-  }
-
-  smoothScroll(fromRow, toRow, done) {
-    const topPixelFrom = {top: this.getPixelRectTopForSceenRow(fromRow)}
-    const topPixelTo = {top: this.getPixelRectTopForSceenRow(toRow)}
-    // [NOTE]
-    // intentionally use `element.component.setScrollTop` instead of `element.setScrollTop`.
-    // SInce element.setScrollTop will throw exception when element.component no longer exists.
-    const step = newTop => {
-      if (this.editor.element.component) {
-        this.editor.element.component.setScrollTop(newTop)
-        this.editor.element.component.updateSync()
-      }
-    }
-
-    const duration = this.getSmoothScrollDuation()
-    this.vimState.requestScrollAnimation(topPixelFrom, topPixelTo, {duration, step, done})
-  }
-
-  getAmountOfRows() {
-    return Math.ceil(this.amountOfPage * this.editor.getRowsPerPage() * this.getCount())
-  }
-
-  getBufferRow(cursor) {
-    const screenRow = this.utils.getValidVimScreenRow(this.editor, cursor.getScreenRow() + this.getAmountOfRows())
-    return this.editor.bufferRowForScreenRow(screenRow)
-  }
-
   moveCursor(cursor) {
-    const bufferRow = this.getBufferRow(cursor)
-    this.setCursorBufferRow(cursor, this.getBufferRow(cursor), {autoscroll: false})
+    const screenRow = this.utils.getValidVimScreenRow(this.editor, cursor.getScreenRow() + this.amountOfRowsToScroll)
+    this.setCursorBufferRow(cursor, this.editor.bufferRowForScreenRow(screenRow), {autoscroll: false})
+  }
 
-    if (cursor.isLastCursor()) {
-      if (this.isSmoothScrollEnabled()) this.vimState.finishScrollAnimation()
+  execute() {
+    this.amountOfRowsToScroll = Math.ceil(this.amountOfPage * this.editor.getRowsPerPage() * this.getCount())
 
-      const firstVisibileScreenRow = this.editor.getFirstVisibleScreenRow()
-      const newFirstVisibileBufferRow = this.editor.bufferRowForScreenRow(
-        firstVisibileScreenRow + this.getAmountOfRows()
-      )
-      const newFirstVisibileScreenRow = this.editor.screenRowForBufferRow(newFirstVisibileBufferRow)
-      const done = () => {
-        this.editor.setFirstVisibleScreenRow(newFirstVisibileScreenRow)
-        // [FIXME] sometimes, scrollTop is not updated, calling this fix.
-        // Investigate and find better approach then remove this workaround.
-        if (this.editor.element.component) this.editor.element.component.updateSync()
-      }
+    super.execute()
 
-      if (this.isSmoothScrollEnabled()) this.smoothScroll(firstVisibileScreenRow, newFirstVisibileScreenRow, done)
-      else done()
+    if (this.isSmoothScrollEnabled()) {
+      const duration = this.getSmoothScrollDuation()
+      const onFinish = () => this.vimState.flashScreenRow(this.editor.getCursorScreenPosition().row)
+      this.vimState.requestScroll(this.amountOfRowsToScroll, {duration, onFinish})
+    } else {
+      this.vimState.requestScroll(this.amountOfRowsToScroll)
     }
   }
 }
@@ -991,6 +956,18 @@ class ScrollHalfScreenUp extends Scroll {
   amountOfPage = -1 / 2
 }
 ScrollHalfScreenUp.register()
+
+// keymap: g ctrl-d
+class ScrollQuarterScreenDown extends Scroll {
+  amountOfPage = +1 / 4
+}
+ScrollQuarterScreenDown.register()
+
+// keymap: g ctrl-u
+class ScrollQuarterScreenUp extends Scroll {
+  amountOfPage = -1 / 4
+}
+ScrollQuarterScreenUp.register()
 
 // Find
 // -------------------------

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -921,7 +921,7 @@ class Scroll extends Motion {
     this.amountOfRowsToScroll = Math.ceil(this.amountOfPage * this.editor.getRowsPerPage() * this.getCount())
     super.execute()
     const duration = this.isSmoothScrollEnabled() ? this.getSmoothScrollDuation() : 0
-    this.vimState.requestScroll(this.amountOfRowsToScroll, {duration})
+    this.vimState.requestScroll({amountOfScreenRows: this.amountOfRowsToScroll, duration})
   }
 }
 Scroll.register(false)

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -919,16 +919,9 @@ class Scroll extends Motion {
 
   execute() {
     this.amountOfRowsToScroll = Math.ceil(this.amountOfPage * this.editor.getRowsPerPage() * this.getCount())
-
     super.execute()
-
-    if (this.isSmoothScrollEnabled()) {
-      const duration = this.getSmoothScrollDuation()
-      const onFinish = () => this.vimState.flashScreenRow(this.editor.getCursorScreenPosition().row)
-      this.vimState.requestScroll(this.amountOfRowsToScroll, {duration, onFinish})
-    } else {
-      this.vimState.requestScroll(this.amountOfRowsToScroll)
-    }
+    const duration = this.isSmoothScrollEnabled() ? this.getSmoothScrollDuation() : 0
+    this.vimState.requestScroll(this.amountOfRowsToScroll, {duration})
   }
 }
 Scroll.register(false)

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -490,6 +490,14 @@ module.exports = new Settings("vim-mode-plus", {
     default: 500,
     description: "Smooth scroll duration( msec ) for `ctrl-d` and `ctrl-u`",
   },
+  smoothScrollOnRedrawCursorLine: {
+    default: false,
+    description: "For `z t`, `z enter`, `z u`, `z space`, `z z`, `z .`, `z b`, `z - `",
+  },
+  smoothScrollOnRedrawCursorLineDuration: {
+    default: 300,
+    description: "Smooth scroll duration( msec ) for `z` beginning `redraw-cursor-line` command familiy",
+  },
   smoothScrollOnMiniScroll: {
     default: false,
     description: "For `ctrl-e` and `ctrl-y`",

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -490,6 +490,18 @@ module.exports = new Settings("vim-mode-plus", {
     default: 500,
     description: "Smooth scroll duration( msec ) for `ctrl-d` and `ctrl-u`",
   },
+  smoothScrollOnMiniScroll: {
+    default: false,
+    description: "For `ctrl-e` and `ctrl-y`",
+  },
+  smoothScrollOnMiniScrollDuration: {
+    default: 200,
+    description: "Smooth scroll duration( msec ) for `ctrl-e` and `ctrl-y`",
+  },
+  defaultScrollRowsOnMiniScroll: {
+    default: 1,
+    description: "Default amount of screen rows used in `ctrl-e` and `ctrl-y`",
+  },
   statusBarModeStringStyle: {
     default: "short",
     enum: ["short", "long"],

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -36,7 +36,6 @@ module.exports = class VimState {
   isMode(...args) { return this.modeManager.isMode(...args) } // prettier-ignore
   activate(...args) { this.modeManager.activate(...args) } // prettier-ignore
   flash(...args) { this.flashManager.flash(...args) } // prettier-ignore
-  flashScreenRow(...args) { this.flashManager.flashScreenRow(...args) } // prettier-ignore
   clearFlash() { this.__flashManager && this.flashManager.clearAllMarkers() } // prettier-ignore
   updateStatusBar() { this.statusBarManager.update(this.mode, this.submode) } // prettier-ignore
   setOperatorModifier(...args) { this.operationStack.setOperatorModifier(...args) } // prettier-ignore

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -412,34 +412,39 @@ module.exports = class VimState {
     if (this.__persistentSelection) this.persistentSelection.clearMarkers()
   }
 
-  requestScroll(amountOfScreenRows, {duration, onFinish}) {
+  requestScroll({amountOfScreenRows, scrollTop, duration, onFinish}) {
     // Finalize previous scroll request first
     if (this.scrollRequest) {
       this.scrollRequest.finish()
       this.scrollRequest = null
     }
 
-    const fromRow = this.editor.getFirstVisibleScreenRow()
-    const toRow = fromRow + amountOfScreenRows
+    let scrollFrom, scrollTo
+    if (amountOfScreenRows != null) {
+      const fromRow = this.editor.getFirstVisibleScreenRow()
+      const toRow = fromRow + amountOfScreenRows
 
-    const done = () => {
-      this.editor.setFirstVisibleScreenRow(toRow)
-      this.scrollRequest = null
-      if (this.editor.element.component) this.editor.element.component.updateSync()
-      if (onFinish) onFinish()
+      if (!duration) {
+        this.editor.setFirstVisibleScreenRow(toRow)
+        if (onFinish) onFinish()
+        return
+      }
+
+      const getPixelRectTopForRow = row => this.editorElement.pixelRectForScreenRange([[row, 0], [row, 0]]).top
+      scrollFrom = {top: getPixelRectTopForRow(fromRow)}
+      scrollTo = {top: getPixelRectTopForRow(toRow)}
+    } else {
+      if (!duration) {
+        this.editorElement.setScrollTop(scrollTop)
+        if (onFinish) onFinish()
+        return
+      }
+      scrollFrom = {top: this.editorElement.getScrollTop()}
+      scrollTo = {top: scrollTop}
     }
-
-    if (!duration) {
-      done()
-      return
-    }
-
-    const getPixelRectTopForRow = row => this.editorElement.pixelRectForScreenRange([[row, 0], [row, 0]]).top
-    const from = {top: getPixelRectTopForRow(fromRow)}
-    const to = {top: getPixelRectTopForRow(toRow)}
 
     if (!jQuery) jQuery = require("atom-space-pen-views").jQuery
-    this.scrollRequest = jQuery(from).animate(to, {
+    this.scrollRequest = jQuery(scrollFrom).animate(scrollTo, {
       duration: duration,
       step: newTop => {
         // [NOTE]
@@ -450,7 +455,11 @@ module.exports = class VimState {
           this.editorElement.component.updateSync()
         }
       },
-      done: done,
+      done: () => {
+        this.scrollRequest = null
+        if (this.editor.element.component) this.editor.element.component.updateSync()
+        if (onFinish) onFinish()
+      },
     })
   }
 

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -36,7 +36,7 @@ module.exports = class VimState {
   isMode(...args) { return this.modeManager.isMode(...args) } // prettier-ignore
   activate(...args) { this.modeManager.activate(...args) } // prettier-ignore
   flash(...args) { this.flashManager.flash(...args) } // prettier-ignore
-  flashScreenRange(...args) { this.flashManager.flashScreenRange(...args) } // prettier-ignore
+  flashScreenRow(...args) { this.flashManager.flashScreenRow(...args) } // prettier-ignore
   clearFlash() { this.__flashManager && this.flashManager.clearAllMarkers() } // prettier-ignore
   updateStatusBar() { this.statusBarManager.update(this.mode, this.submode) } // prettier-ignore
   setOperatorModifier(...args) { this.operationStack.setOperatorModifier(...args) } // prettier-ignore
@@ -413,16 +413,46 @@ module.exports = class VimState {
     if (this.__persistentSelection) this.persistentSelection.clearMarkers()
   }
 
-  requestScrollAnimation(from, to, options) {
-    if (!jQuery) jQuery = require("atom-space-pen-views").jQuery
-    this.scrollAnimationEffect = jQuery(from).animate(to, options)
-  }
-
-  finishScrollAnimation() {
-    if (this.scrollAnimationEffect) {
-      this.scrollAnimationEffect.finish()
-      this.scrollAnimationEffect = null
+  requestScroll(amountOfScreenRows, {duration, onFinish}) {
+    // Finalize previous scroll request first
+    if (this.scrollRequest) {
+      this.scrollRequest.finish()
+      this.scrollRequest = null
     }
+
+    const fromRow = this.editor.getFirstVisibleScreenRow()
+    const toRow = fromRow + amountOfScreenRows
+
+    const done = () => {
+      this.editor.setFirstVisibleScreenRow(toRow)
+      this.scrollRequest = null
+      if (this.editor.element.component) this.editor.element.component.updateSync()
+      if (onFinish) onFinish()
+    }
+
+    if (!duration) {
+      done()
+      return
+    }
+
+    const getPixelRectTopForRow = row => this.editorElement.pixelRectForScreenRange([[row, 0], [row, 0]]).top
+    const from = {top: getPixelRectTopForRow(fromRow)}
+    const to = {top: getPixelRectTopForRow(toRow)}
+
+    if (!jQuery) jQuery = require("atom-space-pen-views").jQuery
+    this.scrollRequest = jQuery(from).animate(to, {
+      duration: duration,
+      step: newTop => {
+        // [NOTE]
+        // intentionally use `element.component.setScrollTop` instead of `element.setScrollTop`.
+        // Since element.setScrollTop will throw exception when element.component no longer exists.
+        if (this.editorElement.component) {
+          this.editorElement.component.setScrollTop(newTop)
+          this.editorElement.component.updateSync()
+        }
+      },
+      done: done,
+    })
   }
 
   // Other

--- a/spec/scroll-spec.coffee
+++ b/spec/scroll-spec.coffee
@@ -18,11 +18,10 @@ describe "Scrolling", ->
       initialRowRange = [0, 5]
 
       set
-        cursor: [1, 2]
-        text: """
+        textC: """
           100
           200
-          300
+          30|0
           400
           500
           600
@@ -35,15 +34,15 @@ describe "Scrolling", ->
 
     describe "the ctrl-e and ctrl-y keybindings", ->
       it "moves the screen up and down by one and keeps cursor onscreen", ->
-        ensure 'ctrl-e', cursor: [2, 2]
+        ensure 'ctrl-e', cursor: [3, 2]
         expect(editor.getFirstVisibleScreenRow()).toBe 1
         expect(editor.getLastVisibleScreenRow()).toBe 6
 
-        ensure '2 ctrl-e', cursor: [4, 2]
+        ensure '2 ctrl-e', cursor: [5, 2]
         expect(editor.getFirstVisibleScreenRow()).toBe 3
         expect(editor.getLastVisibleScreenRow()).toBe 8
 
-        ensure '2 ctrl-y', cursor: [2, 2]
+        ensure '2 ctrl-y', cursor: [4, 2]
         expect(editor.getFirstVisibleScreenRow()).toBe 1
         expect(editor.getLastVisibleScreenRow()).toBe 6
 

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -82,6 +82,7 @@ atom-text-editor.vim-mode-plus-input-char-waiting {
 @flash-search-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%);
 @flash-added-color: fadeout(darken(@syntax-color-added, 10%), 50%);
 @flash-removed-color: fadeout(@syntax-color-removed, 50%);
+@flash-screen-line-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%);
 
 // flashOnOperate
 .flash-animation(flash-operator, @flash-base-color);
@@ -96,6 +97,9 @@ atom-text-editor.vim-mode-plus-input-char-waiting {
 // flashOnSearch
 .flash-animation(flash-search, @flash-search-color);
 .flash-animation(flash-screen, @flash-base-color);
+
+// CursorLine on ctrl-f, b, d, u
+.flash-animation(flash-screen-line, @flash-screen-line-color);
 
 atom-text-editor .vim-mode-plus-flash {
   // flashOnOperate
@@ -121,6 +125,13 @@ atom-text-editor .vim-mode-plus-flash {
   &.undo-redo-demo                  .region { background: @flash-base-color; }
   &.undo-redo-multiple-changes-demo .region { background: @flash-added-color; }
   &.undo-redo-multiple-delete-demo  .region { background: @flash-removed-color; }
+}
+
+atom-text-editor {
+  // CursorLine on ctrl-f, b, d, u
+  .line.vim-mode-plus-flash.screen-line {
+    .flash(flash-screen-line, 0.5s);
+  }
 }
 
 // Hover Counter

--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -82,7 +82,6 @@ atom-text-editor.vim-mode-plus-input-char-waiting {
 @flash-search-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%);
 @flash-added-color: fadeout(darken(@syntax-color-added, 10%), 50%);
 @flash-removed-color: fadeout(@syntax-color-removed, 50%);
-@flash-screen-line-color: fadeout(darken(@syntax-selection-flash-color, 10%), 20%);
 
 // flashOnOperate
 .flash-animation(flash-operator, @flash-base-color);
@@ -97,9 +96,6 @@ atom-text-editor.vim-mode-plus-input-char-waiting {
 // flashOnSearch
 .flash-animation(flash-search, @flash-search-color);
 .flash-animation(flash-screen, @flash-base-color);
-
-// CursorLine on ctrl-f, b, d, u
-.flash-animation(flash-screen-line, @flash-screen-line-color);
 
 atom-text-editor .vim-mode-plus-flash {
   // flashOnOperate
@@ -125,13 +121,6 @@ atom-text-editor .vim-mode-plus-flash {
   &.undo-redo-demo                  .region { background: @flash-base-color; }
   &.undo-redo-multiple-changes-demo .region { background: @flash-added-color; }
   &.undo-redo-multiple-delete-demo  .region { background: @flash-removed-color; }
-}
-
-atom-text-editor {
-  // CursorLine on ctrl-f, b, d, u
-  .line.vim-mode-plus-flash.screen-line {
-    .flash(flash-screen-line, 0.5s);
-  }
 }
 
 // Hover Counter


### PR DESCRIPTION
- :bomb: Rename confusing `ScrollXXX`
  - `ScrollDown`(`ctrl-e`) to `MiniScrollDown`
  - `ScrollUp`(`ctrl-y`) to `MiniScrollUp`
- :gift: New config options to tune `MiniScroll`
  `smoothScrollOnMiniScroll`: default `false`
  `smoothScrollOnMiniScrollDuration`: default `200`
  `defaultScrollRowsOnMiniScroll`: default `1`
- :gift: [experimental] New motion
  - `ScrollQuarterScreenDown`: `g ctrl-d`
  - `ScrollQuarterScreenUp`: `g ctrl-u`
  - smoothScrollOptions is NOT explicitly provided, use `ScrollHalf` value.
