### PR TITLE
Move migration warning for "Coffee to JS based extension" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ vim-mode improved.
 - [Installation](#installation)
 - [Some Features](#some-features)
 - [Important](#important)
+    - [**vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus**.](#vim-mode-plus-is-replacement-for-vim-mode-you-must-disable-vim-mode-first-to-use-vim-mode-plus)
+    - [From v1.9.0 CoffeeScript based vmp-extension is no longer supported](#from-v190-coffeescript-based-vmp-extension-is-no-longer-supported)
 - [Thanks](#thanks)
 - [Issue report](#issue-report)
 - [Whats this?](#whats-this)
@@ -43,12 +45,19 @@ These features are very powerful, especially for the power user. Read the follow
 
 # Important
 
-- **vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus**.
+### **vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus**.
+
 - You don't need the following packages since they're built-in to vim-mode-plus:
   - [vim-surround](https://atom.io/packages/vim-surround): No default keymap. See FAQ section in this doc.
   - [vim-mode-visual-block](https://atom.io/packages/vim-mode-visual-block)
 - Scope for CSS selector and keymap is different from vim-mode, **not compatible**.
 - Internal code base is very different. Thus, issues and PRs should be directly sent to vim-mode-plus. **DON'T report vim-mode-plus's issues or PRs to the official vim-mode.**
+
+### From v1.9.0 CoffeeScript based vmp-extension is no longer supported
+
+- Now all operations are defined as ES6 class which is NOT extend-able by CoffeeScript.
+  - If you have vmp custom operations in your `init.coffee`, those are no longer working.
+  - See [CHANGELOG](https://github.com/t9md/atom-vim-mode-plus/blob/master/CHANGELOG.md) and [Wiki](https://github.com/t9md/atom-vim-mode-plus/wiki/ExtendVimModePlusInInitFile) for detail.
 
 # Thanks
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ vim-mode improved.
 - [Installation](#installation)
 - [Some Features](#some-features)
 - [Important](#important)
-    - [vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus](#vim-mode-plus-is-replacement-for-vim-mode-you-must-disable-vim-mode-first-to-use-vim-mode-plus)
-    - [From v1.9.0 CoffeeScript based vmp-extension is no longer supported](#from-v190-coffeescript-based-vmp-extension-is-no-longer-supported)
+    - [You must disable vim-mode to use vim-mode-plus](#you-must-disable-vim-mode-to-use-vim-mode-plus)
+    - [From v1.9.0 CoffeeScript based vim-mode-plus extension is no longer supported](#from-v190-coffeescript-based-vim-mode-plus-extension-is-no-longer-supported)
 - [Thanks](#thanks)
 - [Issue report](#issue-report)
 - [Whats this?](#whats-this)
@@ -45,7 +45,7 @@ These features are very powerful, especially for the power user. Read the follow
 
 # Important
 
-### vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus
+### You must disable vim-mode to use vim-mode-plus
 
 - You don't need the following packages since they're built-in to vim-mode-plus:
   - [vim-surround](https://atom.io/packages/vim-surround): No default keymap. See FAQ section in this doc.
@@ -53,7 +53,7 @@ These features are very powerful, especially for the power user. Read the follow
 - Scope for CSS selector and keymap is different from vim-mode, **not compatible**.
 - Internal code base is very different. Thus, issues and PRs should be directly sent to vim-mode-plus. **DON'T report vim-mode-plus's issues or PRs to the official vim-mode.**
 
-### From v1.9.0 CoffeeScript based vmp-extension is no longer supported
+### From v1.9.0 CoffeeScript based vim-mode-plus extension is no longer supported
 
 - Now all operations are defined as ES6 class which is NOT extend-able by CoffeeScript.
   - If you have vmp custom operations in your `init.coffee`, those are no longer working.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ vim-mode improved.
 - [Installation](#installation)
 - [Some Features](#some-features)
 - [Important](#important)
-    - [**vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus**.](#vim-mode-plus-is-replacement-for-vim-mode-you-must-disable-vim-mode-first-to-use-vim-mode-plus)
+    - [vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus](#vim-mode-plus-is-replacement-for-vim-mode-you-must-disable-vim-mode-first-to-use-vim-mode-plus)
     - [From v1.9.0 CoffeeScript based vmp-extension is no longer supported](#from-v190-coffeescript-based-vmp-extension-is-no-longer-supported)
 - [Thanks](#thanks)
 - [Issue report](#issue-report)
@@ -45,7 +45,7 @@ These features are very powerful, especially for the power user. Read the follow
 
 # Important
 
-### **vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus**.
+### vim-mode-plus is replacement for vim-mode, you must disable vim-mode first to use vim-mode-plus
 
 - You don't need the following packages since they're built-in to vim-mode-plus:
   - [vim-surround](https://atom.io/packages/vim-surround): No default keymap. See FAQ section in this doc.

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,8 +9,7 @@ module.exports = {
 
   activate() {
     this.emitter = new Emitter()
-    settings.notifyDeprecatedParams()
-    settings.notifyCoffeeScriptNoLongerSupportedToExtendVMP()
+    settings.silentlyRemoveUnusedParams()
     settings.migrateRenamedParams()
 
     if (atom.inSpecMode()) settings.set("strictAssertion", true)

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -7,7 +7,8 @@ function inferType(value) {
   if (typeof value === "string") return "string"
 }
 
-const DEPRECATED_PARAMS = ["showCursorInVisualMode"]
+const DEPRECATED_PARAMS = []
+const FORCE_DELETE_PARAMS = ["showCursorInVisualMode", "notifiedCoffeeScriptNoLongerSupportedToExtendVMP"]
 
 function invertValue(value) {
   return !value
@@ -49,6 +50,12 @@ class Settings {
         },
       ],
     })
+  }
+
+  silentlyRemoveUnusedParams() {
+    for (const param of FORCE_DELETE_PARAMS) {
+      this.delete(param)
+    }
   }
 
   notifyCoffeeScriptNoLongerSupportedToExtendVMP() {


### PR DESCRIPTION
Vmp have been warning for CoffeeScript to ES6 migration for a month.

When I got PR #964  by @filipewl, I noticed this warning is also displayed to user who **newly installed vmp pkg**.

This warning should be displayed for upgraded user only, but Atom doesn't provide the way to distinguish upgrade/install(I haven't investigate deeply though).

Anyway  my solution is just remove non-perfect warning, and move it to README.
I believe most of user already have migrated to JS based extension if they have it.