### PR TITLE
tryout to make text-object "function" correctly detect multiline-args function

### DIFF
--- a/lib/misc-command.js
+++ b/lib/misc-command.js
@@ -145,11 +145,12 @@ class FoldCurrentRowRecursivelyBase extends MiscCommand {
     for (const {row} of this.getCursorBufferPositionsOrdered().reverse()) {
       if (!this.editor.isFoldableAtBufferRow(row)) continue
 
-      this.utils
-        .getFoldRowRangesContainedByFoldStartsAtRow(this.editor, row)
-        .map(rowRange => rowRange[0]) // mapt to startRow of fold
-        .reverse() // reverse to process encolosed(nested) fold first than encolosing fold.
-        .forEach(fn)
+      const foldRanges = this.utils.getCodeFoldRanges(this.editor)
+      const enclosingFoldRange = foldRanges.find(range => range.start.row === row)
+      const enclosedFoldRanges = foldRanges.filter(range => enclosingFoldRange.containsRange(range))
+
+      // Why reverse() is to process encolosed(nested) fold first than encolosing fold.
+      enclosedFoldRanges.reverse().forEach(range => fn(range.start.row))
     }
   }
 
@@ -205,9 +206,9 @@ class FoldAll extends MiscCommand {
     if (!allFold) return
 
     this.editor.unfoldAll()
-    for (const {indent, startRow, endRow} of allFold.rowRangesWithIndent) {
+    for (const {indent, range} of allFold.listOfRangeAndIndent) {
       if (indent <= this.getConfig("maxFoldableIndentLevel")) {
-        this.editor.foldBufferRowRange(startRow, endRow)
+        this.editor.foldBufferRange(range)
       }
     }
     this.editor.scrollToCursorPosition({center: true})
@@ -219,11 +220,11 @@ class UnfoldNextIndentLevel extends MiscCommand {
   execute() {
     const {folded} = this.utils.getFoldInfoByKind(this.editor)
     if (!folded) return
-    const {minIndent, rowRangesWithIndent} = folded
+    const {minIndent, listOfRangeAndIndent} = folded
     const targetIndents = this.utils.getList(minIndent, minIndent + this.getCount() - 1)
-    for (const {indent, startRow} of rowRangesWithIndent) {
+    for (const {indent, range} of listOfRangeAndIndent) {
       if (targetIndents.includes(indent)) {
-        this.editor.unfoldBufferRow(startRow)
+        this.editor.unfoldBufferRow(range.start.row)
       }
     }
   }
@@ -245,9 +246,9 @@ class FoldNextIndentLevel extends MiscCommand {
     let fromLevel = Math.min(unfolded.maxIndent, maxFoldable)
     fromLevel = this.limitNumber(fromLevel - this.getCount() - 1, {min: 0})
     const targetIndents = this.utils.getList(fromLevel, maxFoldable)
-    for (const {indent, startRow, endRow} of allFold.rowRangesWithIndent) {
+    for (const {indent, range} of allFold.listOfRangeAndIndent) {
       if (targetIndents.includes(indent)) {
-        this.editor.foldBufferRowRange(startRow, endRow)
+        this.editor.foldBufferRange(range)
       }
     }
   }

--- a/lib/motion.js
+++ b/lib/motion.js
@@ -1031,20 +1031,18 @@ class MoveToPreviousFoldStart extends Motion {
   direction = "previous"
 
   execute() {
-    this.rows = this.getFoldRows(this.which)
+    const foldRanges = this.utils.getCodeFoldRanges(this.editor)
+    this.rows = foldRanges.map(range => range[this.which].row).sort((a, b) => a - b)
     if (this.direction === "previous") this.rows.reverse()
     super.execute()
   }
 
-  getFoldRows(which) {
-    const foldRanges = this.utils.getCodeFoldRowRanges(this.editor)
-    return foldRanges.map(rowRange => rowRange[which === "start" ? 0 : 1]).sort((a, b) => a - b)
-  }
-
   getScanRows(cursor) {
-    const cursorRow = cursor.getBufferRow()
-    const isVald = this.direction === "previous" ? row => row < cursorRow : row => row > cursorRow
-    return this.rows.filter(isVald)
+    if (this.direction === "previous") {
+      return this.rows.filter(row => row < cursor.getBufferRow())
+    } else {
+      return this.rows.filter(row => row > cursor.getBufferRow())
+    }
   }
 
   detectRow(cursor) {

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -460,40 +460,66 @@ class CommentOrParagraph extends TextObject {
 class Fold extends TextObject {
   wise = "linewise"
 
-  adjustRowRange(rowRange) {
-    if (this.isA()) return rowRange
-
-    let [startRow, endRow] = rowRange
-    if (this.editor.indentationForBufferRow(startRow) === this.editor.indentationForBufferRow(endRow)) {
-      endRow -= 1
-    }
-    startRow += 1
-    return [startRow, endRow]
-  }
-
-  getFoldRowRangesContainsForRow(row) {
-    return this.utils.getCodeFoldRowRangesContainesForRow(this.editor, row).reverse()
-  }
-
   getRange(selection) {
     const {row} = this.getCursorPositionForSelection(selection)
     const selectedRange = selection.getBufferRange()
-    for (const rowRange of this.getFoldRowRangesContainsForRow(row)) {
-      const range = this.getBufferRangeForRowRange(this.adjustRowRange(rowRange))
-
-      // Don't change to `if range.containsRange(selectedRange, true)`
-      // There is behavior diff when cursor is at beginning of line( column 0 ).
+    const foldRanges = this.utils.getCodeFoldRangesContainesRow(this.editor, row).reverse()
+    for (const foldRange of foldRanges) {
+      const {start, end} = this.adjustRange(foldRange)
+      const range = this.getBufferRangeForRowRange([start.row, end.row])
       if (!selectedRange.containsRange(range)) return range
     }
+  }
+
+  adjustRange(range) {
+    if (this.isA()) return range
+    if (this.editor.indentationForBufferRow(range.start.row) === this.editor.indentationForBufferRow(range.end.row)) {
+      range.end.row -= 1
+    }
+    range.start.row += 1
+    return range
   }
 }
 
 // NOTE: Function range determination is depending on fold.
-class Function extends Fold {
+class Function extends TextObject {
+  wise = "linewise"
   // Some language don't include closing `}` into fold.
   scopeNamesOmittingEndRow = ["source.go", "source.elixir"]
 
-  isGrammarNotFoldEndRow() {
+  getRange(selection) {
+    const {row} = this.getCursorPositionForSelection(selection)
+    const selectedRange = selection.getBufferRange()
+
+    const functionFoldRanges = this.utils
+      .getCodeFoldRangesContainesRow(this.editor, row)
+      .reverse()
+      .filter(range => this.utils.isIncludeFunctionScopeForRow(this.editor, range.start.row))
+
+    for (const foldRange of functionFoldRanges) {
+      const {start, end} = this.adjustRange(foldRange)
+      const range = this.getBufferRangeForRowRange([start.row, end.row])
+      if (!selectedRange.containsRange(range)) return range
+    }
+  }
+
+  adjustRange(range) {
+    const {start, end} = range
+    if (this.isA()) {
+      // NOTE: This adjustment shoud not be necessary if language-syntax is properly defined.
+      if (this.isGrammarDoesNotFoldClosingRow()) {
+        end.row += 1
+      }
+    } else {
+      if (this.editor.indentationForBufferRow(start.row) === this.editor.indentationForBufferRow(end.row)) {
+        end.row -= 1
+      }
+      start.row += 1
+    }
+    return range
+  }
+
+  isGrammarDoesNotFoldClosingRow() {
     const {scopeName, packageName} = this.editor.getGrammar()
     if (this.scopeNamesOmittingEndRow.includes(scopeName)) {
       return true
@@ -502,19 +528,6 @@ class Function extends Fold {
       // language-rust don't fold ending `}`, but atom-language-rust does.
       return scopeName === "source.rust" && packageName === "language-rust"
     }
-  }
-
-  getFoldRowRangesContainsForRow(row) {
-    return super.getFoldRowRangesContainsForRow(row).filter(rowRange => {
-      return this.utils.isIncludeFunctionScopeForRow(this.editor, rowRange[0])
-    })
-  }
-
-  adjustRowRange(rowRange) {
-    let [startRow, endRow] = super.adjustRowRange(rowRange)
-    // NOTE: This adjustment shoud not be necessary if language-syntax is properly defined.
-    if (this.isA() && this.isGrammarNotFoldEndRow()) endRow += 1
-    return [startRow, endRow]
   }
 }
 

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -481,42 +481,78 @@ class Fold extends TextObject {
   }
 }
 
-// NOTE: Function range determination is depending on fold.
 class Function extends TextObject {
   wise = "linewise"
-  // Some language don't include closing `}` into fold.
+  // Some language doesn't include closing `}` into fold.
   scopeNamesOmittingEndRow = ["source.go", "source.elixir"]
 
+  getFunctionParameterEndRegex({scopeName}) {
+    if (scopeName === "source.python") {
+      return /:$/
+    } else if (scopeName === "source.coffee") {
+      return /-|=>$/
+    } else {
+      return /{$/
+    }
+  }
+
+  isMultiLineParameterFunctionRange(parameterRange, bodyRange, parameterEndRegex) {
+    const isParameterEndRow = row => parameterEndRegex.test(this.editor.lineTextForBufferRow(row))
+
+    if (isParameterEndRow(parameterRange.start.row)) return false
+    if (isParameterEndRow(parameterRange.end.row)) return bodyRange.start.row === parameterRange.end.row
+    if (isParameterEndRow(parameterRange.end.row + 1)) return bodyRange.start.row === parameterRange.end.row + 1
+    return false
+  }
+
   getRange(selection) {
-    const {row} = this.getCursorPositionForSelection(selection)
+    const cursorRow = this.getCursorPositionForSelection(selection).row
     const selectedRange = selection.getBufferRange()
 
-    const functionFoldRanges = this.utils
-      .getCodeFoldRangesContainesRow(this.editor, row)
-      .reverse()
-      .filter(range => this.utils.isIncludeFunctionScopeForRow(this.editor, range.start.row))
+    const parameterEndRegex = this.getFunctionParameterEndRegex(this.editor.getGrammar())
+    const functionRanges = []
+    const foldRanges = this.utils.getCodeFoldRanges(this.editor)
 
-    for (const foldRange of functionFoldRanges) {
-      const {start, end} = this.adjustRange(foldRange)
+    while (foldRanges.length) {
+      const range = foldRanges.shift()
+      if (this.utils.isIncludeFunctionScopeForRow(this.editor, range.start.row)) {
+        const nextRange = foldRanges[0]
+        const nextFoldIsConnected = nextRange && [range.end.row, range.end.row + 1].includes(nextRange.start.row)
+        const maybeFunctionRange = nextFoldIsConnected ? range.union(nextRange) : range
+        if (!maybeFunctionRange.containsPoint([cursorRow, Infinity])) continue // skip to avoid heavy computation
+
+        if (nextFoldIsConnected && this.isMultiLineParameterFunctionRange(range, foldRanges[0], parameterEndRegex)) {
+          const bodyRange = foldRanges.shift()
+          functionRanges.push({
+            aRange: this.buildInnerRange(bodyRange),
+            innerRange: this.buildARange(range.union(bodyRange)),
+          })
+        } else {
+          functionRanges.push({
+            aRange: this.buildARange(range),
+            innerRange: this.buildInnerRange(range),
+          })
+        }
+      }
+    }
+
+    for (const functionRange of functionRanges.reverse()) {
+      const {start, end} = this.isA() ? functionRange.aRange : functionRange.innerRange
       const range = this.getBufferRangeForRowRange([start.row, end.row])
       if (!selectedRange.containsRange(range)) return range
     }
   }
 
-  adjustRange(range) {
-    const {start, end} = range
-    if (this.isA()) {
-      // NOTE: This adjustment shoud not be necessary if language-syntax is properly defined.
-      if (this.isGrammarDoesNotFoldClosingRow()) {
-        end.row += 1
-      }
-    } else {
-      if (this.editor.indentationForBufferRow(start.row) === this.editor.indentationForBufferRow(end.row)) {
-        end.row -= 1
-      }
-      start.row += 1
-    }
-    return range
+  buildInnerRange(range) {
+    const indentForRow = row => this.editor.indentationForBufferRow(row)
+    const endRowTranslation = indentForRow(range.start.row) === indentForRow(range.end.row) ? -1 : 0
+    return range.translate([1, 0], [endRowTranslation, 0])
+  }
+
+  buildARange(range) {
+    // NOTE: This adjustment shoud not be necessary if language-syntax is properly defined.
+    const endRowTranslation = this.isGrammarDoesNotFoldClosingRow() ? +1 : 0
+    return range.translate([0, 0], [endRowTranslation, 0])
   }
 
   isGrammarDoesNotFoldClosingRow() {

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -524,8 +524,8 @@ class Function extends TextObject {
         if (nextFoldIsConnected && this.isMultiLineParameterFunctionRange(range, foldRanges[0], parameterEndRegex)) {
           const bodyRange = foldRanges.shift()
           functionRanges.push({
-            aRange: this.buildInnerRange(bodyRange),
-            innerRange: this.buildARange(range.union(bodyRange)),
+            aRange: this.buildARange(range.union(bodyRange)),
+            innerRange: this.buildInnerRange(bodyRange),
           })
         } else {
           functionRanges.push({

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -507,39 +507,43 @@ class Function extends TextObject {
 
   getRange(selection) {
     const cursorRow = this.getCursorPositionForSelection(selection).row
-    const selectedRange = selection.getBufferRange()
-
     const parameterEndRegex = this.getFunctionParameterEndRegex(this.editor.getGrammar())
-    const functionRanges = []
-    const foldRanges = this.utils.getCodeFoldRanges(this.editor)
+    const isIncludeFunctionScopeForRow = row => row >= 0 && this.utils.isIncludeFunctionScopeForRow(this.editor, row)
+    const isParameterEndRow = row => parameterEndRegex.test(this.editor.lineTextForBufferRow(row))
 
+    const functionRanges = []
+    const saveFunctionRange = ({aRange, innerRange}) => {
+      functionRanges.push({
+        aRange: this.buildARange(aRange),
+        innerRange: this.buildInnerRange(innerRange),
+      })
+    }
+
+    const foldRanges = this.utils.getCodeFoldRanges(this.editor)
     while (foldRanges.length) {
       const range = foldRanges.shift()
-      if (this.utils.isIncludeFunctionScopeForRow(this.editor, range.start.row)) {
+      if (isIncludeFunctionScopeForRow(range.start.row)) {
         const nextRange = foldRanges[0]
-        const nextFoldIsConnected = nextRange && [range.end.row, range.end.row + 1].includes(nextRange.start.row)
-        const maybeFunctionRange = nextFoldIsConnected ? range.union(nextRange) : range
-        if (!maybeFunctionRange.containsPoint([cursorRow, Infinity])) continue // skip to avoid heavy computation
-
-        if (nextFoldIsConnected && this.isMultiLineParameterFunctionRange(range, foldRanges[0], parameterEndRegex)) {
+        const nextFoldIsConnected = nextRange && nextRange.start.row <= range.end.row + 1
+        const maybeAFunctionRange = nextFoldIsConnected ? range.union(nextRange) : range
+        if (!maybeAFunctionRange.containsPoint([cursorRow, Infinity])) continue // skip to avoid heavy computation
+        if (nextFoldIsConnected && this.isMultiLineParameterFunctionRange(range, nextRange, parameterEndRegex)) {
           const bodyRange = foldRanges.shift()
-          functionRanges.push({
-            aRange: this.buildARange(range.union(bodyRange)),
-            innerRange: this.buildInnerRange(bodyRange),
-          })
+          saveFunctionRange({aRange: range.union(bodyRange), innerRange: bodyRange})
         } else {
-          functionRanges.push({
-            aRange: this.buildARange(range),
-            innerRange: this.buildInnerRange(range),
-          })
+          saveFunctionRange({aRange: range, innerRange: range})
         }
+      } else if (isParameterEndRow(range.start.row) && isIncludeFunctionScopeForRow(range.start.row - 1)) {
+        const maybeAFunctionRange = range.union(this.editor.bufferRangeForBufferRow(range.start.row - 1))
+        if (!maybeAFunctionRange.containsPoint([cursorRow, Infinity])) continue // skip to avoid heavy computation
+        saveFunctionRange({aRange: maybeAFunctionRange, innerRange: range})
       }
     }
 
     for (const functionRange of functionRanges.reverse()) {
       const {start, end} = this.isA() ? functionRange.aRange : functionRange.innerRange
       const range = this.getBufferRangeForRowRange([start.row, end.row])
-      if (!selectedRange.containsRange(range)) return range
+      if (!selection.getBufferRange().containsRange(range)) return range
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -312,60 +312,37 @@ function getLineTextToBufferPosition(editor, {row, column}, {exclusive = true} =
   return editor.lineTextForBufferRow(row).slice(0, exclusive ? column : column + 1)
 }
 
-function getCodeFoldRowRanges(editor) {
-  return editor.tokenizedBuffer
-    .getFoldableRanges()
-    .filter(range => !editor.tokenizedBuffer.isRowCommented(range.start.row))
-    .map(range => [range.start.row, range.end.row])
+function getCodeFoldRanges({tokenizedBuffer}) {
+  return tokenizedBuffer.getFoldableRanges().filter(range => !tokenizedBuffer.isRowCommented(range.start.row))
 }
 
 // Used in vmp-jasmine-increase-focus
-function getCodeFoldRowRangesContainesForRow(editor, bufferRow, {includeStartRow = true} = {}) {
-  const bufferRowContained = includeStartRow
-    ? ([startRow, endRow]) => startRow <= bufferRow && bufferRow <= endRow
-    : ([startRow, endRow]) => startRow < bufferRow && bufferRow <= endRow
-
-  return getCodeFoldRowRanges(editor).filter(bufferRowContained)
-}
-
-function getFoldRowRangesContainedByFoldStartsAtRow(editor, row) {
-  if (!editor.isFoldableAtBufferRow(row)) return null
-
-  const rowRanges = getCodeFoldRowRanges(editor)
-  const foldRowRange = rowRanges.find(rowRange => rowRange[0] === row)
-  return rowRanges.filter(rowRange => foldRowRange[0] <= rowRange[0] && foldRowRange[1] >= rowRange[1])
-}
-
-function getFoldRangesWithIndent(editor) {
-  return getCodeFoldRowRanges(editor).map(([startRow, endRow]) => ({
-    startRow,
-    endRow,
-    indent: editor.indentationForBufferRow(startRow),
-  }))
+function getCodeFoldRangesContainesRow(editor, bufferRow) {
+  return getCodeFoldRanges(editor).filter(range => range.start.row <= bufferRow && bufferRow <= range.end.row)
 }
 
 function getFoldInfoByKind(editor) {
   const foldInfoByKind = {}
 
-  function updateFoldInfo(kind, rowRangeWithIndent) {
+  function updateFoldInfo(kind, rangeAndIndent) {
     if (!foldInfoByKind[kind]) {
-      foldInfoByKind[kind] = {rowRangesWithIndent: []}
+      foldInfoByKind[kind] = {listOfRangeAndIndent: []}
     }
     const foldInfo = foldInfoByKind[kind]
-    foldInfo.rowRangesWithIndent.push(rowRangeWithIndent)
-    const {indent} = rowRangeWithIndent
+    foldInfo.listOfRangeAndIndent.push(rangeAndIndent)
+    const {indent} = rangeAndIndent
     foldInfo.minIndent = Math.min(foldInfo.minIndent != null ? foldInfo.minIndent : indent, indent)
     foldInfo.maxIndent = Math.max(foldInfo.maxIndent != null ? foldInfo.maxIndent : indent, indent)
   }
 
-  for (const rowRangeWithIndent of getFoldRangesWithIndent(editor)) {
-    updateFoldInfo("allFold", rowRangeWithIndent)
-    const folded = editor.isFoldedAtBufferRow(rowRangeWithIndent.startRow)
-    if (editor.isFoldedAtBufferRow(rowRangeWithIndent.startRow)) {
-      updateFoldInfo("folded", rowRangeWithIndent)
-    } else {
-      updateFoldInfo("unfolded", rowRangeWithIndent)
+  for (const range of getCodeFoldRanges(editor)) {
+    const rangeAndIndent = {
+      range: range,
+      indent: editor.indentationForBufferRow(range.start.row),
     }
+    updateFoldInfo("allFold", rangeAndIndent)
+    const kind = editor.isFoldedAtBufferRow(range.start.row) ? "folded" : "unfolded"
+    updateFoldInfo(kind, rangeAndIndent)
   }
   return foldInfoByKind
 }
@@ -1181,10 +1158,8 @@ module.exports = {
   getLineTextToBufferPosition,
   getTextInScreenRange,
   isEmptyRow,
-  getCodeFoldRowRanges,
-  getCodeFoldRowRangesContainesForRow,
-  getFoldRowRangesContainedByFoldStartsAtRow,
-  getFoldRangesWithIndent,
+  getCodeFoldRanges,
+  getCodeFoldRangesContainesRow,
   getFoldInfoByKind,
   getBufferRangeForRowRange,
   trimBufferRange,

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1550,7 +1550,7 @@ describe "TextObject", ->
 
       describe 'inner-function for coffee', ->
         it 'select except start row', ->
-          cursor: [3, 3]
+          set cursor: [3, 3]
           ensure 'v i f', selectedBufferRange: [[3, 0], [6, 0]]
 
         it "[when cursor is at column 0 of function-fold start row]", ->
@@ -1559,7 +1559,7 @@ describe "TextObject", ->
 
       describe 'a-function for coffee', ->
         it 'select function', ->
-          cursor: [3, 3]
+          set cursor: [3, 3]
           ensure 'v a f', selectedBufferRange: [[2, 0], [6, 0]]
 
         it "[when cursor is at column 0 of function-fold start row]", ->

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1632,6 +1632,24 @@ describe "TextObject", ->
         it '[from param] i f', -> set cursor: [3, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(7, 8)
         it '[from  body] i f', -> set cursor: [7, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(7, 8)
 
+      describe '[case-3]: body start from next-row-of-param-end-row', ->
+        beforeEach ->
+          set
+            textC: """
+
+            function f3(a1, a2, a3)
+            {
+              // comment
+              console.log(a1, a2, a3)
+            }
+
+            """
+
+        it '[from param] a f', -> set cursor: [1, 0]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from  body] a f', -> set cursor: [3, 0]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from param] i f', -> set cursor: [1, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(3, 4)
+        it '[from  body] i f', -> set cursor: [3, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(3, 4)
+
     describe 'ruby', ->
       pack = 'language-ruby'
       scope = 'source.ruby'

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1447,6 +1447,10 @@ describe "TextObject", ->
         set cursor: [13, 0]
         ensure 'v i z', selectedBufferRange: rangeForRows(10, 25)
 
+      it "[when cursor is at column 0 of fold start row] select inner range of fold", ->
+        set cursor: [9, 0]
+        ensure 'v i z', selectedBufferRange: rangeForRows(10, 25)
+
       it "select inner range of fold", ->
         set cursor: [19, 0]
         ensure 'v i z', selectedBufferRange: rangeForRows(19, 23)
@@ -1488,6 +1492,10 @@ describe "TextObject", ->
     describe 'a-fold', ->
       it 'select fold row range', ->
         set cursor: [13, 0]
+        ensure 'v a z', selectedBufferRange: rangeForRows(9, 25)
+
+      it "[when cursor is at column 0 of fold start row] select inner range of fold", ->
+        set cursor: [9, 0]
         ensure 'v a z', selectedBufferRange: rangeForRows(9, 25)
 
       it 'select fold row range', ->
@@ -1533,7 +1541,6 @@ describe "TextObject", ->
 
             # Commment
             """
-          cursor: [3, 0]
 
         runs ->
           grammar = atom.grammars.grammarForScopeName(scope)
@@ -1543,10 +1550,20 @@ describe "TextObject", ->
 
       describe 'inner-function for coffee', ->
         it 'select except start row', ->
+          cursor: [3, 3]
+          ensure 'v i f', selectedBufferRange: [[3, 0], [6, 0]]
+
+        it "[when cursor is at column 0 of function-fold start row]", ->
+          set cursor: [2, 0]
           ensure 'v i f', selectedBufferRange: [[3, 0], [6, 0]]
 
       describe 'a-function for coffee', ->
         it 'select function', ->
+          cursor: [3, 3]
+          ensure 'v a f', selectedBufferRange: [[2, 0], [6, 0]]
+
+        it "[when cursor is at column 0 of function-fold start row]", ->
+          set cursor: [2, 0]
           ensure 'v a f', selectedBufferRange: [[2, 0], [6, 0]]
 
     describe 'ruby', ->


### PR DESCRIPTION
#983
https://github.com/t9md/atom-vim-mode-plus/issues/819#issuecomment-318629360

Heuristically find function range.

I **won't** try to be perfectly detect function body by **parsing**.
I will try to improve coverage of detection by supporting **common** multi-func-patterns used in different function.
I want keep language specific handling as minimum as possible.
So I will still **get hint from indentation**.

## What is commonalities in samples in following `Objective` section?

- For multiline parameter's function
  - funcStartRow is not ended by `{` , that multi-line param function!
    - funcEndRow is ended by `{`, then body is fold starting from this row.
    - next row of funcEndRow is ended by `{` is fold starting from this row.

Still vmp function text object greatly depends on `fold` info.

## Objective

### PHP: OK

```php
<?php
class Kernel extends ConsoleKernel
{
  protected function schedule(Schedule $schedule)
  {
      // $schedule->command('inspire')
      //          ->hourly();
  }
}
```


### Python: OK

```python

## WONT support
class Rectangle(Blob):

    def __init__(self, width, height,
                 color='black', emphasis=None, highlight=0):

## will support
class Rectangle(Blob):

    def __init__(
        self, width, height,
        color='black', emphasis=None, highlight=0
    ):
      # body
```

### c: OK

```c
    int
get_beval_info(
    BalloonEval	*beval,
    int		getword,
    win_T	**winp,
    linenr_T	*lnump,
    char_u	**textp,
    int		*colp)
{
    win_T	*wp;
    int		row, col;
    char_u	*lbuf;
    linenr_T	lnum;
}
```

### coffee: SKIP BECAUSE COST NOT PAY FOR ME

```coffeescript
f1 = (a, b) ->
  console.log a, b

f2 = (
  a,
  b
) ->
  console.log a, b
```

### js: OK

```javascript
function f1(a1, a2) {
  console.log(a1, a2)
}

function f2(
  a1,
  a2
) {
  console.log(a1, a2)
}
```

### rust: OK

```rust
fn f1(arg1: i64, arg2: u64, arg3: String) -> i64 {
    let sum = 1 + 1;
    sum + 2
}

fn f2(
    arg1: i64,
    arg2: u64,
    arg3: String,
) -> i64 {
    let sum = 1 + 1;
    sum + 2
}
```
