### PR TITLE
use buffer.onDidChangeText()

### DIFF
--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -54,13 +54,15 @@ class Undo extends MiscCommand {
   }
 
   mutateWithTrackChanges() {
-    const changes = {newRanges: [], oldRanges: []}
+    const changedRanges = {newRanges: [], oldRanges: []}
 
-    const disposable = this.editor.getBuffer().onDidChange(({newRange, oldRange}) => {
-      if (newRange.isEmpty()) {
-        changes.oldRanges.push(oldRange) // Remove only
-      } else {
-        changes.newRanges.push(newRange)
+    const disposable = this.editor.getBuffer().onDidChangeText(event => {
+      for (const {newRange, oldRange} of event.changes) {
+        if (newRange.isEmpty()) {
+          changedRanges.oldRanges.push(oldRange) // Remove only
+        } else {
+          changedRanges.newRanges.push(newRange)
+        }
       }
     })
 
@@ -71,7 +73,7 @@ class Undo extends MiscCommand {
     }
 
     disposable.dispose()
-    return changes
+    return changedRanges
   }
 
   flashChanges({newRanges, oldRanges}) {
@@ -557,7 +559,7 @@ CopyFromLineAbove.register()
 
 class CopyFromLineBelow extends CopyFromLineAbove {
   rowDelta = +1
-} 
+}
 CopyFromLineBelow.register()
 
 class NextTab extends MiscCommand {


### PR DESCRIPTION
Fix #939

@maxbrunsfeld

Hi, Thanks for notifying me for upcoming changes.
And `onDidChangeText` was worked for my purpose.
Anyway, I want to share vim-mode-plus(vmp)'s usage of `onDidChange`, since this is very critical for vmp's feature which I think very important among many features of vmp.

Different from the code you pointed out in issue comment, following code is actually affected by this change.(maybe because your regex didn't match `getBuffer().onDidChange`).

https://github.com/t9md/atom-vim-mode-plus/blob/74d3b350bfd57fa3bd0c52742c0ef2b12106cf11/lib/misc-command.js#L59-L65

vim-mode-plus really depending on `buffer.onDidChange` event to **flash** changed(add/delete) text range on `undo` or `redo` operation.
That's gives enough context for developers.

And vmp support occurrence, it change/delete multiple selection in **single transaction**.

![changes-hl](https://user-images.githubusercontent.com/155205/32316745-d66affd0-bff4-11e7-8d81-07255394ace9.gif)

So summarized range info is not enough, granular information for each changes are crucial for precise highlight.
Fortunately `onDidChangeText` provides this granular information with `{changes}` props.
And as far as I checked, v1.19.7 works with `onDidChangeText()`

So I did just **replaced** old `onDidChange` event.
