### PR TITLE
VimState.requestScroll: Scroll by pixels instead of lines, e.g. for inline images

### DIFF
--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -419,29 +419,27 @@ module.exports = class VimState {
       this.scrollRequest = null
     }
 
-    let scrollFrom, scrollTo
+    // Translate amountOfScreenRows into scrollTop so that we scroll by pixels instead of lines
+    //  - This is important so we play nicely with inline images (e.g. from hydrogen or
+    //    inline-markdown-images), otherwise we'd "jump" over an image as if it was one line, which
+    //    is very disorienting (e.g. when using ^E/^Y or ^U/^D)
     if (amountOfScreenRows != null) {
-      const fromRow = this.editor.getFirstVisibleScreenRow()
-      const toRow = fromRow + amountOfScreenRows
-
-      if (!duration) {
-        this.editor.setFirstVisibleScreenRow(toRow)
-        if (onFinish) onFinish()
-        return
-      }
-
-      const getPixelRectTopForRow = row => this.editorElement.pixelRectForScreenRange([[row, 0], [row, 0]]).top
-      scrollFrom = {top: getPixelRectTopForRow(fromRow)}
-      scrollTo = {top: getPixelRectTopForRow(toRow)}
-    } else {
-      if (!duration) {
-        this.editorElement.setScrollTop(scrollTop)
-        if (onFinish) onFinish()
-        return
-      }
-      scrollFrom = {top: this.editorElement.getScrollTop()}
-      scrollTo = {top: scrollTop}
+      this.requestScroll({
+        scrollTop: this.editorElement.getScrollTop() + amountOfScreenRows * this.editor.lineHeightInPixels,
+        duration,
+        onFinish,
+      })
+      return
     }
+
+    if (!duration) {
+      this.editorElement.setScrollTop(scrollTop)
+      if (onFinish) onFinish()
+      return
+    }
+
+    const scrollFrom = {top: this.editorElement.getScrollTop()}
+    const scrollTo = {top: scrollTop}
 
     if (!jQuery) jQuery = require("atom-space-pen-views").jQuery
     this.scrollRequest = jQuery(scrollFrom).animate(scrollTo, {

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -424,12 +424,7 @@ module.exports = class VimState {
     //    inline-markdown-images), otherwise we'd "jump" over an image as if it was one line, which
     //    is very disorienting (e.g. when using ^E/^Y or ^U/^D)
     if (amountOfScreenRows != null) {
-      this.requestScroll({
-        scrollTop: this.editorElement.getScrollTop() + amountOfScreenRows * this.editor.lineHeightInPixels,
-        duration,
-        onFinish,
-      })
-      return
+      scrollTop = this.editorElement.getScrollTop() + amountOfScreenRows * this.editor.lineHeightInPixels
     }
 
     if (!duration) {
@@ -437,7 +432,6 @@ module.exports = class VimState {
       if (onFinish) onFinish()
       return
     }
-
     const scrollFrom = {top: this.editorElement.getScrollTop()}
     const scrollTo = {top: scrollTop}
 


### PR DESCRIPTION
- Problem: scrolling by lines (e.g. ^E/^Y, ^D/^U) with inline images (e.g. using hydrogen or inline-markdown-images) "jumps" over the images as if they're one line, which is very disorienting
- Solution: scroll by pixels instead of lines, calculated from `editor.lineHeightInPixels`