### PR TITLE
Improve scroll motion

### DIFF
--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -271,6 +271,7 @@ class MiniScrollDown extends MiscCommand {
   }
 
   execute() {
+    // FIXME
     this.vimState.requestScroll({
       amountOfScreenRows: this.direction === "down" ? this.getCount() : -this.getCount(),
       duration: this.getSmoothScrollDuation("MiniScroll"),

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -271,7 +271,6 @@ class MiniScrollDown extends MiscCommand {
   }
 
   execute() {
-    const amountOfPixels = (this.direction === "down" ? 1 : -1) * this.getCount() * this.editor.getLineHeightInPixels()
     this.vimState.requestScroll({
       amountOfPixels: (this.direction === "down" ? 1 : -1) * this.getCount() * this.editor.getLineHeightInPixels(),
       duration: this.getSmoothScrollDuation("MiniScroll"),

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -271,9 +271,9 @@ class MiniScrollDown extends MiscCommand {
   }
 
   execute() {
-    // FIXME
+    const amountOfPixels = (this.direction === "down" ? 1 : -1) * this.getCount() * this.editor.getLineHeightInPixels()
     this.vimState.requestScroll({
-      amountOfScreenRows: this.direction === "down" ? this.getCount() : -this.getCount(),
+      amountOfPixels: (this.direction === "down" ? 1 : -1) * this.getCount() * this.editor.getLineHeightInPixels(),
       duration: this.getSmoothScrollDuation("MiniScroll"),
       onFinish: () => this.keepCursorOnScreen(),
     })
@@ -300,13 +300,15 @@ class RedrawCursorLine extends MiscCommand {
 
   execute() {
     const scrollTop = Math.round(this.getScrollTop())
-    const onFinish = () => {
-      if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
-        this.recommendToEnableScrollPastEnd()
-      }
-    }
-    const duration = this.getSmoothScrollDuation("RedrawCursorLine")
-    this.vimState.requestScroll({scrollTop, duration, onFinish})
+    this.vimState.requestScroll({
+      scrollTop: scrollTop,
+      duration: this.getSmoothScrollDuation("RedrawCursorLine"),
+      onFinish: () => {
+        if (this.editorElement.getScrollTop() !== scrollTop && !this.editor.getScrollPastEnd()) {
+          this.recommendToEnableScrollPastEnd()
+        }
+      },
+    })
     if (this.moveToFirstCharacterOfLine) this.editor.moveToFirstCharacterOfLine()
   }
 

--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -295,7 +295,19 @@ class MiniScrollUp extends MiniScrollDown {
 // +-------------------------------------------+
 class RedrawCursorLine extends MiscCommand {
   static command = false
-  moveToFirstCharacterOfLine = false
+  static coefficientByName = {
+    RedrawCursorLineAtTop: 0,
+    RedrawCursorLineAtUpperMiddle: 0.25,
+    RedrawCursorLineAtMiddle: 0.5,
+    RedrawCursorLineAtBottom: 1,
+  }
+
+  initialize() {
+    const baseName = this.name.replace(/AndMoveToFirstCharacterOfLine$/, "")
+    this.coefficient = this.constructor.coefficientByName[baseName]
+    this.moveToFirstCharacterOfLine = this.name.endsWith("AndMoveToFirstCharacterOfLine")
+    super.initialize()
+  }
 
   execute() {
     const scrollTop = Math.round(this.getScrollTop())
@@ -315,6 +327,7 @@ class RedrawCursorLine extends MiscCommand {
     const {top} = this.editorElement.pixelPositionForScreenPosition(this.editor.getCursorScreenPosition())
     const editorHeight = this.editorElement.getHeight()
     const lineHeightInPixel = this.editor.getLineHeightInPixels()
+
     return this.utils.limitNumber(top - editorHeight * this.coefficient, {
       min: top - editorHeight + lineHeightInPixel * 3,
       max: top - lineHeightInPixel * 2,
@@ -348,49 +361,14 @@ class RedrawCursorLine extends MiscCommand {
   }
 }
 
-// top: zt
-class RedrawCursorLineAtTop extends RedrawCursorLine {
-  coefficient = 0
-}
-
-// top: z enter
-class RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
-  coefficient = 0
-  moveToFirstCharacterOfLine = true
-}
-
-// upper-middle: zu
-class RedrawCursorLineAtUpperMiddle extends RedrawCursorLine {
-  coefficient = 0.25
-}
-
-// upper-middle: z space
-class RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
-  coefficient = 0.25
-  moveToFirstCharacterOfLine = true
-}
-
-// middle: zz
-class RedrawCursorLineAtMiddle extends RedrawCursorLine {
-  coefficient = 0.5
-}
-
-// middle: z.
-class RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
-  coefficient = 0.5
-  moveToFirstCharacterOfLine = true
-}
-
-// bottom: zb
-class RedrawCursorLineAtBottom extends RedrawCursorLine {
-  coefficient = 1
-}
-
-// bottom: z-
-class RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine extends RedrawCursorLine {
-  coefficient = 1
-  moveToFirstCharacterOfLine = true
-}
+class RedrawCursorLineAtTop extends RedrawCursorLine {} // zt
+class RedrawCursorLineAtTopAndMoveToFirstCharacterOfLine extends RedrawCursorLine {} // z enter
+class RedrawCursorLineAtUpperMiddle extends RedrawCursorLine {} // zu
+class RedrawCursorLineAtUpperMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {} // z space
+class RedrawCursorLineAtMiddle extends RedrawCursorLine {} // z z
+class RedrawCursorLineAtMiddleAndMoveToFirstCharacterOfLine extends RedrawCursorLine {} // z .
+class RedrawCursorLineAtBottom extends RedrawCursorLine {} // z b
+class RedrawCursorLineAtBottomAndMoveToFirstCharacterOfLine extends RedrawCursorLine {} // z -
 
 // Horizontal Scroll without changing cursor position
 // -------------------------

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -779,19 +779,22 @@ class Scroll extends Motion {
 
   execute() {
     const amountOfPage = this.constructor.amountOfPageByName[this.name]
-    this.amountOfRowsToScroll = Math.trunc(amountOfPage * this.editor.getRowsPerPage() * this.getCount())
+    const amountOfScreenRows = Math.trunc(amountOfPage * this.editor.getRowsPerPage() * this.getCount())
+    this.amountOfPixels = amountOfScreenRows * this.editor.getLineHeightInPixels()
 
     super.execute()
 
-    // FIXME
     this.vimState.requestScroll({
-      amountOfScreenRows: this.amountOfRowsToScroll,
-      duration: this.getSmoothScrollDuation((Math.abs(amountOfPage) === 1 ? "Full" : "Half") + "ScrollMotion"),
+      amountOfPixels: this.amountOfPixels,
+      duration: this.getSmoothScrollDuation((this.name.startsWith("ScrollFull") ? "Full" : "Half") + "ScrollMotion"),
     })
   }
 
   moveCursor(cursor) {
-    const screenRow = this.getValidVimScreenRow(cursor.getScreenRow() + this.amountOfRowsToScroll)
+    const cursorPixel = this.editorElement.pixelPositionForScreenPosition(cursor.getScreenPosition())
+    cursorPixel.top += this.amountOfPixels
+    const screenPosition = this.editorElement.screenPositionForPixelPosition(cursorPixel)
+    const screenRow = this.getValidVimScreenRow(screenPosition.row)
     this.setCursorBufferRow(cursor, this.editor.bufferRowForScreenRow(screenRow), {autoscroll: false})
   }
 }

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -783,6 +783,7 @@ class Scroll extends Motion {
 
     super.execute()
 
+    // FIXME
     this.vimState.requestScroll({
       amountOfScreenRows: this.amountOfRowsToScroll,
       duration: this.getSmoothScrollDuation((Math.abs(amountOfPage) === 1 ? "Full" : "Half") + "ScrollMotion"),

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -786,7 +786,7 @@ class Scroll extends Motion {
 
     this.vimState.requestScroll({
       amountOfPixels: this.amountOfPixels,
-      duration: this.getSmoothScrollDuation((this.name.startsWith("ScrollFull") ? "Full" : "Half") + "ScrollMotion"),
+      duration: this.getSmoothScrollDuation((Math.abs(amountOfPage) === 1 ? "Full" : "Half") + "ScrollMotion"),
     })
   }
 

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -461,7 +461,6 @@ module.exports = class VimState {
         }
       },
       done: () => {
-        console.log("Called DONE!")
         this.scrollRequest = null
         if (this.editor.element.component) this.editor.element.component.updateSync()
         if (onFinish) onFinish()

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -412,19 +412,29 @@ module.exports = class VimState {
     if (this.__persistentSelection) this.persistentSelection.clearMarkers()
   }
 
-  requestScroll({amountOfScreenRows, scrollTop, duration, onFinish}) {
-    // Finalize previous scroll request first
+  // It's possible that multiple scroll request comes in sequentially.
+  //
+  // When you pass `amountOfPixels`, it calculate final scrollTop based on
+  // prevoiusly requested scrollTop. In other word. animation is concatnated to
+  // scroll smoothly in sequential request.
+  //
+  // When you pass `scrollTop`, it's absolute value, just use passed scrollTop.
+  // So passed scrollTop should not be based on **relative** scrollTop, because it's might not finalized.
+  // - OK: {scrollTop: cursor.pixelPositionForScreenPosition(point) + pixels}
+  // - NG: {scrollTop: editorElement.getScrollTop() + pixels}
+  // - Hacky but should be OK: {scrollTop: vimState.scrollRequest.scrollTop + pixels}
+  requestScroll({amountOfPixels, scrollTop, duration, onFinish}) {
+    const currentScrollTop = this.editorElement.getScrollTop()
+    let baseScrollTop = currentScrollTop
+
     if (this.scrollRequest) {
-      this.scrollRequest.finish()
+      this.scrollRequest.request.stop()
+      baseScrollTop = this.scrollRequest.scrollTop
       this.scrollRequest = null
     }
 
-    // Translate amountOfScreenRows into scrollTop so that we scroll by pixels instead of lines
-    //  - This is important so we play nicely with inline images (e.g. from hydrogen or
-    //    inline-markdown-images), otherwise we'd "jump" over an image as if it was one line, which
-    //    is very disorienting (e.g. when using ^E/^Y or ^U/^D)
-    if (amountOfScreenRows != null) {
-      scrollTop = this.editorElement.getScrollTop() + amountOfScreenRows * this.editor.lineHeightInPixels
+    if (amountOfPixels) {
+      scrollTop = baseScrollTop + amountOfPixels
     }
 
     if (!duration) {
@@ -432,11 +442,14 @@ module.exports = class VimState {
       if (onFinish) onFinish()
       return
     }
-    const scrollFrom = {top: this.editorElement.getScrollTop()}
+
+    const scrollFrom = {top: currentScrollTop}
     const scrollTo = {top: scrollTop}
 
     if (!jQuery) jQuery = require("atom-space-pen-views").jQuery
-    this.scrollRequest = jQuery(scrollFrom).animate(scrollTo, {
+
+    this.scrollRequest = {scrollTop}
+    this.scrollRequest.request = jQuery(scrollFrom).animate(scrollTo, {
       duration: duration,
       step: newTop => {
         // [NOTE]
@@ -448,6 +461,7 @@ module.exports = class VimState {
         }
       },
       done: () => {
+        console.log("Called DONE!")
         this.scrollRequest = null
         if (this.editor.element.component) this.editor.element.component.updateSync()
         if (onFinish) onFinish()


### PR DESCRIPTION
After merging #957, all command that user `vimState.requestScroll` get wrong in editor which have inline image(block decoration).

- `ctrl-f, b, d, u` should move cursor based on pixel, instead of screen rows to sync coordinate with pixel-based-scroll.

- And this PR include tune for smoother UX on sequential scroll request :tada:.
