### PR TITLE
Allow numpad0 to be used when entering a number before a command

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -429,6 +429,7 @@
 
 'atom-text-editor.vim-mode-plus.with-count:not(.insert-mode)':
   '0': 'vim-mode-plus:set-count-0'
+  'numpad0': 'vim-mode-plus:set-count-0'
   '%': 'vim-mode-plus:move-to-line-by-percent'
 
 'atom-text-editor.vim-mode-plus.has-persistent-selection:not(.insert-mode)':


### PR DESCRIPTION
Discovered that this wasn't working and then used the keybinding debugger (ctrl+.) to figure out the issue. Checked whether this works by adding this line to my local keymap. It fixes the problem.

Without this, typing something like `420G` fails while typing `0` because `numpad0` always takes you to the front of the line. This change is consistent with the rest of the file because `numpad0` is mapped to all of the same things as `0` everywhere else.