### PR TITLE
Hide commands from command-palette

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -27,7 +27,7 @@ class Base {
   static commandScope = "atom-text-editor"
   static operationKind = null
   static getEditorState = null // set through init()
-  static hideCommand = false
+  static hiddenCommand = true
 
   recordable = false
   repeated = false
@@ -251,9 +251,16 @@ class Base {
     const commandTable = {}
     for (const file of filesToLoad) {
       for (const klass of klassesGroupedByFile[file]) {
-        commandTable[klass.name] = klass.command
-          ? {file: klass.file, commandName: klass.getCommandName(), commandScope: klass.commandScope}
-          : {file: klass.file}
+        const spec = {file: klass.file}
+        if (klass.command) {
+          spec.commandName = klass.getCommandName()
+          spec.commandScope = klass.commandScope
+          if (!klass.hiddenCommand) {
+            // Default `true`, so set prop when `false` to reduce table size.
+            spec.hiddenCommand = klass.hiddenCommand
+          }
+        }
+        commandTable[klass.name] = spec
       }
     }
     return commandTable
@@ -315,20 +322,30 @@ class Base {
     return this.registerCommandFromSpec(this.name, {
       commandScope: this.commandScope,
       commandName: this.getCommandName(),
+      hiddenCommand: this.hiddenCommand,
       getClass: () => this,
     })
   }
 
   static registerCommandFromSpec(name, spec) {
-    let {commandScope = "atom-text-editor", commandPrefix = "vim-mode-plus", commandName, getClass} = spec
+    let {
+      commandScope = "atom-text-editor",
+      commandPrefix = "vim-mode-plus",
+      commandName,
+      getClass,
+      hiddenCommand = true,
+    } = spec
     if (!commandName) commandName = commandPrefix + ":" + _plus().dasherize(name)
     if (!getClass) getClass = name => this.getClass(name)
 
     const getEditorState = this.getEditorState
-    return atom.commands.add(commandScope, commandName, function(event) {
-      const vimState = getEditorState(this.getModel()) || getEditorState(atom.workspace.getActiveTextEditor())
-      if (vimState) vimState.operationStack.run(getClass(name)) // vimState possibly be undefined See #85
-      event.stopPropagation()
+    return atom.commands.add(commandScope, commandName, {
+      hiddenInCommandPalette: hiddenCommand,
+      didDispatch(event) {
+        const vimState = getEditorState(this.getModel()) || getEditorState(atom.workspace.getActiveTextEditor())
+        if (vimState) vimState.operationStack.run(getClass(name)) // vimState possibly be undefined See #85
+        event.stopPropagation()
+      },
     })
   }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -27,6 +27,7 @@ class Base {
   static commandScope = "atom-text-editor"
   static operationKind = null
   static getEditorState = null // set through init()
+  static hideCommand = false
 
   recordable = false
   repeated = false

--- a/lib/main.js
+++ b/lib/main.js
@@ -193,10 +193,13 @@ module.exports = {
       const boundCommands = {}
       for (const name of Object.keys(commands)) {
         const fn = commands[name]
-        boundCommands[`vim-mode-plus:${name}`] = function(event) {
-          event.stopPropagation()
-          const vimState = getEditorState(this.getModel())
-          if (vimState) fn.call(vimState, event)
+        boundCommands[`vim-mode-plus:${name}`] = {
+          hiddenInCommandPalette: true,
+          didDispatch(event) {
+            event.stopPropagation()
+            const vimState = getEditorState(this.getModel())
+            if (vimState) fn.call(vimState, event)
+          },
         }
       }
       return boundCommands


### PR DESCRIPTION
## Summary

Hide vmp commands from command-palette to improve responsiveness of command-palette.

## Basic

See this example.
- 1st command is hidden from command-palette(this capability is added in https://github.com/atom/command-palette/pull/92).
- 2nd command is shown in command-palette.

```js
atom.commands.add("atom-workspace", {
  "this-command-is-hidden": {
    hiddenInCommandPalette: true,
    didDispatch() {
      console.log("hidden")
    },
  },
  "this-command-is-displayed": {
    didDispatch() {
      console.log("displayed")
    },
  },
})
console.log("loaded")
```
Most vmp commands are invoked via keymaps. So should be hidden from command-palette.
Why?
- I believe can reduce user's confusion(less noise is basically better).
- Improve responsiveness of command-palette.

## HOW?

- Introduce operation class's static prop `hiddenCommand`( default `true`).
- Use `hiddenCommand` when registering operation class as atom commands.
- Currently **all** commands are hidden.
- Override to `true` for command which should be shown  in palette.
  - Maybe it's useful especially while initial active dev of new operation class.
