### PR TITLE
Better reword the warning when installing the package

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -57,8 +57,8 @@ class Settings {
       const message = [
         this.scope,
         "- From vmp-v.1.9.0 all operations are defined as ES6 class which is NOT extend-able by CoffeeScript.",
-        "- If you have vmp custom operations in your `init.coffee`. Those are no longer work(You might saw error already).",
-        "- Sorry for not providing gradual migration path, I couldn't find the way and also I'm lazy.",
+        "- If you have vmp custom operations in your `init.coffee`, those are no longer working (you might have already seen the error).",
+        "- Sorry for not providing a gradual migration path. I couldn't find a way and I'm also lazy.",
         "- See [CHANGELOG](https://github.com/t9md/atom-vim-mode-plus/blob/master/CHANGELOG.md) and [Wiki](https://github.com/t9md/atom-vim-mode-plus/wiki/ExtendVimModePlusInInitFile) for detail.",
       ].join("\n")
       atom.notifications.addInfo(message, {dismissable: true})


### PR DESCRIPTION
Hey there!

I normally use Atom, but I'm trying to learn vim. A friend suggested me the `vim-mode` package and I decided to install it. I got a notification message and I couldn't help to notice some small English mistakes in it.

I hope this helps a little bit.