### PR TITLE
Improve word motion, make it independent from Atom's native cursor motion.

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -385,6 +385,7 @@ class Base {
   getBufferRangeForRowRange(rowRange) { return this.utils.getBufferRangeForRowRange(this.editor, rowRange) } // prettier-ignore
   scanForward(...args) { return this.utils.scanEditor(this.editor, "forward", ...args) } // prettier-ignore
   scanBackward(...args) { return this.utils.scanEditor(this.editor, "backward", ...args) } // prettier-ignore
+  findWord(...args) { return this.utils.findWord(this.editor, ...args) } // prettier-ignore
   getFoldStartRowForRow(...args) { return this.utils.getFoldStartRowForRow(this.editor, ...args) } // prettier-ignore
   getFoldEndRowForRow(...args) { return this.utils.getFoldEndRowForRow(this.editor, ...args) } // prettier-ignore
   getBufferRows(...args) { return this.utils.getRows(this.editor, "buffer", ...args) } // prettier-ignore

--- a/lib/base.js
+++ b/lib/base.js
@@ -386,6 +386,7 @@ class Base {
   scanForward(...args) { return this.utils.scanEditor(this.editor, "forward", ...args) } // prettier-ignore
   scanBackward(...args) { return this.utils.scanEditor(this.editor, "backward", ...args) } // prettier-ignore
   findWord(...args) { return this.utils.findWord(this.editor, ...args) } // prettier-ignore
+  isEmptyRow(...args) { return this.utils.isEmptyRow(this.editor, ...args) } // prettier-ignore
   getFoldStartRowForRow(...args) { return this.utils.getFoldStartRowForRow(this.editor, ...args) } // prettier-ignore
   getFoldEndRowForRow(...args) { return this.utils.getFoldEndRowForRow(this.editor, ...args) } // prettier-ignore
   getBufferRows(...args) { return this.utils.getRows(this.editor, "buffer", ...args) } // prettier-ignore

--- a/lib/base.js
+++ b/lib/base.js
@@ -235,10 +235,7 @@ class Base {
     for (const file of filesToLoad) {
       for (const klass of Object.values(require(file))) {
         klass.file = file
-        if (klass.name in CLASS_REGISTRY) {
-          console.warn(`Duplicate constructor ${klass.name}`)
-        }
-        CLASS_REGISTRY[klass.name] = klass
+        klass.register()
         const isCommand = klass.hasOwnProperty("command") ? klass.command : true
         if (isCommand) {
           commandTable[klass.name] = {file, commandName: klass.getCommandName(), commandScope: klass.commandScope}
@@ -267,9 +264,7 @@ class Base {
       }
       const spec = this.commandTable[name]
       const file = typeof spec === "string" ? spec : spec.file
-      Object.values(require(file)).forEach(klass => {
-        CLASS_REGISTRY[klass.name] = klass
-      })
+      Object.values(require(file)).forEach(klass => klass.register())
     }
     if (name in CLASS_REGISTRY) return CLASS_REGISTRY[name]
     throw new Error(`class '${name}' not found`)
@@ -281,6 +276,15 @@ class Base {
     if (properties) Object.assign(object, properties)
     object.initialize()
     return object
+  }
+
+  // Dont remove this. Public API to register operations to CLASS_REGISTRY
+  // This can be used from vmp-plugin such as vmp-ex-mode.
+  static register() {
+    if (this.name in CLASS_REGISTRY) {
+      console.warn(`Duplicate constructor ${this.name}`)
+    }
+    CLASS_REGISTRY[this.name] = this
   }
 
   static getClassRegistry() {

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -429,10 +429,24 @@ class MoveToNextAlphanumericWord extends MoveToNextWord {
 class MoveToPreviousWord extends WordMotion {
   moveCursor(cursor) {
     this.moveCursorCountTimes(cursor, () => {
-      const wordRegex = this.getWordRegex(cursor)
-      const point = cursor.getBeginningOfCurrentWordBufferPosition({wordRegex})
-      cursor.setBufferPosition(point)
+      cursor.setBufferPosition(this.findPreviousWord(cursor))
     })
+  }
+
+  findPreviousWord(cursor) {
+    const from = cursor.getBufferPosition()
+
+    let foundPoint
+    this.scanBackward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
+      // vim compatibility, skip non empty whilte-space only row.
+      if (matchText && !/\S+/.test(matchText)) return
+
+      if (range.start.isLessThan(from)) {
+        foundPoint = range.start
+        stop()
+      }
+    })
+    return foundPoint || [0, 0]
   }
 }
 
@@ -454,30 +468,52 @@ class MoveToPreviousAlphanumericWord extends MoveToPreviousWord {
   wordRegex = /\w+/
 }
 
-
 // Next EndOfWord
 //--------------------------------------
 // e
 class MoveToEndOfWord extends WordMotion {
   inclusive = true
-
-  moveToNextEndOfWord(cursor) {
-    this.utils.moveCursorToNextNonWhitespace(cursor)
-    const wordRegex = this.getWordRegex(cursor)
-    const point = cursor.getEndOfCurrentWordBufferPosition({wordRegex}).translate([0, -1])
-    cursor.setBufferPosition(Point.min(point, this.getVimEofBufferPosition()))
-  }
+  direction = "next"
 
   moveCursor(cursor) {
     this.moveCursorCountTimes(cursor, () => {
-      const originalPoint = cursor.getBufferPosition()
-      this.moveToNextEndOfWord(cursor)
-      if (originalPoint.isEqual(cursor.getBufferPosition())) {
-        // Retry from right column if cursor was already on EndOfWord
-        cursor.moveRight()
-        this.moveToNextEndOfWord(cursor)
+      const point = this.direction === "next" ? this.findNextEndOfWord(cursor) : this.findPreviousEndOfWord(cursor)
+      cursor.setBufferPosition(point)
+    })
+  }
+
+  findNextEndOfWord(cursor) {
+    const from = this.editor.clipBufferPosition(cursor.getBufferPosition().translate([0, +1]))
+
+    let foundPoint
+    this.scanForward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
+      // Skip empty or whilte-space only row
+      if (!matchText || !/\S+/.test(matchText)) return
+
+      if (range.end.isGreaterThan(from)) {
+        foundPoint = range.end.translate([0, -1])
+        stop()
       }
     })
+    return foundPoint || this.getVimEofBufferPosition()
+  }
+
+  findPreviousEndOfWord(cursor) {
+    // find from one column right position to contain char under cursor.
+    // Unless that, we cannot distinguish when left column is real end of word.
+    const from = this.editor.clipBufferPosition(cursor.getBufferPosition().translate([0, +1]))
+
+    let foundPoint
+    this.scanBackward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
+      // vim compatibility, skip non empty whilte-space only row.
+      if (matchText && !/\S+/.test(matchText)) return
+
+      if (range.end.isLessThan(from)) {
+        foundPoint = range.end.translate([0, -1])
+        stop()
+      }
+    })
+    return foundPoint || [0, 0]
   }
 }
 
@@ -502,30 +538,9 @@ class MoveToEndOfAlphanumericWord extends MoveToEndOfWord {
 // Previous EndOfWord
 //--------------------------------------
 // ge
-class MoveToPreviousEndOfWord extends WordMotion {
+class MoveToPreviousEndOfWord extends MoveToEndOfWord {
   inclusive = true
-  moveCursor(cursor) {
-    this.moveCursorCountTimes(cursor, () => {
-      cursor.setBufferPosition(this.findPreviousEndOfWord(cursor))
-    })
-  }
-
-  findPreviousEndOfWord(cursor) {
-    // find from one column right position to contain char under cursor.
-    const from = this.editor.clipBufferPosition(cursor.getBufferPosition().translate([0, +1]))
-
-    let foundPoint
-    this.scanBackward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
-      // vim compatibility, skip non empty whilte-space only row.
-      if (matchText && !/\S+/.test(matchText)) return
-
-      if (range.end.isLessThan(from)) {
-        foundPoint = range.end.translate([0, -1])
-        stop()
-      }
-    })
-    return foundPoint || [0, 0]
-  }
+  direction = "previous"
 }
 
 // gE

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -356,10 +356,10 @@ class WordMotion extends Motion {
     if (this.moveTo === "next-start") {
       if (this.operator && this.operator.name === "Change") {
         if (!this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)) {
-          point = this.findWordByType("next-end", {from: cursorPosition, regex})
+          point = this.findWord("next", "end", {from: cursorPosition, regex})
         } else {
           // console.log('2');
-          point = this.findWordByType("next-start", {from: cursorPosition, regex})
+          point = this.findWord("next", "start", {from: cursorPosition, regex})
           // console.log({isFinal});
           if (isFinal && point.row !== cursorPosition.row) {
             // console.log(point.toString(), cursorPosition.toString());
@@ -369,31 +369,33 @@ class WordMotion extends Motion {
         }
       } else {
         // console.log('3');
-        point = this.findWordByType("next-start", {from: cursorPosition, regex})
+        point = this.findWord("next", "start", {from: cursorPosition, regex})
       }
       point = point || this.getVimEofBufferPosition()
     } else if (this.moveTo === "previous-start") {
       const options = {from: cursorPosition, regex, skipWhiteSpaceOnlyRow: true}
-      point = this.findWordByType(this.moveTo, options) || [0, 0]
+      point = this.findWord("previous", "start", options) || [0, 0]
     } else if (this.moveTo === "next-end") {
       const options = {from: cursorPosition.translate([0, +1]), regex, skipBlankRow: true, skipWhiteSpaceOnlyRow: true}
-      point = this.findWordByType(this.moveTo, options)
+      point = this.findWord("next", "end", options)
       point = point ? point.translate([0, -1]) : this.getVimEofBufferPosition()
     } else if (this.moveTo === "previous-end") {
       // find from one column right position to contain char under cursor.
       // Unless that, we cannot distinguish when left column is real end of word.
       const options = {from: cursorPosition.translate([0, +1]), regex, skipWhiteSpaceOnlyRow: true}
-      point = this.findWordByType(this.moveTo, options)
+      point = this.findWord("previous", "end", options)
       point = point ? point.translate([0, -1]) : [0, 0]
     }
     cursor.setBufferPosition(point)
   }
 
-  findWord(direction, options = {}, fn) {
+  findWord(direction, which, options = {}, fn) {
+    const compareMethod = direction === "next" ? "isGreaterThan" : "isLessThan"
+    const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
+
     const {regex, skipBlankRow, skipWhiteSpaceOnlyRow} = options
     const from = this.editor.clipBufferPosition(options.from)
     let found
-    const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
     this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
@@ -401,31 +403,13 @@ class WordMotion extends Motion {
       if (options.skipBlankRow && !matchText) return
       if (options.skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
 
-      const result = fn({matchText, range, from})
-      if (result) {
-        found = result
+      const pointToCompare = range[which]
+      if (pointToCompare[compareMethod](from)) {
+        found = pointToCompare
         stop()
       }
     })
     return found
-  }
-
-  findWordByType(type, options) {
-    let direction
-    if (type === "next-start") {
-      direction = "next"
-      fn = ({range, from}) => range.start.isGreaterThan(from) && range.start
-    } else if (type === "previous-start") {
-      direction = "previous"
-      fn = ({range, from}) => range.start.isLessThan(from) && range.start
-    } else if (type === "next-end") {
-      direction = "next"
-      fn = ({range, from}) => range.end.isGreaterThan(from) && range.end
-    } else if (type === "previous-end") {
-      direction = "previous"
-      fn = ({range, from}) => range.end.isLessThan(from) && range.end
-    }
-    return this.findWord(direction, options, fn)
   }
 }
 

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -333,6 +333,7 @@ class MoveDownToEdge extends MoveUpToEdge {
 class WordMotion extends Motion {
   static command = false
   wordRegex = null
+
   getWordRegex(cursor) {
     if (this.name.endsWith("Subword")) {
       return cursor.subwordRegExp()
@@ -340,10 +341,138 @@ class WordMotion extends Motion {
       return this.wordRegex || cursor.wordRegExp()
     }
   }
+
+  moveCursor(cursor) {
+    this.moveCursorCountTimes(cursor, state => this.moveByWord(cursor, state))
+  }
+
+  // ONLY TWO ERROR for w and W
+
+  moveByWord(cursor, {isFinal}) {
+    const regex = this.getWordRegex(cursor)
+    const cursorPosition = cursor.getBufferPosition()
+    let point
+
+    if (this.moveTo === "next-start") {
+      if (this.operator && this.operator.name === "Change") {
+        if (!this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)) {
+          point = this.findNextEndOfWord(cursorPosition, regex)
+        } else {
+          // console.log('2');
+          point = this.findNextWord(cursorPosition, regex)
+          // console.log({isFinal});
+          if (isFinal && point.row !== cursorPosition.row) {
+            // console.log(point.toString(), cursorPosition.toString());
+            // console.log("OKK!!");
+            point = new Point(cursorPosition.row, Infinity)
+          }
+        }
+      } else {
+        // console.log('3');
+        point = this.findNextWord(cursorPosition, regex)
+      }
+      point = point || this.getVimEofBufferPosition()
+    } else if (this.moveTo === "previous-start") {
+      point = this.findPreviousStartOfWord(cursorPosition, regex) || [0, 0]
+    } else if (this.moveTo === "next-end") {
+      point = this.findNextEndOfWord(cursorPosition.translate([0, +1]), regex)
+      point = point ? point.translate([0, -1]) : this.getVimEofBufferPosition()
+    } else if (this.moveTo === "previous-end") {
+      // find from one column right position to contain char under cursor.
+      // Unless that, we cannot distinguish when left column is real end of word.
+      point = this.findPreviousEndOfWord(cursorPosition.translate([0, +1]), regex)
+      point = point ? point.translate([0, -1]) : [0, 0]
+    }
+    cursor.setBufferPosition(point)
+  }
+
+  findNextWord(from, regex) {
+    from = this.editor.clipBufferPosition(from)
+
+    let found
+    this.scanForward(regex, {from}, ({matchText, range, stop}) => {
+      // Ignore 'empty line' matches between '\r' and '\n'
+      if (matchText === "" && range.start.column !== 0) return
+
+      if (range.start.isGreaterThan(from)) {
+        found = range.start
+        stop()
+      }
+    })
+    return found
+  }
+
+  findPreviousStartOfWord(from, regex) {
+    from = this.editor.clipBufferPosition(from)
+
+    let found
+    this.scanBackward(regex, {from}, ({matchText, range, stop}) => {
+      // Ignore 'empty line' matches between '\r' and '\n'
+      if (matchText === "" && range.start.column !== 0) return
+
+      // vim compatibility, skip non empty whilte-space only row.
+      if (matchText && !/\S+/.test(matchText)) return
+
+      if (range.start.isLessThan(from)) {
+        found = range.start
+        stop()
+      }
+    })
+    return found
+  }
+
+  findNextEndOfWord(from, regex) {
+    from = this.editor.clipBufferPosition(from)
+
+    let found
+    this.scanForward(regex, {from}, ({matchText, range, stop}) => {
+      // Ignore 'empty line' matches between '\r' and '\n'
+      if (matchText === "" && range.start.column !== 0) return
+
+      // Skip empty or whilte-space only row
+      if (!matchText || !/\S+/.test(matchText)) return
+
+      if (range.end.isGreaterThan(from)) {
+        found = range.end
+        stop()
+      }
+    })
+    return found
+  }
+
+  findPreviousEndOfWord(from, regex) {
+    from = this.editor.clipBufferPosition(from)
+
+    let found
+    this.scanBackward(regex, {from}, ({matchText, range, stop}) => {
+      // Ignore 'empty line' matches between '\r' and '\n'
+      if (matchText === "" && range.start.column !== 0) return
+
+      // vim compatibility, skip non empty whilte-space only row.
+      if (matchText && !/\S+/.test(matchText)) return
+
+      if (range.end.isLessThan(from)) {
+        found = range.end
+        stop()
+      }
+    })
+    return found
+  }
 }
 
 // w
 class MoveToNextWord extends WordMotion {
+  moveTo = "next-start"
+}
+
+class _MoveToNextWord extends Motion {
+  getWordRegex(cursor) {
+    if (this.name.endsWith("Subword")) {
+      return cursor.subwordRegExp()
+    } else {
+      return this.wordRegex || cursor.wordRegExp()
+    }
+  }
   getPoint(regex, from) {
     let wordRange
     let found = false
@@ -383,7 +512,7 @@ class MoveToNextWord extends WordMotion {
     const cursorPosition = cursor.getBufferPosition()
     if (this.utils.pointIsAtVimEndOfFile(this.editor, cursorPosition)) return
 
-    const wasOnWhiteSpace = this.utils.pointIsOnWhiteSpace(this.editor, cursorPosition)
+    const wasAtWhiteSpace = this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)
     const isTargetOfNormalOperator = this.isTargetOfNormalOperator()
 
     this.moveCursorCountTimes(cursor, ({isFinal}) => {
@@ -393,7 +522,7 @@ class MoveToNextWord extends WordMotion {
       } else {
         let point = this.getPoint(this.getWordRegex(cursor), cursorPosition)
         if (isFinal && isTargetOfNormalOperator) {
-          if (this.operator.name === "Change" && !wasOnWhiteSpace) {
+          if (this.operator.name === "Change" && !wasAtWhiteSpace) {
             point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
           } else {
             point = Point.min(point, this.utils.getEndOfLineForBufferRow(this.editor, cursorPosition.row))
@@ -423,31 +552,9 @@ class MoveToNextAlphanumericWord extends MoveToNextWord {
   wordRegex = /\w+/g
 }
 
-// Previous Word
-//--------------------------------------
 // b
 class MoveToPreviousWord extends WordMotion {
-  moveCursor(cursor) {
-    this.moveCursorCountTimes(cursor, () => {
-      cursor.setBufferPosition(this.findPreviousWord(cursor))
-    })
-  }
-
-  findPreviousWord(cursor) {
-    const from = cursor.getBufferPosition()
-
-    let foundPoint
-    this.scanBackward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
-      // vim compatibility, skip non empty whilte-space only row.
-      if (matchText && !/\S+/.test(matchText)) return
-
-      if (range.start.isLessThan(from)) {
-        foundPoint = range.start
-        stop()
-      }
-    })
-    return foundPoint || [0, 0]
-  }
+  moveTo = "previous-start"
 }
 
 // B
@@ -468,53 +575,10 @@ class MoveToPreviousAlphanumericWord extends MoveToPreviousWord {
   wordRegex = /\w+/
 }
 
-// Next EndOfWord
-//--------------------------------------
 // e
 class MoveToEndOfWord extends WordMotion {
   inclusive = true
-  direction = "next"
-
-  moveCursor(cursor) {
-    this.moveCursorCountTimes(cursor, () => {
-      const point = this.direction === "next" ? this.findNextEndOfWord(cursor) : this.findPreviousEndOfWord(cursor)
-      cursor.setBufferPosition(point)
-    })
-  }
-
-  findNextEndOfWord(cursor) {
-    const from = this.editor.clipBufferPosition(cursor.getBufferPosition().translate([0, +1]))
-
-    let foundPoint
-    this.scanForward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
-      // Skip empty or whilte-space only row
-      if (!matchText || !/\S+/.test(matchText)) return
-
-      if (range.end.isGreaterThan(from)) {
-        foundPoint = range.end.translate([0, -1])
-        stop()
-      }
-    })
-    return foundPoint || this.getVimEofBufferPosition()
-  }
-
-  findPreviousEndOfWord(cursor) {
-    // find from one column right position to contain char under cursor.
-    // Unless that, we cannot distinguish when left column is real end of word.
-    const from = this.editor.clipBufferPosition(cursor.getBufferPosition().translate([0, +1]))
-
-    let foundPoint
-    this.scanBackward(this.getWordRegex(cursor), {from}, ({matchText, range, stop}) => {
-      // vim compatibility, skip non empty whilte-space only row.
-      if (matchText && !/\S+/.test(matchText)) return
-
-      if (range.end.isLessThan(from)) {
-        foundPoint = range.end.translate([0, -1])
-        stop()
-      }
-    })
-    return foundPoint || [0, 0]
-  }
+  moveTo = "next-end"
 }
 
 // E
@@ -535,12 +599,10 @@ class MoveToEndOfAlphanumericWord extends MoveToEndOfWord {
   wordRegex = /\w+/g
 }
 
-// Previous EndOfWord
-//--------------------------------------
 // ge
-class MoveToPreviousEndOfWord extends MoveToEndOfWord {
+class MoveToPreviousEndOfWord extends WordMotion {
   inclusive = true
-  direction = "previous"
+  moveTo = "previous-end"
 }
 
 // gE

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -337,14 +337,19 @@ class WordMotion extends Motion {
   skipWhiteSpaceOnlyRow = false
 
   moveCursor(cursor) {
+    const {direction, which} = this
+    const lastResort = direction === "previous" ? [0, 0] : this.getVimEofBufferPosition()
+
     this.moveCursorCountTimes(cursor, state => {
-      cursor.setBufferPosition(
-        this.getPoint(cursor, state) || (this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition())
-      )
+      const options = this.buildOptions(cursor)
+      if (direction === "next" && which === "start") {
+        cursor.setBufferPosition(this.getNextWord(options, state) || lastResort)
+      } else {
+        cursor.setBufferPosition(this.findWord(direction, which, options) || lastResort)
+      }
     })
   }
 
-  // ONLY TWO ERROR for w and W
   buildOptions(cursor) {
     let translate
     let from = cursor.getBufferPosition()
@@ -356,15 +361,8 @@ class WordMotion extends Motion {
     return {from, regex, skipBlankRow: this.skipBlankRow, skipWhiteSpaceOnlyRow: this.skipWhiteSpaceOnlyRow, translate}
   }
 
-  getPoint(cursor, {isFinal}) {
-    const {direction, which} = this
-    const options = this.buildOptions(cursor)
-
-    if (!(direction === "next" && which === "start")) {
-      return this.findWord(direction, which, options)
-    }
-
-    // NextWord is VERY complex: still have BUG.
+  // [FIXME] NextWord is VERY complex: still have BUG.
+  getNextWord(options, {isFinal}) {
     const {from} = options
     if (this.operator && this.operator.name === "Change") {
       if (!this.utils.pointIsAtWhiteSpace(this.editor, from)) {

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -387,14 +387,14 @@ class WordMotion extends Motion {
   }
 
   findWord(direction, from, regex, fn) {
-    clippedFrom = this.editor.clipBufferPosition(from)
+    from = this.editor.clipBufferPosition(from)
     let found
     const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
     this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
 
-      const result = fn({matchText, range, clippedFrom})
+      const result = fn({matchText, range, from})
       if (result) {
         found = result
         stop()
@@ -404,34 +404,32 @@ class WordMotion extends Motion {
   }
 
   findNextWord(from, regex) {
-    return this.findWord("next", from, regex, ({matchText, range, clippedFrom}) => {
-      if (range.start.isGreaterThan(clippedFrom)) return range.start
+    return this.findWord("next", from, regex, ({matchText, range, from}) => {
+      if (range.start.isGreaterThan(from)) return range.start
     })
   }
 
   findPreviousStartOfWord(from, regex) {
-    return this.findWord("previous", from, regex, ({matchText, range, clippedFrom}) => {
+    return this.findWord("previous", from, regex, ({matchText, range, from}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
-
-      if (range.start.isLessThan(clippedFrom)) return range.start
+      if (range.start.isLessThan(from)) return range.start
     })
   }
 
   findNextEndOfWord(from, regex) {
-    return this.findWord("next", from, regex, ({matchText, range, clippedFrom}) => {
+    return this.findWord("next", from, regex, ({matchText, range, from}) => {
       // Skip empty or whilte-space only row
       if (!matchText || !/\S+/.test(matchText)) return
-
-      if (range.end.isGreaterThan(clippedFrom)) return range.end
+      if (range.end.isGreaterThan(from)) return range.end
     })
   }
 
   findPreviousEndOfWord(from, regex) {
-    return this.findWord("previous", from, regex, ({matchText, range, clippedFrom}) => {
+    return this.findWord("previous", from, regex, ({matchText, range, from}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
-      if (range.end.isLessThan(clippedFrom)) return range.end
+      if (range.end.isLessThan(from)) return range.end
     })
   }
 }

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -324,14 +324,14 @@ class MoveDownToEdge extends MoveUpToEdge {
 }
 
 // Word Motion family
-// +-------------------------------------------------------------------------+
-// | where         | word  | WORD | subword       | smartword | alphanumeric |
-// |---------------+-------+------+---------------+-----------+--------------+
-// | Next          | w     | W    | -             | -         | -            |
-// | Previous      | b     | b    | -             | -         | -            |
-// | NextEndOf     | e     | E    | -             | -         | -            |
-// | PreviousEndOF | ge    | g E  | n/a           | n/a       | n/a          |
-// +-------------------------------------------------------------------------+
+// +----------------------------------------------------------------------------+
+// | direction | which      | word  | WORD | subword | smartword | alphanumeric |
+// |-----------+------------+-------+------+---------+-----------+--------------+
+// | next      | word-start | w     | W    | -       | -         | -            |
+// | previous  | word-start | b     | b    | -       | -         | -            |
+// | next      | word-end   | e     | E    | -       | -         | -            |
+// | previous  | word-end   | ge    | g E  | n/a     | n/a       | n/a          |
+// +----------------------------------------------------------------------------+
 
 class WordMotion extends Motion {
   static command = false

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -386,77 +386,57 @@ class WordMotion extends Motion {
     cursor.setBufferPosition(point)
   }
 
-  findNextWord(from, regex) {
-    from = this.editor.clipBufferPosition(from)
-
+  findWord(direction, from, regex, fn) {
+    // from = this.editor.clipBufferPosition(from)
     let found
-    this.scanForward(regex, {from}, ({matchText, range, stop}) => {
+    const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
+    this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
 
-      if (range.start.isGreaterThan(from)) {
-        found = range.start
+      const result = fn({matchText, range, stop})
+      if (result) {
+        found = result
         stop()
       }
     })
     return found
+  }
+
+  findNextWord(from, regex) {
+    from = this.editor.clipBufferPosition(from)
+    return this.findWord("next", from, regex, ({matchText, range}) => {
+      if (range.start.isGreaterThan(from)) return range.start
+    })
   }
 
   findPreviousStartOfWord(from, regex) {
     from = this.editor.clipBufferPosition(from)
-
-    let found
-    this.scanBackward(regex, {from}, ({matchText, range, stop}) => {
-      // Ignore 'empty line' matches between '\r' and '\n'
-      if (matchText === "" && range.start.column !== 0) return
-
+    return this.findWord("previous", from, regex, ({matchText, range}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
 
-      if (range.start.isLessThan(from)) {
-        found = range.start
-        stop()
-      }
+      if (range.start.isLessThan(from)) return range.start
     })
-    return found
   }
 
   findNextEndOfWord(from, regex) {
     from = this.editor.clipBufferPosition(from)
-
-    let found
-    this.scanForward(regex, {from}, ({matchText, range, stop}) => {
-      // Ignore 'empty line' matches between '\r' and '\n'
-      if (matchText === "" && range.start.column !== 0) return
-
+    return this.findWord("next", from, regex, ({matchText, range}) => {
       // Skip empty or whilte-space only row
       if (!matchText || !/\S+/.test(matchText)) return
 
-      if (range.end.isGreaterThan(from)) {
-        found = range.end
-        stop()
-      }
+      if (range.end.isGreaterThan(from)) return range.end
     })
-    return found
   }
 
   findPreviousEndOfWord(from, regex) {
     from = this.editor.clipBufferPosition(from)
-
-    let found
-    this.scanBackward(regex, {from}, ({matchText, range, stop}) => {
-      // Ignore 'empty line' matches between '\r' and '\n'
-      if (matchText === "" && range.start.column !== 0) return
-
+    return this.findWord("previous", from, regex, ({matchText, range}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
-
-      if (range.end.isLessThan(from)) {
-        found = range.end
-        stop()
-      }
+      if (range.end.isLessThan(from)) return range.end
     })
-    return found
   }
 }
 

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -320,8 +320,16 @@ class MoveDownToEdge extends MoveUpToEdge {
   direction = "next"
 }
 
-// Next Word
-//--------------------------------------
+// Word Motion family
+// +-------------------------------------------------------------------------+
+// | where         | word  | WORD | subword       | smartword | alphanumeric |
+// |---------------+-------+------+---------------+-----------+--------------+
+// | Next          | w     | W    | -             | -         | -            |
+// | Previous      | b     | b    | -             | -         | -            |
+// | NextEndOf     | e     | E    | -             | -         | -            |
+// | PreviousEndOF | ge    | g E  | n/a           | n/a       | n/a          |
+// +-------------------------------------------------------------------------+
+
 class WordMotion extends Motion {
   static command = false
   wordRegex = null
@@ -403,9 +411,7 @@ class MoveToNextWholeWord extends MoveToNextWord {
 }
 
 // no-keymap
-class MoveToNextAlphanumericWord extends MoveToNextWord {
-  wordRegex = /\w+/g
-}
+class MoveToNextSubword extends MoveToNextWord {}
 
 // no-keymap
 class MoveToNextSmartWord extends MoveToNextWord {
@@ -413,7 +419,9 @@ class MoveToNextSmartWord extends MoveToNextWord {
 }
 
 // no-keymap
-class MoveToNextSubword extends MoveToNextWord {}
+class MoveToNextAlphanumericWord extends MoveToNextWord {
+  wordRegex = /\w+/g
+}
 
 // Previous Word
 //--------------------------------------
@@ -434,9 +442,7 @@ class MoveToPreviousWholeWord extends MoveToPreviousWord {
 }
 
 // no-keymap
-class MoveToPreviousAlphanumericWord extends MoveToPreviousWord {
-  wordRegex = /\w+/
-}
+class MoveToPreviousSubword extends MoveToPreviousWord {}
 
 // no-keymap
 class MoveToPreviousSmartWord extends MoveToPreviousWord {
@@ -444,7 +450,10 @@ class MoveToPreviousSmartWord extends MoveToPreviousWord {
 }
 
 // no-keymap
-class MoveToPreviousSubword extends MoveToPreviousWord {}
+class MoveToPreviousAlphanumericWord extends MoveToPreviousWord {
+  wordRegex = /\w+/
+}
+
 
 // Next EndOfWord
 //--------------------------------------
@@ -478,9 +487,7 @@ class MoveToEndOfWholeWord extends MoveToEndOfWord {
 }
 
 // no-keymap
-class MoveToEndOfAlphanumericWord extends MoveToEndOfWord {
-  wordRegex = /\w+/g
-}
+class MoveToEndOfSubword extends MoveToEndOfWord {}
 
 // no-keymap
 class MoveToEndOfSmartWord extends MoveToEndOfWord {
@@ -488,7 +495,9 @@ class MoveToEndOfSmartWord extends MoveToEndOfWord {
 }
 
 // no-keymap
-class MoveToEndOfSubword extends MoveToEndOfWord {}
+class MoveToEndOfAlphanumericWord extends MoveToEndOfWord {
+  wordRegex = /\w+/g
+}
 
 // Previous EndOfWord
 //--------------------------------------

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -291,7 +291,7 @@ class MoveUpToEdge extends Motion {
   isStoppable(point) {
     return (
       this.isNonWhiteSpace(point) ||
-      this.isFirstRowOrLastRowAndEqualAfterClipped(point) ||
+      this.isFirstRowOrLastRowAndStoppable(point) ||
       // If right or left column is non-white-space char, it's stoppable.
       (this.isNonWhiteSpace(point.translate([0, -1])) && this.isNonWhiteSpace(point.translate([0, +1])))
     )
@@ -302,17 +302,16 @@ class MoveUpToEdge extends Motion {
     return char != null && /\S/.test(char)
   }
 
-  isFirstRowOrLastRowAndEqualAfterClipped(point) {
+  isFirstRowOrLastRowAndStoppable(point) {
     // In notmal-mode, cursor is NOT stoppable to EOL of non-blank row.
     // So explicitly guard to not answer it stoppable.
     if (this.mode === "normal" && this.utils.pointIsAtEndOfLineAtNonEmptyRow(this.editor, point)) {
       return false
     }
 
-    return (
-      (point.row === 0 || point.row === this.getVimLastScreenRow()) &&
-      point.isEqual(this.editor.clipScreenPosition(point))
-    )
+    // If clipped, it means that original ponit was non stoppable(e.g. point.colum > EOL).
+    const {row} = point
+    return (row === 0 || row === this.getVimLastScreenRow()) && point.isEqual(this.editor.clipScreenPosition(point))
   }
 }
 
@@ -337,31 +336,30 @@ class WordMotion extends Motion {
   skipWhiteSpaceOnlyRow = false
 
   moveCursor(cursor) {
-    this.moveCursorCountTimes(cursor, state => {
-      cursor.setBufferPosition(
-        this.getPoint(cursor, state) || (this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition())
-      )
+    this.moveCursorCountTimes(cursor, countState => {
+      cursor.setBufferPosition(this.getPoint(cursor, countState))
     })
   }
 
-  getPoint(cursor, state) {
+  getPoint(cursor, countState) {
     const {direction, which} = this
     const lastResort = this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition()
 
     const options = this.buildOptions(cursor)
-    if (direction === "next" && which === "start" && this.operator && state.isFinal) {
-      // Exceptional behavior for w and W: [Detail in vim help `:help w`.]
-
+    if (direction === "next" && which === "start" && this.operator && countState.isFinal) {
+      // [NOTE] Exceptional behavior for w and W: [Detail in vim help `:help w`.]
+      // [case-A] cw, cW treated as ce, cE when cursor is at non-blank.
+      // [case-B] when w, W used as TARGET, it doesn't move over new line.
       const {from} = options
       if (this.isEmptyRow(from.row)) return [from.row + 1, 0]
 
       if (this.operator.name === "Change" && !this.utils.pointIsAtWhiteSpace(this.editor, from)) {
-        // [case-A] cw, cW treated as ce, cE when cursor is at non-blank.
+        // [case-A]
         // We are at non-white-space, so 100% can find end of word here(no lastResort required)
         return this.findWord("next", "end", options)
       }
 
-      // [case-B] when w, W used as TARGET, it doesn't move over new line.
+      // [case-B]
       const point = this.findWord("next", "start", options)
       return point ? Point.min(point, new Point(from.row, Infinity)) : lastResort
     } else {

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -333,75 +333,67 @@ class MoveDownToEdge extends MoveUpToEdge {
 class WordMotion extends Motion {
   static command = false
   wordRegex = null
-
-  getWordRegex(cursor) {
-    if (this.name.endsWith("Subword")) {
-      return cursor.subwordRegExp()
-    } else {
-      return this.wordRegex || cursor.wordRegExp()
-    }
-  }
+  skipBlankRow = false
+  skipWhiteSpaceOnlyRow = false
 
   moveCursor(cursor) {
-    this.moveCursorCountTimes(cursor, state => this.moveByWord(cursor, state))
+    this.moveCursorCountTimes(cursor, state => {
+      cursor.setBufferPosition(
+        this.getPoint(cursor, state) || (this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition())
+      )
+    })
   }
 
   // ONLY TWO ERROR for w and W
-
-  moveByWord(cursor, {isFinal}) {
-    const regex = this.getWordRegex(cursor)
-    const cursorPosition = cursor.getBufferPosition()
-    let point
-
-    if (this.moveTo === "next-start") {
-      if (this.operator && this.operator.name === "Change") {
-        if (!this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)) {
-          point = this.findWord("next", "end", {from: cursorPosition, regex})
-        } else {
-          // console.log('2');
-          point = this.findWord("next", "start", {from: cursorPosition, regex})
-          // console.log({isFinal});
-          if (isFinal && point.row !== cursorPosition.row) {
-            // console.log(point.toString(), cursorPosition.toString());
-            // console.log("OKK!!");
-            point = new Point(cursorPosition.row, Infinity)
-          }
-        }
-      } else {
-        // console.log('3');
-        point = this.findWord("next", "start", {from: cursorPosition, regex})
-      }
-      point = point || this.getVimEofBufferPosition()
-    } else if (this.moveTo === "previous-start") {
-      const options = {from: cursorPosition, regex, skipWhiteSpaceOnlyRow: true}
-      point = this.findWord("previous", "start", options) || [0, 0]
-    } else if (this.moveTo === "next-end") {
-      const options = {from: cursorPosition.translate([0, +1]), regex, skipBlankRow: true, skipWhiteSpaceOnlyRow: true}
-      point = this.findWord("next", "end", options)
-      point = point ? point.translate([0, -1]) : this.getVimEofBufferPosition()
-    } else if (this.moveTo === "previous-end") {
-      // find from one column right position to contain char under cursor.
-      // Unless that, we cannot distinguish when left column is real end of word.
-      const options = {from: cursorPosition.translate([0, +1]), regex, skipWhiteSpaceOnlyRow: true}
-      point = this.findWord("previous", "end", options)
-      point = point ? point.translate([0, -1]) : [0, 0]
+  buildOptions(cursor) {
+    let translate
+    let from = cursor.getBufferPosition()
+    if (this.which === "end") {
+      from.column += 1
+      translate = [0, -1]
     }
-    cursor.setBufferPosition(point)
+    const regex = this.name.endsWith("Subword") ? cursor.subwordRegExp() : this.wordRegex || cursor.wordRegExp()
+    return {from, regex, skipBlankRow: this.skipBlankRow, skipWhiteSpaceOnlyRow: this.skipWhiteSpaceOnlyRow, translate}
+  }
+
+  getPoint(cursor, {isFinal}) {
+    const {direction, which} = this
+    const options = this.buildOptions(cursor)
+
+    if (!(direction === "next" && which === "start")) {
+      return this.findWord(direction, which, options)
+    }
+
+    // NextWord is VERY complex: still have BUG.
+    const {from} = options
+    if (this.operator && this.operator.name === "Change") {
+      if (!this.utils.pointIsAtWhiteSpace(this.editor, from)) {
+        return this.findWord("next", "end", options)
+      } else {
+        let point = this.findWord("next", "start", options)
+        if (isFinal && point.row !== from.row) {
+          point = new Point(from.row, Infinity)
+        }
+        return point
+      }
+    } else {
+      return this.findWord("next", "start", options)
+    }
   }
 
   findWord(direction, which, options = {}, fn) {
     const compareMethod = direction === "next" ? "isGreaterThan" : "isLessThan"
     const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
 
-    const {regex, skipBlankRow, skipWhiteSpaceOnlyRow} = options
+    const {regex, skipBlankRow, skipWhiteSpaceOnlyRow, translate} = options
     const from = this.editor.clipBufferPosition(options.from)
     let found
     this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
 
-      if (options.skipBlankRow && !matchText) return
-      if (options.skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
+      if (skipBlankRow && !matchText) return
+      if (skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
 
       const pointToCompare = range[which]
       if (pointToCompare[compareMethod](from)) {
@@ -409,13 +401,16 @@ class WordMotion extends Motion {
         stop()
       }
     })
-    return found
+    if (found) {
+      return translate ? found.translate(translate) : found
+    }
   }
 }
 
 // w
 class MoveToNextWord extends WordMotion {
-  moveTo = "next-start"
+  direction = "next"
+  which = "start"
 }
 
 class _MoveToNextWord extends Motion {
@@ -507,7 +502,9 @@ class MoveToNextAlphanumericWord extends MoveToNextWord {
 
 // b
 class MoveToPreviousWord extends WordMotion {
-  moveTo = "previous-start"
+  direction = "previous"
+  which = "start"
+  skipWhiteSpaceOnlyRow = true
 }
 
 // B
@@ -531,7 +528,10 @@ class MoveToPreviousAlphanumericWord extends MoveToPreviousWord {
 // e
 class MoveToEndOfWord extends WordMotion {
   inclusive = true
-  moveTo = "next-end"
+  direction = "next"
+  which = "end"
+  skipBlankRow = true
+  skipWhiteSpaceOnlyRow = true
 }
 
 // E
@@ -555,7 +555,9 @@ class MoveToEndOfAlphanumericWord extends MoveToEndOfWord {
 // ge
 class MoveToPreviousEndOfWord extends WordMotion {
   inclusive = true
-  moveTo = "previous-end"
+  direction = "previous"
+  which = "end"
+  skipWhiteSpaceOnlyRow = true
 }
 
 // gE

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -387,14 +387,14 @@ class WordMotion extends Motion {
   }
 
   findWord(direction, from, regex, fn) {
-    // from = this.editor.clipBufferPosition(from)
+    clippedFrom = this.editor.clipBufferPosition(from)
     let found
     const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
     this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
 
-      const result = fn({matchText, range, stop})
+      const result = fn({matchText, range, clippedFrom})
       if (result) {
         found = result
         stop()
@@ -404,38 +404,34 @@ class WordMotion extends Motion {
   }
 
   findNextWord(from, regex) {
-    from = this.editor.clipBufferPosition(from)
-    return this.findWord("next", from, regex, ({matchText, range}) => {
-      if (range.start.isGreaterThan(from)) return range.start
+    return this.findWord("next", from, regex, ({matchText, range, clippedFrom}) => {
+      if (range.start.isGreaterThan(clippedFrom)) return range.start
     })
   }
 
   findPreviousStartOfWord(from, regex) {
-    from = this.editor.clipBufferPosition(from)
-    return this.findWord("previous", from, regex, ({matchText, range}) => {
+    return this.findWord("previous", from, regex, ({matchText, range, clippedFrom}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
 
-      if (range.start.isLessThan(from)) return range.start
+      if (range.start.isLessThan(clippedFrom)) return range.start
     })
   }
 
   findNextEndOfWord(from, regex) {
-    from = this.editor.clipBufferPosition(from)
-    return this.findWord("next", from, regex, ({matchText, range}) => {
+    return this.findWord("next", from, regex, ({matchText, range, clippedFrom}) => {
       // Skip empty or whilte-space only row
       if (!matchText || !/\S+/.test(matchText)) return
 
-      if (range.end.isGreaterThan(from)) return range.end
+      if (range.end.isGreaterThan(clippedFrom)) return range.end
     })
   }
 
   findPreviousEndOfWord(from, regex) {
-    from = this.editor.clipBufferPosition(from)
-    return this.findWord("previous", from, regex, ({matchText, range}) => {
+    return this.findWord("previous", from, regex, ({matchText, range, clippedFrom}) => {
       // vim compatibility, skip non empty whilte-space only row.
       if (matchText && !/\S+/.test(matchText)) return
-      if (range.end.isLessThan(from)) return range.end
+      if (range.end.isLessThan(clippedFrom)) return range.end
     })
   }
 }

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -356,10 +356,10 @@ class WordMotion extends Motion {
     if (this.moveTo === "next-start") {
       if (this.operator && this.operator.name === "Change") {
         if (!this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)) {
-          point = this.findNextEndOfWord(cursorPosition, regex)
+          point = this.findWordByType("next-end", {from: cursorPosition, regex})
         } else {
           // console.log('2');
-          point = this.findNextWord(cursorPosition, regex)
+          point = this.findWordByType("next-start", {from: cursorPosition, regex})
           // console.log({isFinal});
           if (isFinal && point.row !== cursorPosition.row) {
             // console.log(point.toString(), cursorPosition.toString());
@@ -369,18 +369,21 @@ class WordMotion extends Motion {
         }
       } else {
         // console.log('3');
-        point = this.findNextWord(cursorPosition, regex)
+        point = this.findWordByType("next-start", {from: cursorPosition, regex})
       }
       point = point || this.getVimEofBufferPosition()
     } else if (this.moveTo === "previous-start") {
-      point = this.findPreviousStartOfWord(cursorPosition, regex) || [0, 0]
+      const options = {from: cursorPosition, regex, skipWhiteSpaceOnlyRow: true}
+      point = this.findWordByType(this.moveTo, options) || [0, 0]
     } else if (this.moveTo === "next-end") {
-      point = this.findNextEndOfWord(cursorPosition.translate([0, +1]), regex)
+      const options = {from: cursorPosition.translate([0, +1]), regex, skipBlankRow: true, skipWhiteSpaceOnlyRow: true}
+      point = this.findWordByType(this.moveTo, options)
       point = point ? point.translate([0, -1]) : this.getVimEofBufferPosition()
     } else if (this.moveTo === "previous-end") {
       // find from one column right position to contain char under cursor.
       // Unless that, we cannot distinguish when left column is real end of word.
-      point = this.findPreviousEndOfWord(cursorPosition.translate([0, +1]), regex)
+      const options = {from: cursorPosition.translate([0, +1]), regex, skipWhiteSpaceOnlyRow: true}
+      point = this.findWordByType(this.moveTo, options)
       point = point ? point.translate([0, -1]) : [0, 0]
     }
     cursor.setBufferPosition(point)
@@ -407,23 +410,22 @@ class WordMotion extends Motion {
     return found
   }
 
-  findNextWord(from, regex) {
-    return this.findWord("next", {from, regex}, ({range, from}) => range.start.isGreaterThan(from) && range.start)
-  }
-
-  findPreviousStartOfWord(from, regex) {
-    const options = {from, regex, skipWhiteSpaceOnlyRow: true}
-    return this.findWord("previous", options, ({range, from}) => range.start.isLessThan(from) && range.start)
-  }
-
-  findNextEndOfWord(from, regex) {
-    const options = {from, regex, skipBlankRow: true, skipWhiteSpaceOnlyRow: true}
-    return this.findWord("next", options, ({range, from}) => range.end.isGreaterThan(from) && range.end)
-  }
-
-  findPreviousEndOfWord(from, regex) {
-    const options = {from, regex, skipWhiteSpaceOnlyRow: true}
-    return this.findWord("previous", options, ({range, from}) => range.end.isLessThan(from) && range.end)
+  findWordByType(type, options) {
+    let direction
+    if (type === "next-start") {
+      direction = "next"
+      fn = ({range, from}) => range.start.isGreaterThan(from) && range.start
+    } else if (type === "previous-start") {
+      direction = "previous"
+      fn = ({range, from}) => range.start.isLessThan(from) && range.start
+    } else if (type === "next-end") {
+      direction = "next"
+      fn = ({range, from}) => range.end.isGreaterThan(from) && range.end
+    } else if (type === "previous-end") {
+      direction = "previous"
+      fn = ({range, from}) => range.end.isLessThan(from) && range.end
+    }
+    return this.findWord(direction, options, fn)
   }
 }
 

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -386,13 +386,17 @@ class WordMotion extends Motion {
     cursor.setBufferPosition(point)
   }
 
-  findWord(direction, from, regex, fn) {
-    from = this.editor.clipBufferPosition(from)
+  findWord(direction, options = {}, fn) {
+    const {regex, skipBlankRow, skipWhiteSpaceOnlyRow} = options
+    const from = this.editor.clipBufferPosition(options.from)
     let found
     const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
     this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
       // Ignore 'empty line' matches between '\r' and '\n'
       if (matchText === "" && range.start.column !== 0) return
+
+      if (options.skipBlankRow && !matchText) return
+      if (options.skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
 
       const result = fn({matchText, range, from})
       if (result) {
@@ -404,33 +408,22 @@ class WordMotion extends Motion {
   }
 
   findNextWord(from, regex) {
-    return this.findWord("next", from, regex, ({matchText, range, from}) => {
-      if (range.start.isGreaterThan(from)) return range.start
-    })
+    return this.findWord("next", {from, regex}, ({range, from}) => range.start.isGreaterThan(from) && range.start)
   }
 
   findPreviousStartOfWord(from, regex) {
-    return this.findWord("previous", from, regex, ({matchText, range, from}) => {
-      // vim compatibility, skip non empty whilte-space only row.
-      if (matchText && !/\S+/.test(matchText)) return
-      if (range.start.isLessThan(from)) return range.start
-    })
+    const options = {from, regex, skipWhiteSpaceOnlyRow: true}
+    return this.findWord("previous", options, ({range, from}) => range.start.isLessThan(from) && range.start)
   }
 
   findNextEndOfWord(from, regex) {
-    return this.findWord("next", from, regex, ({matchText, range, from}) => {
-      // Skip empty or whilte-space only row
-      if (!matchText || !/\S+/.test(matchText)) return
-      if (range.end.isGreaterThan(from)) return range.end
-    })
+    const options = {from, regex, skipBlankRow: true, skipWhiteSpaceOnlyRow: true}
+    return this.findWord("next", options, ({range, from}) => range.end.isGreaterThan(from) && range.end)
   }
 
   findPreviousEndOfWord(from, regex) {
-    return this.findWord("previous", from, regex, ({matchText, range, from}) => {
-      // vim compatibility, skip non empty whilte-space only row.
-      if (matchText && !/\S+/.test(matchText)) return
-      if (range.end.isLessThan(from)) return range.end
-    })
+    const options = {from, regex, skipWhiteSpaceOnlyRow: true}
+    return this.findWord("previous", options, ({range, from}) => range.end.isLessThan(from) && range.end)
   }
 }
 

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -380,31 +380,6 @@ class WordMotion extends Motion {
       return this.findWord("next", "start", options)
     }
   }
-
-  findWord(direction, which, options = {}, fn) {
-    const compareMethod = direction === "next" ? "isGreaterThan" : "isLessThan"
-    const scanMethod = direction === "next" ? "scanForward" : "scanBackward"
-
-    const {regex, skipBlankRow, skipWhiteSpaceOnlyRow, translate} = options
-    const from = this.editor.clipBufferPosition(options.from)
-    let found
-    this[scanMethod](regex, {from}, ({matchText, range, stop}) => {
-      // Ignore 'empty line' matches between '\r' and '\n'
-      if (matchText === "" && range.start.column !== 0) return
-
-      if (skipBlankRow && !matchText) return
-      if (skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
-
-      const pointToCompare = range[which]
-      if (pointToCompare[compareMethod](from)) {
-        found = pointToCompare
-        stop()
-      }
-    })
-    if (found) {
-      return translate ? found.translate(translate) : found
-    }
-  }
 }
 
 // w

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -337,17 +337,36 @@ class WordMotion extends Motion {
   skipWhiteSpaceOnlyRow = false
 
   moveCursor(cursor) {
-    const {direction, which} = this
-    const lastResort = direction === "previous" ? [0, 0] : this.getVimEofBufferPosition()
-
     this.moveCursorCountTimes(cursor, state => {
-      const options = this.buildOptions(cursor)
-      if (direction === "next" && which === "start") {
-        cursor.setBufferPosition(this.getNextWord(options, state) || lastResort)
-      } else {
-        cursor.setBufferPosition(this.findWord(direction, which, options) || lastResort)
-      }
+      cursor.setBufferPosition(
+        this.getPoint(cursor, state) || (this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition())
+      )
     })
+  }
+
+  getPoint(cursor, state) {
+    const {direction, which} = this
+    const lastResort = this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition()
+
+    const options = this.buildOptions(cursor)
+    if (direction === "next" && which === "start" && this.operator && state.isFinal) {
+      // Exceptional behavior for w and W: [Detail in vim help `:help w`.]
+
+      const {from} = options
+      if (this.isEmptyRow(from.row)) return [from.row + 1, 0]
+
+      if (this.operator.name === "Change" && !this.utils.pointIsAtWhiteSpace(this.editor, from)) {
+        // [case-A] cw, cW treated as ce, cE when cursor is at non-blank.
+        // We are at non-white-space, so 100% can find end of word here(no lastResort required)
+        return this.findWord("next", "end", options)
+      }
+
+      // [case-B] when w, W used as TARGET, it doesn't move over new line.
+      const point = this.findWord("next", "start", options)
+      return point ? Point.min(point, new Point(from.row, Infinity)) : lastResort
+    } else {
+      return this.findWord(direction, which, options) || lastResort
+    }
   }
 
   buildOptions(cursor) {
@@ -360,99 +379,12 @@ class WordMotion extends Motion {
     const regex = this.name.endsWith("Subword") ? cursor.subwordRegExp() : this.wordRegex || cursor.wordRegExp()
     return {from, regex, skipBlankRow: this.skipBlankRow, skipWhiteSpaceOnlyRow: this.skipWhiteSpaceOnlyRow, translate}
   }
-
-  // [FIXME] NextWord is VERY complex: still have BUG.
-  getNextWord(options, {isFinal}) {
-    const {from} = options
-    if (this.operator && this.operator.name === "Change") {
-      if (!this.utils.pointIsAtWhiteSpace(this.editor, from)) {
-        return this.findWord("next", "end", options)
-      } else {
-        let point = this.findWord("next", "start", options)
-        if (isFinal && point.row !== from.row) {
-          point = new Point(from.row, Infinity)
-        }
-        return point
-      }
-    } else {
-      return this.findWord("next", "start", options)
-    }
-  }
 }
 
 // w
 class MoveToNextWord extends WordMotion {
   direction = "next"
   which = "start"
-}
-
-class _MoveToNextWord extends Motion {
-  getWordRegex(cursor) {
-    if (this.name.endsWith("Subword")) {
-      return cursor.subwordRegExp()
-    } else {
-      return this.wordRegex || cursor.wordRegExp()
-    }
-  }
-  getPoint(regex, from) {
-    let wordRange
-    let found = false
-
-    this.scanForward(regex, {from}, ({range, matchText, stop}) => {
-      wordRange = range
-      // Ignore 'empty line' matches between '\r' and '\n'
-      if (matchText === "" && range.start.column !== 0) return
-      if (range.start.isGreaterThan(from)) {
-        found = true
-        stop()
-      }
-    })
-
-    if (found) {
-      const point = wordRange.start
-      return this.utils.pointIsAtEndOfLineAtNonEmptyRow(this.editor, point) &&
-        !point.isEqual(this.getVimEofBufferPosition())
-        ? point.traverse([1, 0])
-        : point
-    } else {
-      return wordRange ? wordRange.end : from
-    }
-  }
-
-  // Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is
-  // on a non-blank.  This is because "cw" is interpreted as change-word, and a
-  // word does not include the following white space.  {Vi: "cw" when on a blank
-  // followed by other blanks changes only the first blank; this is probably a
-  // bug, because "dw" deletes all the blanks}
-  //
-  // Another special case: When using the "w" motion in combination with an
-  // operator and the last word moved over is at the end of a line, the end of
-  // that word becomes the end of the operated text, not the first word in the
-  // next line.
-  moveCursor(cursor) {
-    const cursorPosition = cursor.getBufferPosition()
-    if (this.utils.pointIsAtVimEndOfFile(this.editor, cursorPosition)) return
-
-    const wasAtWhiteSpace = this.utils.pointIsAtWhiteSpace(this.editor, cursorPosition)
-    const isTargetOfNormalOperator = this.isTargetOfNormalOperator()
-
-    this.moveCursorCountTimes(cursor, ({isFinal}) => {
-      const cursorPosition = cursor.getBufferPosition()
-      if (this.utils.isEmptyRow(this.editor, cursorPosition.row) && isTargetOfNormalOperator) {
-        cursor.setBufferPosition(cursorPosition.traverse([1, 0]))
-      } else {
-        let point = this.getPoint(this.getWordRegex(cursor), cursorPosition)
-        if (isFinal && isTargetOfNormalOperator) {
-          if (this.operator.name === "Change" && !wasAtWhiteSpace) {
-            point = cursor.getEndOfCurrentWordBufferPosition({wordRegex: this.wordRegex})
-          } else {
-            point = Point.min(point, this.utils.getEndOfLineForBufferRow(this.editor, cursorPosition.row))
-          }
-        }
-        cursor.setBufferPosition(point)
-      }
-    })
-  }
 }
 
 // W

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -120,6 +120,10 @@ class Motion extends Base {
       ? term.search(/[A-Z]/) !== -1
       : !this.getConfig(`ignoreCaseFor${this.caseSensitivityKind}`)
   }
+
+  getFirstOrLastPoint(direction) {
+    return this.direction === "previous" ? new Point(0, 0) : this.getVimEofBufferPosition()
+  }
 }
 
 // Used as operator's target in visual-mode.
@@ -343,7 +347,6 @@ class WordMotion extends Motion {
 
   getPoint(cursor, countState) {
     const {direction, which} = this
-    const lastResort = this.direction === "previous" ? [0, 0] : this.getVimEofBufferPosition()
 
     const options = this.buildOptions(cursor)
     if (direction === "next" && which === "start" && this.operator && countState.isFinal) {
@@ -361,9 +364,9 @@ class WordMotion extends Motion {
 
       // [case-B]
       const point = this.findWord("next", "start", options)
-      return point ? Point.min(point, new Point(from.row, Infinity)) : lastResort
+      return point ? Point.min(point, new Point(from.row, Infinity)) : this.getFirstOrLastPoint(direction)
     } else {
-      return this.findWord(direction, which, options) || lastResort
+      return this.findWord(direction, which, options) || this.getFirstOrLastPoint(direction)
     }
   }
 
@@ -483,14 +486,11 @@ class MoveToNextSentence extends Motion {
 
   moveCursor(cursor) {
     this.moveCursorCountTimes(cursor, () => {
-      const cursorPosition = cursor.getBufferPosition()
-
       const point =
         this.direction === "next"
-          ? this.getNextStartOfSentence(cursorPosition)
-          : this.getPreviousStartOfSentence(cursorPosition)
-
-      cursor.setBufferPosition(point)
+          ? this.getNextStartOfSentence(cursor.getBufferPosition())
+          : this.getPreviousStartOfSentence(cursor.getBufferPosition())
+      cursor.setBufferPosition(point || this.getFirstOrLastPoint(this.direction))
     })
   }
 
@@ -512,7 +512,7 @@ class MoveToNextSentence extends Motion {
       }
       if (foundPoint) stop()
     })
-    return foundPoint || this.getVimEofBufferPosition()
+    return foundPoint
   }
 
   getPreviousStartOfSentence(from) {
@@ -534,7 +534,7 @@ class MoveToNextSentence extends Motion {
       }
       if (foundPoint) stop()
     })
-    return foundPoint || [0, 0]
+    return foundPoint
   }
 }
 
@@ -558,7 +558,8 @@ class MoveToNextParagraph extends Motion {
 
   moveCursor(cursor) {
     this.moveCursorCountTimes(cursor, () => {
-      cursor.setBufferPosition(this.getPoint(cursor.getBufferPosition()))
+      const point = this.getPoint(cursor.getBufferPosition())
+      cursor.setBufferPosition(point || this.getFirstOrLastPoint(this.direction))
     })
   }
 
@@ -572,9 +573,6 @@ class MoveToNextParagraph extends Motion {
       }
       wasBlankRow = isBlankRow
     }
-
-    // fallback
-    return this.direction === "previous" ? new Point(0, 0) : this.getVimEofBufferPosition()
   }
 }
 
@@ -619,8 +617,7 @@ class MoveToLastNonblankCharacterOfLineAndDown extends Motion {
 // ^
 class MoveToFirstCharacterOfLine extends Motion {
   moveCursor(cursor) {
-    const point = this.getFirstCharacterPositionForBufferRow(cursor.getBufferRow())
-    cursor.setBufferPosition(point)
+    cursor.setBufferPosition(this.getFirstCharacterPositionForBufferRow(cursor.getBufferRow()))
   }
 }
 
@@ -792,16 +789,25 @@ class MoveToBottomOfScreen extends MoveToTopOfScreen {
 class Scroll extends Motion {
   static command = false
   static scrollTask = null
+  static amountOfPageByName = {
+    ScrollFullScreenDown: 1,
+    ScrollFullScreenUp: -1,
+    ScrollHalfScreenDown: 0.5,
+    ScrollHalfScreenUp: -0.5,
+    ScrollQuarterScreenDown: 0.25,
+    ScrollQuarterScreenUp: -0.25,
+  }
   verticalMotion = true
 
   execute() {
-    this.amountOfRowsToScroll = Math.trunc(this.amountOfPage * this.editor.getRowsPerPage() * this.getCount())
+    const amountOfPage = this.constructor.amountOfPageByName[this.name]
+    this.amountOfRowsToScroll = Math.trunc(amountOfPage * this.editor.getRowsPerPage() * this.getCount())
 
     super.execute()
 
     this.vimState.requestScroll({
       amountOfScreenRows: this.amountOfRowsToScroll,
-      duration: this.getSmoothScrollDuation((Math.abs(this.amountOfPage) === 1 ? "Full" : "Half") + "ScrollMotion"),
+      duration: this.getSmoothScrollDuation((Math.abs(amountOfPage) === 1 ? "Full" : "Half") + "ScrollMotion"),
     })
   }
 
@@ -811,35 +817,12 @@ class Scroll extends Motion {
   }
 }
 
-// keymap: ctrl-f
-class ScrollFullScreenDown extends Scroll {
-  amountOfPage = +1
-}
-
-// keymap: ctrl-b
-class ScrollFullScreenUp extends Scroll {
-  amountOfPage = -1
-}
-
-// keymap: ctrl-d
-class ScrollHalfScreenDown extends Scroll {
-  amountOfPage = 0.5
-}
-
-// keymap: ctrl-u
-class ScrollHalfScreenUp extends Scroll {
-  amountOfPage = -0.5
-}
-
-// keymap: g ctrl-d
-class ScrollQuarterScreenDown extends Scroll {
-  amountOfPage = 0.25
-}
-
-// keymap: g ctrl-u
-class ScrollQuarterScreenUp extends Scroll {
-  amountOfPage = -0.25
-}
+class ScrollFullScreenDown extends Scroll {} // ctrl-f
+class ScrollFullScreenUp extends Scroll {} // ctrl-b
+class ScrollHalfScreenDown extends Scroll {} // ctrl-d
+class ScrollHalfScreenUp extends Scroll {} // ctrl-u
+class ScrollQuarterScreenDown extends Scroll {} // g ctrl-d
+class ScrollQuarterScreenUp extends Scroll {} // g ctrl-u
 
 // Find
 // -------------------------

--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -262,17 +262,13 @@ class InsertAboveWithNewline extends ActivateInsertMode {
   autoIndentEmptyRows() {
     for (const cursor of this.editor.getCursors()) {
       const row = cursor.getBufferRow()
-      if (this.utils.isEmptyRow(this.editor, row)) {
-        this.editor.autoIndentBufferRow(row)
-      }
+      if (this.isEmptyRow(row)) this.editor.autoIndentBufferRow(row)
     }
   }
 
   mutateText() {
     this.editor.insertNewlineAbove()
-    if (this.editor.autoIndent) {
-      this.autoIndentEmptyRows()
-    }
+    if (this.editor.autoIndent) this.autoIndentEmptyRows()
   }
 
   repeatInsert(selection, text) {
@@ -410,6 +406,7 @@ class Change extends ActivateInsertModeBase {
       }
       if (isLinewiseTarget) {
         selection.insertText("\n", {autoIndent: true})
+        // selection.insertText("", {autoIndent: true})
         selection.cursor.moveLeft()
       } else {
         selection.insertText("", {autoIndent: true})

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -761,11 +761,7 @@ class PutBefore extends Operator {
 
   pasteCharacterwise(selection, text) {
     const {cursor} = selection
-    if (
-      selection.isEmpty() &&
-      this.location === "after" &&
-      !this.utils.isEmptyRow(this.editor, cursor.getBufferRow())
-    ) {
+    if (selection.isEmpty() && this.location === "after" && !this.isEmptyRow(cursor.getBufferRow())) {
       cursor.moveRight()
     }
     return selection.insertText(text)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,16 +131,21 @@ function getEndOfLineForBufferRow(editor, row) {
   return editor.bufferRangeForBufferRow(row).end
 }
 
-// Point util
+// Buffer Point util
 // -------------------------
 function pointIsAtEndOfLine(editor, point) {
   point = Point.fromObject(point)
   return getEndOfLineForBufferRow(editor, point.row).isEqual(point)
 }
 
-function pointIsOnWhiteSpace(editor, point) {
+function pointIsAtWhiteSpace(editor, point) {
   const char = getRightCharacterForBufferPosition(editor, point)
   return !/\S/.test(char)
+}
+
+function pointIsAtNonWhiteSpace(editor, point) {
+  const char = getRightCharacterForBufferPosition(editor, point)
+  return char != null && /\S/.test(char)
 }
 
 function pointIsAtEndOfLineAtNonEmptyRow(editor, point) {
@@ -1166,7 +1171,8 @@ module.exports = {
   getVisibleBufferRange,
   getVisibleEditors,
   pointIsAtEndOfLine,
-  pointIsOnWhiteSpace,
+  pointIsAtWhiteSpace,
+  pointIsAtNonWhiteSpace,
   pointIsAtEndOfLineAtNonEmptyRow,
   pointIsAtVimEndOfFile,
   getVimEofBufferPosition,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -973,10 +973,12 @@ function scanEditor(editor, direction, regex, {allowNextLine, from, scanRange}, 
   let scanFunction
   switch (direction) {
     case "forward":
+    case "next":
       if (!scanRange) scanRange = new Range(from, getVimEofBufferPosition(editor))
       scanFunction = "scanInBufferRange"
       break
     case "backward":
+    case "previous":
       if (!scanRange) scanRange = new Range([0, 0], from)
       scanFunction = "backwardsScanInBufferRange"
       break
@@ -986,6 +988,31 @@ function scanEditor(editor, direction, regex, {allowNextLine, from, scanRange}, 
     if (!allowNextLine && event.range.start.row !== from.row) event.stop()
     else fn(event)
   })
+}
+
+function findWord(editor, direction, which, options) {
+  const pointCompareMethod = direction === "next" ? "isGreaterThan" : "isLessThan"
+
+  const {regex, skipBlankRow, skipWhiteSpaceOnlyRow, translate} = options
+  const from = editor.clipBufferPosition(options.from)
+
+  let found
+  scanEditor(editor, direction, regex, {from}, ({matchText, range, stop}) => {
+    // Ignore 'empty line' matches between '\r' and '\n'
+    if (matchText === "" && range.start.column !== 0) return
+
+    if (skipBlankRow && !matchText) return
+    if (skipWhiteSpaceOnlyRow && matchText && !/\S+/.test(matchText)) return
+
+    const pointToCompare = range[which]
+    if (pointToCompare[pointCompareMethod](from)) {
+      found = pointToCompare
+      stop()
+    }
+  })
+  if (found) {
+    return translate ? found.translate(translate) : found
+  }
 }
 
 function adjustIndentWithKeepingLayout(editor, range) {
@@ -1243,6 +1270,7 @@ module.exports = {
   splitAndJoinBy,
   splitArguments,
   scanEditor,
+  findWord,
   adjustIndentWithKeepingLayout,
   rangeContainsPointWithEndExclusive,
   traverseTextFromPoint,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,21 +174,6 @@ function getNonWordCharactersForCursor(cursor) {
     : atom.config.get("editor.nonWordCharacters", {scope: cursor.getScopeDescriptor().getScopesArray()})
 }
 
-// FIXME: remove this
-// return true if moved
-function moveCursorToNextNonWhitespace(cursor) {
-  const originalPoint = cursor.getBufferPosition()
-  const editor = cursor.editor
-  const vimEof = getVimEofBufferPosition(editor)
-
-  let point = cursor.getBufferPosition()
-  while (pointIsOnWhiteSpace(editor, point) && !point.isGreaterThanOrEqual(vimEof)) {
-    cursor.moveRight()
-    point = cursor.getBufferPosition()
-  }
-  return !originalPoint.isEqual(cursor.getBufferPosition())
-}
-
 function getRows(editor, bufferOrScreen, {startRow, direction}) {
   switch (direction) {
     case "previous":
@@ -1200,7 +1185,6 @@ module.exports = {
   moveCursorToFirstCharacterAtRow,
   getLineTextToBufferPosition,
   getTextInScreenRange,
-  moveCursorToNextNonWhitespace,
   isEmptyRow,
   getCodeFoldRowRanges,
   getCodeFoldRowRangesContainesForRow,

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -669,7 +669,7 @@ describe "Motion general", ->
 
   describe "the ge keybinding", ->
     describe "as a motion", ->
-      fit "moves the cursor to the end of the previous word", ->
+      it "moves the cursor to the end of the previous word", ->
         set           textC: "1234 5678 wordwo|rd"
         ensure "g e", textC: "1234 567|8 wordword"
         ensure "g e", textC: "123|4 5678 wordword"

--- a/spec/motion-general-spec.coffee
+++ b/spec/motion-general-spec.coffee
@@ -501,236 +501,143 @@ describe "Motion general", ->
         it "change by G", ->  ensure "c G", textC: "000\n111\n|\n", register: {'"': text: "222\n"}, mode: 'insert'
 
   describe "the w keybinding", ->
-    baseText = """
-      ab cde1+-
-       xyz
-
-      zip
-      """
-    beforeEach ->
-      set text: baseText
-
     describe "as a motion", ->
-      beforeEach ->
-        set cursor: [0, 0]
-
       it "moves the cursor to the beginning of the next word", ->
-        ensure 'w', cursor: [0, 3]
-        ensure 'w', cursor: [0, 7]
-        ensure 'w', cursor: [1, 1]
-        ensure 'w', cursor: [2, 0]
-        ensure 'w', cursor: [3, 0]
-        ensure 'w', cursor: [3, 2]
-        # When the cursor gets to the EOF, it should stay there.
-        ensure 'w', cursor: [3, 2]
+        set         textC: "|ab cde1+-\n xyz\n\nzip"
+        ensure "w", textC: "ab |cde1+-\n xyz\n\nzip"
+        ensure "w", textC: "ab cde1|+-\n xyz\n\nzip"
+        ensure "w", textC: "ab cde1+-\n |xyz\n\nzip"
+        ensure "w", textC: "ab cde1+-\n xyz\n|\nzip"
+        ensure "w", textC: "ab cde1+-\n xyz\n\n|zip"
+        ensure "w", textC: "ab cde1+-\n xyz\n\nzi|p"
+        ensure "w", textC: "ab cde1+-\n xyz\n\nzi|p" # Do nothing at vimEOF
 
-      it "moves the cursor to the end of the word if last word in file", ->
-        set text: 'abc', cursor: [0, 0]
-        ensure 'w', cursor: [0, 2]
+      it "[CRLF] moves the cursor to the beginning of the next word", ->
+        set         textC: "|ab cde1+-\r\n xyz\r\n\r\nzip"
+        ensure "w", textC: "ab |cde1+-\r\n xyz\r\n\r\nzip"
+        ensure "w", textC: "ab cde1|+-\r\n xyz\r\n\r\nzip"
+        ensure "w", textC: "ab cde1+-\r\n |xyz\r\n\r\nzip"
+        ensure "w", textC: "ab cde1+-\r\n xyz\r\n|\r\nzip"
+        ensure "w", textC: "ab cde1+-\r\n xyz\r\n\r\n|zip"
+        ensure "w", textC: "ab cde1+-\r\n xyz\r\n\r\nzi|p"
+        ensure "w", textC: "ab cde1+-\r\n xyz\r\n\r\nzi|p" # Do nothing at vimEOF
 
       it "move to next word by skipping trailing white spaces", ->
-        set
-          textC_: """
-            012|___
-              234
-            """
-        ensure 'w',
-          textC_: """
-            012___
-              |234
-            """
+        set         textC: "012|   \n  234"
+        ensure "w", textC: "012   \n  |234"
 
       it "move to next word from EOL", ->
-        set
-          textC_: """
-            |
-            __234"
-            """
-        ensure 'w',
-          textC_: """
+        set         textC: "|\n  234"
+        ensure "w", textC: "\n  |234"
 
-            __|234"
-            """
+    describe "used as change TARGET", ->
+      it "[at-word] not eat whitespace", ->
+        set           textC: "v|ar1 = 1"
+        ensure 'c w', textC: "v = 1"
 
-      # [FIXME] improve spec to loop same section with different text
-      describe "for CRLF buffer", ->
-        beforeEach ->
-          set text: baseText.replace(/\n/g, "\r\n")
+      it "[at white-space] only eat white space", ->
+        set           textC: "|  var1 = 1"
+        ensure 'c w', textC: "var1 = 1"
 
-        describe "as a motion", ->
-          beforeEach ->
-            set cursor: [0, 0]
+      it "[at trailing whitespace] doesnt eat new line character", ->
+        set           textC: "abc|  \ndef"
+        ensure 'c w', textC: "abc|\ndef"
 
-          it "moves the cursor to the beginning of the next word", ->
-            ensure 'w', cursor: [0, 3]
-            ensure 'w', cursor: [0, 7]
-            ensure 'w', cursor: [1, 1]
-            ensure 'w', cursor: [2, 0]
-            ensure 'w', cursor: [3, 0]
-            ensure 'w', cursor: [3, 2]
-            # When the cursor gets to the EOF, it should stay there.
-            ensure 'w', cursor: [3, 2]
-
-    describe "when used by Change operator", ->
-      beforeEach ->
-        set
-          text_: """
-          __var1 = 1
-          __var2 = 2\n
-          """
-
-      describe "when cursor is on word", ->
-        it "not eat whitespace", ->
-          set cursor: [0, 3]
-          ensure 'c w',
-            text_: """
-            __v = 1
-            __var2 = 2\n
-            """
-            cursor: [0, 3]
-
-      describe "when cursor is on white space", ->
-        it "only eat white space", ->
-          set cursor: [0, 0]
-          ensure 'c w',
-            text_: """
-            var1 = 1
-            __var2 = 2\n
-            """
-            cursor: [0, 0]
-
-      describe "when text to EOL is all white space", ->
-        it "wont eat new line character", ->
-          set
-            text_: """
-            abc__
-            def\n
-            """
-            cursor: [0, 3]
-          ensure 'c w',
-            text: """
-            abc
-            def\n
-            """
-            cursor: [0, 3]
-
-        it "cant eat new line when count is specified", ->
-          set text: "\n\n\n\n\nline6\n", cursor: [0, 0]
-          ensure '5 c w', text: "\nline6\n", cursor: [0, 0]
+      it "[at trailing whitespace] eat new line when count is specified", ->
+        set             textC: "|\n\n\n\n\nline6\n"
+        ensure '5 c w', textC: "|\nline6\n"
 
     describe "as a selection", ->
-      describe "within a word", ->
-        it "selects to the end of the word", ->
-          set cursor: [0, 0]
-          ensure 'y w', register: '"': text: 'ab '
+      it "[within-word] selects to the end of the word", ->
+        set textC: "|ab cd"
+        ensure 'y w', register: '"': text: 'ab '
 
-      describe "between words", ->
-        it "selects the whitespace", ->
-          set cursor: [0, 2]
-          ensure 'y w', register: '"': text: ' '
+      it "[between-word] selects the whitespace", ->
+        set textC: "ab| cd"
+        ensure 'y w', register: '"': text: ' '
 
   describe "the W keybinding", ->
-    beforeEach ->
-      set text: "cde1+- ab \n xyz\n\nzip"
-
     describe "as a motion", ->
-      beforeEach ->
-        set cursor: [0, 0]
-
       it "moves the cursor to the beginning of the next word", ->
-        ensure 'W', cursor: [0, 7]
-        ensure 'W', cursor: [1, 1]
-        ensure 'W', cursor: [2, 0]
-        ensure 'W', cursor: [3, 0]
+        set         textC: "|cde1+- ab \n xyz\n\nzip"
+        ensure "W", textC: "cde1+- |ab \n xyz\n\nzip"
+        ensure "W", textC: "cde1+- ab \n |xyz\n\nzip"
+        ensure "W", textC: "cde1+- ab \n xyz\n|\nzip"
+        ensure "W", textC: "cde1+- ab \n xyz\n\n|zip"
+        ensure "W", textC: "cde1+- ab \n xyz\n\nzi|p"
+        ensure "W", textC: "cde1+- ab \n xyz\n\nzi|p" # Do nothing at vimEOF
 
-      it "moves the cursor to beginning of the next word of next line when all remaining text is white space.", ->
-        set
-          text_: """
-            012___
-            __234
-            """
-          cursor: [0, 3]
-        ensure 'W', cursor: [1, 2]
+      it "[at-trailing-WS] moves the cursor to beginning of the next word at next line", ->
+        set         textC: "012|   \n  234"
+        ensure 'W', textC: "012   \n  |234"
 
       it "moves the cursor to beginning of the next word of next line when cursor is at EOL.", ->
-        set
-          text_: """
-
-          __234
-          """
-          cursor: [0, 0]
-        ensure 'W', cursor: [1, 2]
+        set         textC: "|\n  234"
+        ensure 'W', textC: "\n  |234"
 
     # This spec is redundant since W(MoveToNextWholeWord) is child of w(MoveToNextWord).
-    describe "when used by Change operator", ->
-      beforeEach ->
-        set
-          text_: """
-            __var1 = 1
-            __var2 = 2\n
-            """
+    describe "used as change TARGET", ->
+      it "[at-word] not eat whitespace", ->
+        set           textC: "v|ar1 = 1"
+        ensure 'c W', textC: "v| = 1"
 
-      describe "when cursor is on word", ->
-        it "not eat whitespace", ->
-          set cursor: [0, 3]
-          ensure 'c W',
-            text_: """
-              __v = 1
-              __var2 = 2\n
-              """
-            cursor: [0, 3]
+      it "[at-WS] only eat white space", ->
+        set           textC: "|  var1 = 1"
+        ensure 'c W', textC: "var1 = 1"
 
-      describe "when cursor is on white space", ->
-        it "only eat white space", ->
-          set cursor: [0, 0]
-          ensure 'c W',
-            text_: """
-              var1 = 1
-              __var2 = 2\n
-              """
-            cursor: [0, 0]
+      it "[at-trailing-WS] doesn't eat new line character", ->
+        set           textC: "abc|  \ndef\n"
+        ensure 'c W', textC: "abc|\ndef\n"
 
-      describe "when text to EOL is all white space", ->
-        it "wont eat new line character", ->
-          set text: "abc  \ndef\n", cursor: [0, 3]
-          ensure 'c W', text: "abc\ndef\n", cursor: [0, 3]
+      it "can eat new line when count is specified", ->
+        set             textC: "|\n\n\n\n\nline6\n"
+        ensure '5 c W', textC: "|\nline6\n"
 
-        it "cant eat new line when count is specified", ->
-          set text: "\n\n\n\n\nline6\n", cursor: [0, 0]
-          ensure '5 c W', text: "\nline6\n", cursor: [0, 0]
+    describe "as a TARGET", ->
+      it "[at-word] yank", ->
+        set textC: "|cde1+- ab"
+        ensure 'y W', register: '"': text: 'cde1+- '
 
-    describe "as a selection", ->
-      describe "within a word", ->
-        it "selects to the end of the whole word", ->
-          set cursor: [0, 0]
-          ensure 'y W', register: '"': text: 'cde1+- '
+      it "delete new line", ->
+        set           textC: "cde1+- ab \n xyz\n|\nzip"
+        ensure 'd W', textC: "cde1+- ab \n xyz\n|zip", register: {'"': text: "\n"}
 
-      it "continues past blank lines", ->
-        set cursor: [2, 0]
-        ensure 'd W',
-          text_: """
-          cde1+- ab_
-          _xyz
-          zip
-          """
-          register: '"': text: "\n"
-
-      it "doesn't go past the end of the file", ->
-        set cursor: [3, 0]
-        ensure 'd W',
-          text_: """
-          cde1+- ab_
-          _xyz\n\n
-          """
-          register: '"': text: 'zip'
+      it "delete last word in buffer and adjut cursor row to not past vimLastRow", ->
+        set           textC: "cde1+- ab \n xyz\n\n|zip"
+        ensure 'd W', textC: "cde1+- ab \n xyz\n|\n", register: {'"': text: "zip"}
 
   describe "the e keybinding", ->
+    describe "as a motion", ->
+      it "moves the cursor to the end of the current word", ->
+        set         textC_: "|ab cde1+-_\n_xyz\n\nzip"
+        ensure 'e', textC_: "a|b cde1+-_\n_xyz\n\nzip"
+        ensure 'e', textC_: "ab cde|1+-_\n_xyz\n\nzip"
+        ensure 'e', textC_: "ab cde1+|-_\n_xyz\n\nzip"
+        ensure 'e', textC_: "ab cde1+-_\n_xy|z\n\nzip"
+        ensure 'e', textC_: "ab cde1+-_\n_xyz\n\nzi|p"
+
+      it "skips whitespace until EOF", ->
+        set         textC: "|012\n\n\n012\n\n"
+        ensure 'e', textC: "01|2\n\n\n012\n\n"
+        ensure 'e', textC: "012\n\n\n01|2\n\n"
+        ensure 'e', textC: "012\n\n\n012\n|\n"
+
+    describe "as selection", ->
+      it "[in-word] selects to the end of the current word", ->
+        set textC_: "|ab cde1+-_"
+        ensure 'y e', register: '"': text: 'ab'
+
+      it "[between-word] selects to the end of the next word", ->
+        set textC_: "ab| cde1+-_"
+        ensure 'y e', register: '"': text: ' cde1'
+
+  describe "the E keybinding", ->
     beforeEach ->
       set text_: """
-      ab cde1+-_
-      _xyz
+      ab  cde1+-_
+      _xyz_
 
-      zip
+      zip\n
       """
 
     describe "as a motion", ->
@@ -738,34 +645,31 @@ describe "Motion general", ->
         set cursor: [0, 0]
 
       it "moves the cursor to the end of the current word", ->
-        ensure 'e', cursor: [0, 1]
-        ensure 'e', cursor: [0, 6]
-        ensure 'e', cursor: [0, 8]
-        ensure 'e', cursor: [1, 3]
-        ensure 'e', cursor: [3, 2]
-
-      it "skips whitespace until EOF", ->
-        set
-          text: "012\n\n\n012\n\n"
-          cursor: [0, 0]
-        ensure 'e', cursor: [0, 2]
-        ensure 'e', cursor: [3, 2]
-        ensure 'e', cursor: [4, 0]
+        ensure 'E', cursor: [0, 1]
+        ensure 'E', cursor: [0, 9]
+        ensure 'E', cursor: [1, 3]
+        ensure 'E', cursor: [3, 2]
+        ensure 'E', cursor: [3, 2]
 
     describe "as selection", ->
       describe "within a word", ->
         it "selects to the end of the current word", ->
           set cursor: [0, 0]
-          ensure 'y e', register: '"': text: 'ab'
+          ensure 'y E', register: '"': text: 'ab'
 
       describe "between words", ->
         it "selects to the end of the next word", ->
           set cursor: [0, 2]
-          ensure 'y e', register: '"': text: ' cde1'
+          ensure 'y E', register: '"': text: '  cde1+-'
+
+      describe "press more than once", ->
+        it "selects to the end of the current word", ->
+          set cursor: [0, 0]
+          ensure 'v E E y', register: '"': text: 'ab  cde1+-'
 
   describe "the ge keybinding", ->
     describe "as a motion", ->
-      it "moves the cursor to the end of the previous word", ->
+      fit "moves the cursor to the end of the previous word", ->
         set           textC: "1234 5678 wordwo|rd"
         ensure "g e", textC: "1234 567|8 wordword"
         ensure "g e", textC: "123|4 5678 wordword"
@@ -809,42 +713,6 @@ describe "Motion general", ->
       it "selects word fragments", ->
         set text: "cet document", cursor: [0, 7]
         ensure 'v g e', cursor: [0, 2], selectedText: "t docu"
-
-  describe "the E keybinding", ->
-    beforeEach ->
-      set text_: """
-      ab  cde1+-_
-      _xyz_
-
-      zip\n
-      """
-
-    describe "as a motion", ->
-      beforeEach ->
-        set cursor: [0, 0]
-
-      it "moves the cursor to the end of the current word", ->
-        ensure 'E', cursor: [0, 1]
-        ensure 'E', cursor: [0, 9]
-        ensure 'E', cursor: [1, 3]
-        ensure 'E', cursor: [3, 2]
-        ensure 'E', cursor: [3, 2]
-
-    describe "as selection", ->
-      describe "within a word", ->
-        it "selects to the end of the current word", ->
-          set cursor: [0, 0]
-          ensure 'y E', register: '"': text: 'ab'
-
-      describe "between words", ->
-        it "selects to the end of the next word", ->
-          set cursor: [0, 2]
-          ensure 'y E', register: '"': text: '  cde1+-'
-
-      describe "press more than once", ->
-        it "selects to the end of the current word", ->
-          set cursor: [0, 0]
-          ensure 'v E E y', register: '"': text: 'ab  cde1+-'
 
   describe "the gE keybinding", ->
     describe "as a motion", ->


### PR DESCRIPTION
In atom-v1.23.0-beta, many word-motion family broken.
Ultimate cause of why broken is it depends on atom's word motion commands.

- e.g. `cursor.getBeginningOfCurrentWordBufferPosition`.

But these commands are [optimized](https://github.com/atom/atom/pull/15776).
And some command no longer continue to find till [0, 0] or EOF.
It's OK, vmp should NOT use these method for different purpose.

This PR is to make vmp's word-motion robust, independent from atom's cursor command so that no longer be broken in future update of Atom.

# Done

Most work is done by `utils.findWord` utility function.
Which doesn't use native cursor's method, it just search buffer to find regex match.
So less chances to be broken on future update of Atom-core 🍻 