### PR TITLE
Fix change corner case

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -39,12 +39,6 @@
   'ctrl-r': 'vim-mode-plus:insert-register'
   'ctrl-o': 'vim-mode-plus:activate-normal-mode-once'
 
-# Insert-replace
-# -------------------------
-'atom-text-editor.vim-mode-plus.insert-mode.replace':
-  'ctrl-h': 'vim-mode-plus:replace-mode-backspace'
-  'backspace': 'vim-mode-plus:replace-mode-backspace'
-
 # except insert
 # -------------------------
 'atom-text-editor.vim-mode-plus:not(.insert-mode)':

--- a/lib/base.js
+++ b/lib/base.js
@@ -124,13 +124,11 @@ class Base {
     this.vimState.focusInput(options)
   }
 
-  focusInputPromisified(options = {}) {
-    return new Promise((onConfirm, onCancel) => {
-      const defaultOptions = {
-        hideCursor: true,
-        onChange: input => this.vimState.hover.set(input),
-      }
-      this.vimState.focusInput(Object.assign(defaultOptions, options, {onConfirm, onCancel}))
+  // Return promise which resolve with input char or `undefined` when cancelled.
+  focusInputPromised(options = {}) {
+    return new Promise(resolve => {
+      const defaultOptions = {hideCursor: true, onChange: input => this.vimState.hover.set(input)}
+      this.vimState.focusInput(Object.assign(defaultOptions, options, {onConfirm: resolve, onCancel: resolve}))
     })
   }
 

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -1338,10 +1338,6 @@ FoldNextIndentLevel:
   file: "./misc-command"
   commandName: "vim-mode-plus:fold-next-indent-level"
   commandScope: "atom-text-editor"
-ReplaceModeBackspace:
-  file: "./misc-command"
-  commandName: "vim-mode-plus:replace-mode-backspace"
-  commandScope: "atom-text-editor.vim-mode-plus.insert-mode.replace"
 MiniScrollDown:
   file: "./misc-command"
   commandName: "vim-mode-plus:mini-scroll-down"

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -269,270 +269,335 @@ ToggleCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:toggle-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ToggleCaseAndMoveRight:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:toggle-case-and-move-right"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 UpperCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:upper-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 LowerCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:lower-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Replace:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:replace"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ReplaceCharacter:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:replace-character"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitByCharacter:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-by-character"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 CamelCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:camel-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SnakeCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:snake-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 PascalCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:pascal-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DashCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:dash-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TitleCase:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:title-case"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 EncodeUriComponent:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:encode-uri-component"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DecodeUriComponent:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:decode-uri-component"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TrimString:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:trim-string"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 CompactSpaces:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:compact-spaces"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 AlignOccurrence:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:align-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 AlignOccurrenceByPadLeft:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:align-occurrence-by-pad-left"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 AlignOccurrenceByPadRight:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:align-occurrence-by-pad-right"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 RemoveLeadingWhiteSpaces:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:remove-leading-white-spaces"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ConvertToSoftTab:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:convert-to-soft-tab"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ConvertToHardTab:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:convert-to-hard-tab"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TransformStringByExternalCommand:
   file: "./operator-transform-string"
 TransformStringBySelectList:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:transform-string-by-select-list"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TransformWordBySelectList:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:transform-word-by-select-list"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TransformSmartWordBySelectList:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:transform-smart-word-by-select-list"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ReplaceWithRegister:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:replace-with-register"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ReplaceOccurrenceWithRegister:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:replace-occurrence-with-register"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SwapWithRegister:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:swap-with-register"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Indent:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:indent"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Outdent:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:outdent"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 AutoIndent:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:auto-indent"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ToggleLineComments:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:toggle-line-comments"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Reflow:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:reflow"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ReflowWithStay:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:reflow-with-stay"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SurroundBase:
   file: "./operator-transform-string"
 Surround:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:surround"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SurroundWord:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:surround-word"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SurroundSmartWord:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:surround-smart-word"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 MapSurround:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:map-surround"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DeleteSurround:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:delete-surround"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DeleteSurroundAnyPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:delete-surround-any-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DeleteSurroundAnyPairAllowForwarding:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:delete-surround-any-pair-allow-forwarding"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeSurround:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:change-surround"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeSurroundAnyPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:change-surround-any-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeSurroundAnyPairAllowForwarding:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:change-surround-any-pair-allow-forwarding"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 JoinTarget:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:join-target"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Join:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:join"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 JoinBase:
   file: "./operator-transform-string"
 JoinWithKeepingSpace:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:join-with-keeping-space"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 JoinByInput:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:join-by-input"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 JoinByInputWithKeepingSpace:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:join-by-input-with-keeping-space"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitString:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-string"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitStringWithKeepingSplitter:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-string-with-keeping-splitter"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitArguments:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-arguments"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitArgumentsWithRemoveSeparator:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-arguments-with-remove-separator"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SplitArgumentsOfInnerAnyPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:split-arguments-of-inner-any-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeOrder:
   file: "./operator-transform-string"
 Reverse:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:reverse"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ReverseInnerAnyPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:reverse-inner-any-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Rotate:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:rotate"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 RotateBackwards:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:rotate-backwards"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 RotateArgumentsOfInnerPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:rotate-arguments-of-inner-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 RotateArgumentsBackwardsOfInnerPair:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:rotate-arguments-backwards-of-inner-pair"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Sort:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:sort"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SortCaseInsensitively:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:sort-case-insensitively"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SortByNumber:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:sort-by-number"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 NumberingLines:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:numbering-lines"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 DuplicateWithCommentOutOriginal:
   file: "./operator-transform-string"
   commandName: "vim-mode-plus:duplicate-with-comment-out-original"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Motion:
   file: "./motion"
 CurrentSelection:

--- a/lib/command-table.coffee
+++ b/lib/command-table.coffee
@@ -125,116 +125,144 @@ ActivateInsertMode:
   file: "./operator-insert"
   commandName: "vim-mode-plus:activate-insert-mode"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ActivateReplaceMode:
   file: "./operator-insert"
   commandName: "vim-mode-plus:activate-replace-mode"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAfter:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-after"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtBeginningOfLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-beginning-of-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAfterEndOfLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-after-end-of-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtFirstCharacterOfLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-first-character-of-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtLastInsert:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-last-insert"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAboveWithNewline:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-above-with-newline"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertBelowWithNewline:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-below-with-newline"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertByTarget:
   file: "./operator-insert"
 InsertAtStartOfTarget:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-start-of-target"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtEndOfTarget:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-target"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtHeadOfTarget:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-head-of-target"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtStartOfOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-start-of-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtEndOfOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtHeadOfOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-head-of-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtStartOfSubwordOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-start-of-subword-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtEndOfSubwordOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-subword-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtHeadOfSubwordOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-head-of-subword-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtStartOfSmartWord:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-start-of-smart-word"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtEndOfSmartWord:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-end-of-smart-word"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtPreviousFoldStart:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-previous-fold-start"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 InsertAtNextFoldStart:
   file: "./operator-insert"
   commandName: "vim-mode-plus:insert-at-next-fold-start"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Change:
   file: "./operator-insert"
   commandName: "vim-mode-plus:change"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeOccurrence:
   file: "./operator-insert"
   commandName: "vim-mode-plus:change-occurrence"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 Substitute:
   file: "./operator-insert"
   commandName: "vim-mode-plus:substitute"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 SubstituteLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:substitute-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:change-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 ChangeToLastCharacterOfLine:
   file: "./operator-insert"
   commandName: "vim-mode-plus:change-to-last-character-of-line"
   commandScope: "atom-text-editor"
+  hiddenCommand: false
 TransformString:
   file: "./operator-transform-string"
 ToggleCase:

--- a/lib/focus-input.js
+++ b/lib/focus-input.js
@@ -33,7 +33,7 @@ module.exports = function focusInput(
   }
 
   let didChangeTextDisposable
-  
+
   const confirm = text => {
     if (didChangeTextDisposable) {
       didChangeTextDisposable.dispose()

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -267,22 +267,6 @@ class FoldNextIndentLevel extends MiscCommand {
 }
 FoldNextIndentLevel.register()
 
-class ReplaceModeBackspace extends MiscCommand {
-  static commandScope = "atom-text-editor.vim-mode-plus.insert-mode.replace"
-
-  execute() {
-    for (const selection of this.editor.getSelections()) {
-      // char might be empty.
-      const char = this.vimState.modeManager.getReplacedCharForSelection(selection)
-      if (char != null) {
-        selection.selectLeft()
-        if (!selection.insertText(char).isEmpty()) selection.cursor.moveLeft()
-      }
-    }
-  }
-}
-ReplaceModeBackspace.register()
-
 // ctrl-e scroll lines downwards
 class MiniScrollDown extends MiscCommand {
   defaultCount = this.getConfig("defaultScrollRowsOnMiniScroll")

--- a/lib/mode-manager.js
+++ b/lib/mode-manager.js
@@ -22,21 +22,11 @@ module.exports = class ModeManager {
 
   // Event
   // -------------------------
-  onWillActivateMode(fn) {
-    return this.emitter.on("will-activate-mode", fn)
-  }
-  onDidActivateMode(fn) {
-    return this.emitter.on("did-activate-mode", fn)
-  }
-  onWillDeactivateMode(fn) {
-    return this.emitter.on("will-deactivate-mode", fn)
-  }
-  preemptWillDeactivateMode(fn) {
-    return this.emitter.preempt("will-deactivate-mode", fn)
-  }
-  onDidDeactivateMode(fn) {
-    return this.emitter.on("did-deactivate-mode", fn)
-  }
+  onWillActivateMode(fn) { return this.emitter.on("will-activate-mode", fn) } // prettier-ignore
+  onDidActivateMode(fn) { return this.emitter.on("did-activate-mode", fn) } // prettier-ignore
+  onWillDeactivateMode(fn) { return this.emitter.on("will-deactivate-mode", fn) } // prettier-ignore
+  preemptWillDeactivateMode(fn) { return this.emitter.preempt("will-deactivate-mode", fn) } // prettier-ignore
+  onDidDeactivateMode(fn) { return this.emitter.on("did-deactivate-mode", fn) } // prettier-ignore
 
   // activate: Public
   //  Use this method to change mode, DONT use other direct method.
@@ -53,24 +43,32 @@ module.exports = class ModeManager {
       newSubmode = null
     }
 
-    if (newMode !== this.mode) this.deactivate()
+    if (newMode !== this.mode) {
+      this.emitter.emit("will-deactivate-mode", {mode: this.mode, submode: this.submode})
+      if (this.deactivator) {
+        this.deactivator.dispose()
+        this.deactivator = null
+      }
+      this.emitter.emit("did-deactivate-mode", {mode: this.mode, submode: this.submode})
+    }
 
-    if (newMode === "normal") this.deactivator = this.activateNormalMode()
-    else if (newMode === "operator-pending") this.deactivator = this.activateOperatorPendingMode()
-    else if (newMode === "insert") this.deactivator = this.activateInsertMode(newSubmode)
+    if (newMode === "normal") this.activateNormalMode()
+    else if (newMode === "insert") this.editorElement.component.setInputEnabled(true)
     else if (newMode === "visual") this.deactivator = this.activateVisualMode(newSubmode)
 
     this.editorElement.classList.remove(`${this.mode}-mode`)
     this.editorElement.classList.remove(this.submode)
 
+    const oldMode = this.mode
     this.mode = newMode
     this.submode = newSubmode
 
+    if (oldMode === "visual" || this.mode === "visual") this.updateNarrowedState()
+
+    // Prevent swrap from loaded on initial mode-setup on startup.
     if (this.mode === "visual") {
-      this.updateNarrowedState()
       this.vimState.updatePreviousSelection()
     } else {
-      // Prevent swrap from loaded on initial mode-setup on startup.
       if (this.vimState.__swrap) this.vimState.swrap.clearProperties(this.editor)
     }
 
@@ -84,18 +82,6 @@ module.exports = class ModeManager {
 
     this.emitter.emit("did-activate-mode", {mode: this.mode, submode: this.submode})
     this.vimState.ignoreSelectionChange = false
-  }
-
-  deactivate() {
-    if (!this.deactivator || this.deactivator.disposed) return
-
-    this.emitter.emit("will-deactivate-mode", {mode: this.mode, submode: this.submode})
-
-    this.deactivator.dispose()
-    // Remove css class here in-case this.deactivate() called solely(occurrence in visual-mode)
-    this.editorElement.classList.remove(`${this.mode}-mode`)
-    this.editorElement.classList.remove(this.submode)
-    this.emitter.emit("did-deactivate-mode", {mode: this.mode, submode: this.submode})
   }
 
   // Normal
@@ -118,28 +104,6 @@ module.exports = class ModeManager {
         if (goalColumn != null) cursor.goalColumn = goalColumn
       }
     }
-    return new Disposable()
-  }
-
-  // Operator Pending
-  // -------------------------
-  activateOperatorPendingMode() {
-    return new Disposable()
-  }
-
-  // Insert
-  // -------------------------
-  activateInsertMode(submode = null) {
-    this.editorElement.component.setInputEnabled(true)
-    return new Disposable(() => {
-      if (!moveCursorLeft) moveCursorLeft = require("./utils").moveCursorLeft
-
-      // When escape from insert-mode, cursor move Left.
-      const preventIncorrectWrap = this.editor.hasAtomicSoftTabs()
-      for (const cursor of this.editor.getCursors()) {
-        moveCursorLeft(cursor, {preventIncorrectWrap})
-      }
-    })
   }
 
   // Visual
@@ -173,24 +137,16 @@ module.exports = class ModeManager {
       for (const selection of this.editor.getSelections()) {
         selection.clear({autoscroll: false})
       }
-      this.updateNarrowedState(false)
     })
   }
 
-  // Narrow to selection
+  // Narrowed selection
   // -------------------------
-  hasMultiLineSelection() {
-    if (this.isMode("visual", "blockwise")) {
-      // [FIXME] why I need null guard here
-      const blockwiseSelection = this.vimState.getLastBlockwiseSelection()
-      return !blockwiseSelection ? false : !blockwiseSelection.isSingleRow()
-    } else {
-      return !this.vimState.swrap(this.editor.getLastSelection()).isSingleRow()
-    }
-  }
-
-  updateNarrowedState(value) {
-    this.editorElement.classList.toggle("is-narrowed", value ? value : this.hasMultiLineSelection())
+  updateNarrowedState() {
+    const isSingleRowSelection = this.isMode("visual", "blockwise")
+      ? this.vimState.getLastBlockwiseSelection().isSingleRow()
+      : this.vimState.swrap(this.editor.getLastSelection()).isSingleRow()
+    this.editorElement.classList.toggle("is-narrowed", !isSingleRowSelection)
   }
 
   isNarrowed() {

--- a/lib/mode-manager.js
+++ b/lib/mode-manager.js
@@ -9,7 +9,6 @@ module.exports = class ModeManager {
 
     this.mode = "insert" // Bare atom is not modal editor, thus it's `insert` mode.
     this.submode = null
-    this.replacedCharsBySelection = null
 
     this.emitter = new Emitter()
     vimState.onDidDestroy(() => this.destroy())
@@ -131,15 +130,9 @@ module.exports = class ModeManager {
   // Insert
   // -------------------------
   activateInsertMode(submode = null) {
-    let replaceModeDeactivator
     this.editorElement.component.setInputEnabled(true)
-    if (submode === "replace") replaceModeDeactivator = this.activateReplaceMode()
-
     return new Disposable(() => {
       if (!moveCursorLeft) moveCursorLeft = require("./utils").moveCursorLeft
-
-      if (replaceModeDeactivator) replaceModeDeactivator.dispose()
-      replaceModeDeactivator = null
 
       // When escape from insert-mode, cursor move Left.
       const preventIncorrectWrap = this.editor.hasAtomicSoftTabs()
@@ -147,35 +140,6 @@ module.exports = class ModeManager {
         moveCursorLeft(cursor, {preventIncorrectWrap})
       }
     })
-  }
-
-  activateReplaceMode() {
-    this.replacedCharsBySelection = new WeakMap()
-    return new CompositeDisposable(
-      this.editor.onWillInsertText(({text = "", cancel}) => {
-        cancel()
-        this.editor.getSelections().forEach(selection => {
-          for (const char of text.split("")) {
-            if (char !== "\n" && !selection.cursor.isAtEndOfLine()) {
-              selection.selectRight()
-            }
-            if (!this.replacedCharsBySelection.has(selection)) {
-              this.replacedCharsBySelection.set(selection, [])
-            }
-            this.replacedCharsBySelection.get(selection).push(selection.getText())
-            selection.insertText(char)
-          }
-        })
-      }),
-      new Disposable(() => {
-        this.replacedCharsBySelection = null
-      })
-    )
-  }
-
-  getReplacedCharForSelection(selection) {
-    const chars = this.replacedCharsBySelection.get(selection)
-    if (chars) return chars.pop()
   }
 
   // Visual

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -312,7 +312,7 @@ class MoveUpToEdge extends Motion {
   isFirstRowOrLastRowAndEqualAfterClipped(point) {
     // In notmal-mode, cursor is NOT stoppable to EOL of non-blank row.
     // So explicitly guard to not answer it stoppable.
-    if (this.isMode("normal") && this.utils.pointIsAtEndOfLineAtNonEmptyRow(this.editor, point)) {
+    if (this.mode === "normal" && this.utils.pointIsAtEndOfLineAtNonEmptyRow(this.editor, point)) {
       return false
     }
 

--- a/lib/occurrence-manager.js
+++ b/lib/occurrence-manager.js
@@ -167,14 +167,13 @@ module.exports = class OccurrenceManager {
   //  - c(change): So that autocomplete+popup shows at original cursor position or near.
   //  - g U(upper-case): So that undo/redo can respect last cursor position.
   select(wise) {
-    const isVisualMode = this.vimState.mode === "visual"
     const closestRangeIndexByOriginalSelection = new Map()
     const rangesToSelect = []
     const markersSelected = []
     const {editor} = this.vimState
 
     for (const selection of editor.getSelections()) {
-      const markers = this.getMarkersIntersectsWithSelection(selection, isVisualMode)
+      const markers = this.getMarkersIntersectsWithSelection(selection, this.vimState.mode === "visual")
       if (!markers.length) continue
 
       const ranges = markers.map(marker => marker.getBufferRange())
@@ -198,10 +197,9 @@ module.exports = class OccurrenceManager {
     if (rangesToSelect.length) {
       const reversed = editor.getLastSelection().isReversed()
 
-      if (isVisualMode) {
-        // To avoid selected occurrence ruined by normalization when disposing current submode to shift to new submode.
-        this.vimState.modeManager.deactivate()
-        this.vimState.submode = null
+      // To avoid selected occurrence ruined by normalization when deactivating blockwise
+      if (this.vimState.isMode("visual", "blockwise")) {
+        this.vimState.modeManager.activate("visual", "characterwise")
       }
 
       editor.setSelectedBufferRanges(rangesToSelect, {reversed})

--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -1,6 +1,5 @@
 "use babel"
 
-const _ = require("underscore-plus")
 const {Range} = require("atom")
 const Operator = require("./base").getClass("Operator")
 
@@ -13,41 +12,6 @@ class ActivateInsertModeBase extends Operator {
   flashTarget = false
   finalSubmode = null
   supportInsertionCount = true
-
-  observeWillDeactivateMode() {
-    const disposable = this.vimState.modeManager.preemptWillDeactivateMode(({mode}) => {
-      if (mode !== "insert") return
-      disposable.dispose()
-
-      this.vimState.mark.set("^", this.editor.getCursorBufferPosition()) // Last insert-mode position
-      let textByUserInput = ""
-      const change = this.getChangeSinceCheckpoint("insert")
-      if (change) {
-        this.lastChange = change
-        this.setMarkForChange(new Range(change.start, change.start.traverse(change.newExtent)))
-        textByUserInput = change.newText
-      }
-      this.vimState.register.set(".", {text: textByUserInput}) // Last inserted text
-
-      _.times(this.getInsertionCount(), () => {
-        const textToInsert = this.textByOperator + textByUserInput
-        for (const selection of this.editor.getSelections()) {
-          selection.insertText(textToInsert, {autoIndent: true})
-        }
-      })
-
-      // This cursor state is restored on undo.
-      // So cursor state has to be updated before next groupChangesSinceCheckpoint()
-      if (this.getConfig("clearMultipleCursorsOnEscapeInsertMode")) {
-        this.vimState.clearSelections()
-      }
-
-      // grouping changes for undo checkpoint need to come last
-      if (this.getConfig("groupChangesWhenLeavingInsertMode")) {
-        this.groupChangesSinceBufferCheckpoint("undo")
-      }
-    })
-  }
 
   // When each mutaion's extent is not intersecting, muitiple changes are recorded
   // e.g
@@ -90,21 +54,12 @@ class ActivateInsertModeBase extends Operator {
     this.replayLastChange(selection)
   }
 
-  getInsertionCount() {
-    if (this.insertionCount == null) {
-      this.insertionCount = this.supportInsertionCount ? this.getCount(-1) : 0
-    }
-    // Avoid freezing by acccidental big count(e.g. `5555555555555i`), See #560, #596
-    return this.utils.limitNumber(this.insertionCount, {max: 100})
-  }
-
   execute() {
     if (this.repeated) this.flashTarget = this.trackChange = true
 
     this.preSelect()
 
-    if (this.selectTarget() || this.target.wise !== 'linewise') {
-      if (!this.repeated) this.observeWillDeactivateMode()
+    if (this.selectTarget() || this.target.wise !== "linewise") {
       if (this.mutateText) this.mutateText()
 
       if (this.repeated) {
@@ -118,9 +73,13 @@ class ActivateInsertModeBase extends Operator {
         this.emitDidFinishMutation()
         if (this.getConfig("clearMultipleCursorsOnEscapeInsertMode")) this.vimState.clearSelections()
       } else {
-        if (this.getInsertionCount() > 0) {
+        // Avoid freezing by acccidental big count(e.g. `5555555555555i`), See #560, #596
+        let insertionCount = this.supportInsertionCount ? this.utils.limitNumber(this.getCount(-1), {max: 100}) : 0
+
+        let textByOperator = ""
+        if (insertionCount > 0) {
           const change = this.getChangeSinceCheckpoint("undo")
-          this.textByOperator = (change && change.newText) || ""
+          textByOperator = (change && change.newText) || ""
         }
 
         this.createBufferCheckpoint("insert")
@@ -132,12 +91,39 @@ class ActivateInsertModeBase extends Operator {
         for (const blockwiseSelection of this.getBlockwiseSelections()) {
           blockwiseSelection.skipNormalization()
         }
+
+        const disposable = this.vimState.modeManager.preemptWillDeactivateMode(({mode}) => {
+          if (mode !== "insert") return
+          disposable.dispose()
+
+          this.vimState.mark.set("^", this.editor.getCursorBufferPosition()) // Last insert-mode position
+          let textByUserInput = ""
+          const change = this.getChangeSinceCheckpoint("insert")
+          if (change) {
+            this.lastChange = change
+            this.setMarkForChange(new Range(change.start, change.start.traverse(change.newExtent)))
+            textByUserInput = change.newText
+          }
+          this.vimState.register.set(".", {text: textByUserInput}) // Last inserted text
+
+          while (insertionCount) {
+            insertionCount--
+            for (const selection of this.editor.getSelections()) {
+              selection.insertText(textByOperator + textByUserInput, {autoIndent: true})
+            }
+          }
+
+          // This cursor state is restored on undo.
+          // So cursor state has to be updated before next groupChangesSinceCheckpoint()
+          if (this.getConfig("clearMultipleCursorsOnEscapeInsertMode")) this.vimState.clearSelections()
+
+          // grouping changes for undo checkpoint need to come last
+          if (this.getConfig("groupChangesWhenLeavingInsertMode")) this.groupChangesSinceBufferCheckpoint("undo")
+        })
         this.activateMode("insert", this.finalSubmode)
       }
     } else {
-      if (!this.repeated) {
-        this.activateMode("normal")
-      }
+      this.activateMode("normal")
     }
   }
 }

--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -10,7 +10,6 @@ const Operator = require("./base").getClass("Operator")
 class ActivateInsertModeBase extends Operator {
   static hiddenCommand = false
   flashTarget = false
-  finalSubmode = null
   supportInsertionCount = true
 
   // When each mutaion's extent is not intersecting, muitiple changes are recorded
@@ -120,7 +119,8 @@ class ActivateInsertModeBase extends Operator {
           // grouping changes for undo checkpoint need to come last
           if (this.getConfig("groupChangesWhenLeavingInsertMode")) this.groupChangesSinceBufferCheckpoint("undo")
         })
-        this.activateMode("insert", this.finalSubmode)
+        const submode = this.name === "ActivateReplaceMode" ? "replace" : undefined
+        this.activateMode("insert", submode)
       }
     } else {
       this.activateMode("normal")
@@ -137,7 +137,41 @@ class ActivateInsertMode extends ActivateInsertModeBase {
 ActivateInsertMode.register()
 
 class ActivateReplaceMode extends ActivateInsertMode {
-  finalSubmode = "replace"
+  initialize() {
+    const replacedCharsBySelection = new WeakMap()
+
+    const onWillInsertDisposable = this.editor.onWillInsertText(({text = "", cancel}) => {
+      cancel()
+      for (const selection of this.editor.getSelections()) {
+        for (const char of text.split("")) {
+          if (char !== "\n" && !selection.cursor.isAtEndOfLine()) selection.selectRight()
+          if (!replacedCharsBySelection.has(selection)) replacedCharsBySelection.set(selection, [])
+          replacedCharsBySelection.get(selection).push(selection.getText())
+          selection.insertText(char)
+        }
+      }
+    })
+
+    const overrideCoreBackSpaceDisposable = atom.commands.add(this.editorElement, "core:backspace", event => {
+      event.stopImmediatePropagation()
+      for (const selection of this.editor.getSelections()) {
+        const chars = replacedCharsBySelection.get(selection)
+        if (chars && chars.length) {
+          selection.selectLeft()
+          if (!selection.insertText(chars.pop()).isEmpty()) selection.cursor.moveLeft()
+        }
+      }
+    })
+
+    const disposable = this.vimState.modeManager.preemptWillDeactivateMode(({mode}) => {
+      if (mode !== "insert") return
+      disposable.dispose()
+      onWillInsertDisposable.dispose()
+      overrideCoreBackSpaceDisposable.dispose()
+    })
+
+    super.initialize()
+  }
 
   repeatInsert(selection, text) {
     for (const char of text) {
@@ -187,8 +221,9 @@ InsertAfterEndOfLine.register()
 // key: normal 'I'
 class InsertAtFirstCharacterOfLine extends ActivateInsertMode {
   execute() {
-    this.editor.moveToBeginningOfLine()
-    this.editor.moveToFirstCharacterOfLine()
+    for (const cursor of this.editor.getCursors()) {
+      this.utils.moveCursorToFirstCharacterAtRow(cursor, cursor.getBufferRow())
+    }
     super.execute()
   }
 }

--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -118,6 +118,11 @@ class ActivateInsertModeBase extends Operator {
 
           // grouping changes for undo checkpoint need to come last
           if (this.getConfig("groupChangesWhenLeavingInsertMode")) this.groupChangesSinceBufferCheckpoint("undo")
+
+          const preventIncorrectWrap = this.editor.hasAtomicSoftTabs()
+          for (const cursor of this.editor.getCursors()) {
+            this.utils.moveCursorLeft(cursor, {preventIncorrectWrap})
+          }
         })
         const submode = this.name === "ActivateReplaceMode" ? "replace" : undefined
         this.activateMode("insert", submode)

--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -9,6 +9,7 @@ const Operator = require("./base").getClass("Operator")
 // [NOTE]
 // Rule: Don't make any text mutation before calling `@selectTarget()`.
 class ActivateInsertModeBase extends Operator {
+  static hiddenCommand = false
   flashTarget = false
   finalSubmode = null
   supportInsertionCount = true
@@ -98,44 +99,45 @@ class ActivateInsertModeBase extends Operator {
   }
 
   execute() {
-    if (this.repeated) {
-      this.flashTarget = this.trackChange = true
+    if (this.repeated) this.flashTarget = this.trackChange = true
 
-      this.startMutation(() => {
-        if (this.target) this.selectTarget()
-        if (this.mutateText) this.mutateText()
+    this.preSelect()
 
+    if (this.selectTarget() || this.target.wise !== 'linewise') {
+      if (!this.repeated) this.observeWillDeactivateMode()
+      if (this.mutateText) this.mutateText()
+
+      if (this.repeated) {
         for (const selection of this.editor.getSelections()) {
           const textToInsert = (this.lastChange && this.lastChange.newText) || ""
           this.repeatInsert(selection, textToInsert)
           this.utils.moveCursorLeft(selection.cursor)
         }
         this.mutationManager.setCheckpoint("did-finish")
-      })
+        this.groupChangesSinceBufferCheckpoint("undo")
+        this.emitDidFinishMutation()
+        if (this.getConfig("clearMultipleCursorsOnEscapeInsertMode")) this.vimState.clearSelections()
+      } else {
+        if (this.getInsertionCount() > 0) {
+          const change = this.getChangeSinceCheckpoint("undo")
+          this.textByOperator = (change && change.newText) || ""
+        }
 
-      if (this.getConfig("clearMultipleCursorsOnEscapeInsertMode")) this.vimState.clearSelections()
+        this.createBufferCheckpoint("insert")
+        const topCursor = this.editor.getCursorsOrderedByBufferPosition()[0]
+        this.topCursorPositionAtInsertionStart = topCursor.getBufferPosition()
+
+        // Skip normalization of blockwiseSelection.
+        // Since want to keep multi-cursor and it's position in when shift to insert-mode.
+        for (const blockwiseSelection of this.getBlockwiseSelections()) {
+          blockwiseSelection.skipNormalization()
+        }
+        this.activateMode("insert", this.finalSubmode)
+      }
     } else {
-      this.normalizeSelectionsIfNecessary()
-      this.createBufferCheckpoint("undo")
-      this.selectTarget()
-      this.observeWillDeactivateMode()
-      if (this.mutateText) this.mutateText()
-
-      if (this.getInsertionCount() > 0) {
-        const change = this.getChangeSinceCheckpoint("undo")
-        this.textByOperator = (change && change.newText) || ""
+      if (!this.repeated) {
+        this.activateMode("normal")
       }
-
-      this.createBufferCheckpoint("insert")
-      const topCursor = this.editor.getCursorsOrderedByBufferPosition()[0]
-      this.topCursorPositionAtInsertionStart = topCursor.getBufferPosition()
-
-      // Skip normalization of blockwiseSelection.
-      // Since want to keep multi-cursor and it's position in when shift to insert-mode.
-      for (const blockwiseSelection of this.getBlockwiseSelections()) {
-        blockwiseSelection.skipNormalization()
-      }
-      this.activateMode("insert", this.finalSubmode)
     }
   }
 }

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -15,6 +15,7 @@ class TransformString extends Operator {
   autoIndent = false
   autoIndentNewline = false
   autoIndentAfterInsertText = false
+  static hiddenCommand = false
 
   static registerToSelectList() {
     this.stringTransformers.push(this)
@@ -356,8 +357,7 @@ class TransformStringByExternalCommand extends TransformString {
   }
 
   async execute() {
-    this.normalizeSelectionsIfNecessary()
-    this.createBufferCheckpoint("undo")
+    this.preSelect()
 
     if (this.selectTarget()) {
       for (const selection of this.editor.getSelections()) {
@@ -369,10 +369,8 @@ class TransformStringByExternalCommand extends TransformString {
       }
       this.mutationManager.setCheckpoint("did-finish")
       this.restoreCursorPositionsIfNecessary()
-      this.groupChangesSinceBufferCheckpoint("undo")
     }
-    this.emitDidFinishMutation()
-    this.activateMode("normal")
+    this.postMutate()
   }
 
   runExternalCommand(options) {

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -84,7 +84,7 @@ LowerCase.register()
 class Replace extends TransformString {
   flashCheckpoint = "did-select-occurrence"
   autoIndentNewline = true
-  readInputAfterExecute = true
+  readInputAfterSelect = true
 
   getNewText(text) {
     if (this.target.name === "MoveRightBufferColumn" && text.length !== this.getCount()) {
@@ -610,7 +610,7 @@ SurroundBase.register(false)
 
 class Surround extends SurroundBase {
   surroundAction = "surround"
-  readInputAfterExecute = true
+  readInputAfterSelect = true
 }
 Surround.register()
 
@@ -662,13 +662,13 @@ DeleteSurroundAnyPairAllowForwarding.register()
 // -------------------------
 class ChangeSurround extends DeleteSurround {
   surroundAction = "change-surround"
-  readInputAfterExecute = true
+  readInputAfterSelect = true
 
   // Override to show changing char on hover
-  async focusInputPromisified(...args) {
+  async focusInputPromised(...args) {
     const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
     this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
-    return super.focusInputPromisified(...args)
+    return super.focusInputPromised(...args)
   }
 }
 ChangeSurround.register()
@@ -732,7 +732,7 @@ class JoinWithKeepingSpace extends JoinBase {
 JoinWithKeepingSpace.register()
 
 class JoinByInput extends JoinBase {
-  readInputAfterExecute = true
+  readInputAfterSelect = true
   focusInputOptions = {charsMax: 10}
   trim = true
 }
@@ -748,7 +748,7 @@ JoinByInputWithKeepingSpace.register()
 class SplitString extends TransformString {
   target = "MoveToRelativeLine"
   keepSplitter = false
-  readInputAfterExecute = true
+  readInputAfterSelect = true
   focusInputOptions = {charsMax: 10}
 
   getNewText(text) {

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -451,7 +451,7 @@ CreatePersistentSelection.register()
 
 class TogglePersistentSelection extends CreatePersistentSelection {
   initialize() {
-    if (this.isMode("normal")) {
+    if (this.mode === "normal") {
       const point = this.editor.getCursorBufferPosition()
       const marker = this.persistentSelection.getMarkerAtPoint(point)
       if (marker) this.target = "Empty"

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -32,7 +32,7 @@ class Operator extends Base {
 
   targetSelected = null
   input = null
-  readInputAfterExecute = false
+  readInputAfterSelect = false
   bufferCheckpointByPurpose = {}
 
   isReady() {
@@ -256,12 +256,6 @@ class Operator extends Base {
     }
   }
 
-  startMutation(fn) {
-    this.normalizeSelectionsIfNecessary()
-    this.editor.transact(fn)
-    this.emitDidFinishMutation()
-  }
-
   mutateSelections() {
     for (const selection of this.editor.getSelectionsOrderedByBufferPosition()) {
       this.mutateSelection(selection)
@@ -270,29 +264,36 @@ class Operator extends Base {
     this.restoreCursorPositionsIfNecessary()
   }
 
-  // Main
-  execute() {
-    if (this.readInputAfterExecute && !this.repeated) {
-      return this.executeAsyncToReadInputAfterExecute()
-    }
+  preSelect() {
+    this.normalizeSelectionsIfNecessary()
+    this.createBufferCheckpoint("undo")
+  }
 
-    this.startMutation(() => {
-      if (this.selectTarget()) this.mutateSelections()
-    })
+  postMutate() {
+    this.groupChangesSinceBufferCheckpoint("undo")
+    this.emitDidFinishMutation()
 
     // Even though we fail to select target and fail to mutate,
     // we have to return to normal-mode from operator-pending or visual
     this.activateMode("normal")
   }
 
-  async executeAsyncToReadInputAfterExecute() {
-    this.normalizeSelectionsIfNecessary()
-    this.createBufferCheckpoint("undo")
+  // Main
+  execute() {
+    this.preSelect()
 
+    if (this.readInputAfterSelect && !this.repeated) {
+      return this.executeAsyncToReadInputAfterSelect()
+    }
+
+    if (this.selectTarget()) this.mutateSelections()
+    this.postMutate()
+  }
+
+  async executeAsyncToReadInputAfterSelect() {
     if (this.selectTarget()) {
-      try {
-        this.input = await this.focusInputPromisified(this.focusInputOptions)
-      } catch (e) {
+      this.input = await this.focusInputPromised(this.focusInputOptions)
+      if (this.input == null) {
         if (this.mode !== "visual") {
           this.editor.revertToCheckpoint(this.getBufferCheckpoint("undo"))
           this.activateMode("normal")
@@ -300,11 +301,8 @@ class Operator extends Base {
         return
       }
       this.mutateSelections()
-      this.groupChangesSinceBufferCheckpoint("undo")
     }
-
-    this.emitDidFinishMutation()
-    this.activateMode("normal")
+    this.postMutate()
   }
 
   // Return true unless all selection is empty.
@@ -375,7 +373,9 @@ class SelectBase extends Operator {
   recordable = false
 
   execute() {
-    this.startMutation(() => this.selectTarget())
+    // this.startMutation(() => this.selectTarget())
+    this.normalizeSelectionsIfNecessary()
+    this.selectTarget()
 
     if (this.target.selectSucceeded) {
       if (this.target.isTextObject()) {

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -373,7 +373,6 @@ class SelectBase extends Operator {
   recordable = false
 
   execute() {
-    // this.startMutation(() => this.selectTarget())
     this.normalizeSelectionsIfNecessary()
     this.selectTarget()
 

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -470,13 +470,13 @@ describe "Motion general", ->
         beforeEach -> set cursor: [0, 0]
         it "delete by dk", -> ensure "d k", text: originalText, mode: 'normal'
         it "yank by yk", ->   ensure "y k", text: originalText, register: {'"': text: undefined}, mode: 'normal'
-        it "change by ck", -> ensure "c k", textC: "|000\n111\n222\n", register: {'"': text: "\n"}, mode: 'insert' # FIXME, incompatible: shoud remain in normal.
+        it "change by ck", -> ensure "c k", textC: "|000\n111\n222\n", register: {'"': text: undefined}, mode: 'normal'
 
       describe "when it can not move-down", ->
         beforeEach -> set cursor: [2, 0]
         it "delete by dj", -> ensure "d j", text: originalText, mode: 'normal'
         it "yank by yj", ->   ensure "y j", text: originalText, register: {'"': text: undefined}, mode: 'normal'
-        it "change by cj", -> ensure "c j", textC: "000\n111\n|222\n", register: {'"': text: "\n"}, mode: 'insert' # FIXME, incompatible: shoud remain in normal.
+        it "change by cj", -> ensure "c j", textC: "000\n111\n|222\n", register: {'"': text: undefined}, mode: 'normal'
 
     describe "moveSuccessOnLinewise=true motion", ->
       describe "when it can move", ->

--- a/spec/operator-activate-insert-mode-spec.coffee
+++ b/spec/operator-activate-insert-mode-spec.coffee
@@ -823,13 +823,12 @@ describe "Operator ActivateInsertMode family", ->
         cursor: [0, 5]
 
   describe 'preserve inserted text', ->
-    ensureDotRegister = null
-    beforeEach ->
-      ensureDotRegister = (key, {text}) ->
-        ensure key, mode: 'insert'
-        editor.insertText(text)
-        ensure "escape", register: '.': text: text
+    ensureDotRegister = (key, {text}) ->
+      ensure key, mode: 'insert'
+      editor.insertText(text)
+      ensure "escape", register: '.': text: text
 
+    beforeEach ->
       set
         text: "\n\n"
         cursor: [0, 0]

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -1262,8 +1262,7 @@ describe "Operator general", ->
         mode: 'normal'
 
     it "continues beyond end of line as insert", ->
-      ensure 'R',
-        mode: ['insert', 'replace']
+      ensure 'R', mode: ['insert', 'replace']
       editor.insertText "abcde"
       ensure 'escape', text: '12abcde\n67890'
 
@@ -1274,16 +1273,18 @@ describe "Operator general", ->
       editor.insertText "b"
       ensure null, text: "12fooab5\n67890"
 
-      ensure 'backspace', text: "12fooa45\n67890"
+      dispatch(editorElement, 'core:backspace')
+      ensure null, text: "12fooa45\n67890"
+
       editor.insertText "c"
       ensure null, text: "12fooac5\n67890"
-      ensure 'backspace backspace',
-        text: "12foo345\n67890"
-        selectedText: ''
 
-      ensure 'backspace',
-        text: "12foo345\n67890"
-        selectedText: ''
+      dispatch(editor.element, 'core:backspace')
+      dispatch(editor.element, 'core:backspace')
+      ensure null, text: "12foo345\n67890", selectedText: ''
+
+      dispatch(editor.element, 'core:backspace')
+      ensure null, text: "12foo345\n67890", selectedText: ''
 
     it "can be repeated", ->
       ensure 'R'
@@ -1300,7 +1301,7 @@ describe "Operator general", ->
     it "repeats correctly when backspace was used in the text", ->
       ensure 'R'
       editor.insertText "a"
-      ensure 'backspace'
+      dispatch(editor.element, 'core:backspace')
       editor.insertText "b"
       ensure 'escape'
       set cursor: [1, 2]
@@ -1343,7 +1344,9 @@ describe "Operator general", ->
             56789
             """
           cursor: [2, 1]
-        ensure 'backspace',
+
+        dispatch(editor.element, 'core:backspace')
+        ensure null,
           text: """
             0a
             b
@@ -1351,38 +1354,49 @@ describe "Operator general", ->
             56789
             """
           cursor: [2, 0]
-        ensure 'backspace',
+
+        dispatch(editor.element, 'core:backspace')
+        ensure null,
           text: """
             0a
             b34
             56789
             """
           cursor: [1, 1]
-        ensure 'backspace',
+
+        dispatch(editor.element, 'core:backspace')
+        ensure null,
           text: """
             0a
             234
             56789
             """
           cursor: [1, 0]
-        ensure 'backspace',
+
+        dispatch(editor.element, 'core:backspace')
+        ensure null,
           text: """
             0a234
             56789
             """
           cursor: [0, 2]
-        ensure 'backspace',
+
+        dispatch(editor.element, 'core:backspace')
+        ensure null,
           text: """
             01234
             56789
             """
           cursor: [0, 1]
-        ensure 'backspace', # do nothing
+
+        dispatch(editor.element, 'core:backspace') # do nothing
+        ensure null,
           text: """
             01234
             56789
             """
           cursor: [0, 1]
+
         ensure 'escape',
           text: """
             01234


### PR DESCRIPTION
Changes in this PR

- Remove `replace-mode-backspace` command
  - This was mapped from `backspace` in `insert.replace` mode.
  - But now achieve same functionality by overriding `core:backspace`.
  - So, this intermediate command is no longer necessary.
- Base.prototype.focusInputPromised now resolve `undefined` when canceled.
  - Previously reject promise on `canceled`.
- Unhide all operator command.
- ModeManager cleanup
  - No longer expose `deactivate()` since `occurrenceManager` no longer call this.
  - Most of task required for `insert-mode` is moded to `ActivateInsertMode` operation class.
- Operator cleanup
  - Rename `readInputAfterExecute` to `readInputAfterSelect`
  - Remove `startMutation`.
    - Breaks into `preSelect()` and `postSelect()` for more controllability
    - All operator handle checkpoint manually, no longer use `editor.transact`
