### PR TITLE
a-fold now select "conjoined" fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.24.0:
+- Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.23.0...v1.24.0)
+- New, Breaking: `a-fold` now select "conjoined" fold #996
+  - Old: `a-fold` just select current fold only.
+  - New: `a-fold` select all conjoined fold range.
+    - select previous fold if previous fold end at startRow of current fold.
+    - select next fold if next fold start at endRow of current fold.
+  - So you can do
+    - delete(`d z`) or yank(`y z`) whole `if/else-if/else` clause by just two keystrokes.
+    - delete(`d z`) or yank(`y z`) whole `try/catch/finally` clause by just two keystrokes.
+- Fix: `j` and `k` no longer stuck at row when screenRow contains multiple fold. #994, #995
+  - e.g. fold `else if`-fold, then `if`-fold, then try to cross row by `j` or `k` but couldn't.
+
 # 1.23.0:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.22.1...v1.23.0)
 - Doc: add youtube movie link on README.md

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -463,21 +463,26 @@ class Fold extends TextObject {
   getRange(selection) {
     const {row} = this.getCursorPositionForSelection(selection)
     const selectedRange = selection.getBufferRange()
-    const foldRanges = this.utils.getCodeFoldRangesContainesRow(this.editor, row).reverse()
-    for (const foldRange of foldRanges) {
-      const {start, end} = this.adjustRange(foldRange)
-      const range = this.getBufferRangeForRowRange([start.row, end.row])
-      if (!selectedRange.containsRange(range)) return range
-    }
-  }
 
-  adjustRange(range) {
-    if (this.isA()) return range
-    if (this.editor.indentationForBufferRow(range.start.row) === this.editor.indentationForBufferRow(range.end.row)) {
-      range.end.row -= 1
+    const foldRanges = this.utils.getCodeFoldRanges(this.editor)
+    const foldRangesContainsCursorRow = foldRanges.filter(range => range.start.row <= row && row <= range.end.row)
+
+    for (let foldRange of foldRangesContainsCursorRow.reverse()) {
+      if (this.isA()) {
+        let conjoined
+        while ((conjoined = foldRanges.find(range => range.end.row === foldRange.start.row))) {
+          foldRange = foldRange.union(conjoined)
+        }
+        while ((conjoined = foldRanges.find(range => range.start.row === foldRange.end.row))) {
+          foldRange = foldRange.union(conjoined)
+        }
+      } else {
+        if (this.utils.doesRangeStartAndEndWithSameIndentLevel(this.editor, foldRange)) foldRange.end.row -= 1
+        foldRange.start.row += 1
+      }
+      foldRange = this.getBufferRangeForRowRange([foldRange.start.row, foldRange.end.row])
+      if (!selectedRange.containsRange(foldRange)) return foldRange
     }
-    range.start.row += 1
-    return range
   }
 }
 
@@ -554,8 +559,7 @@ class Function extends TextObject {
   }
 
   buildInnerRange(range) {
-    const indentForRow = row => this.editor.indentationForBufferRow(row)
-    const endRowTranslation = indentForRow(range.start.row) === indentForRow(range.end.row) ? -1 : 0
+    const endRowTranslation = this.utils.doesRangeStartAndEndWithSameIndentLevel(this.editor, range) ? -1 : 0
     return range.translate([1, 0], [endRowTranslation, 0])
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1027,6 +1027,10 @@ function getFoldEndRowForRow(editor, row) {
     : row
 }
 
+function doesRangeStartAndEndWithSameIndentLevel(editor, range) {
+  return editor.indentationForBufferRow(range.start.row) === editor.indentationForBufferRow(range.end.row)
+}
+
 function getList(start, end, inclusive = true) {
   const range = []
   if (start < end) {
@@ -1221,6 +1225,7 @@ module.exports = {
   traverseTextFromPoint,
   getFoldStartRowForRow,
   getFoldEndRowForRow,
+  doesRangeStartAndEndWithSameIndentLevel,
   getList,
   unindent,
   removeIndent,

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1520,6 +1520,85 @@ describe "TextObject", ->
           ensure 'V G', selectedBufferRange: rangeForRows(20, 30)
           ensure 'a z', selectedBufferRange: rangeForRows(20, 30)
 
+      describe "select conjoined fold", ->
+        # This feature is language agnostic, don't misunderstsand it as JS specific feature.
+        pack = 'language-javascript'
+        scope = 'source.js'
+        beforeEach ->
+          waitsForPromise -> atom.packages.activatePackage(pack)
+          runs -> editor.setGrammar(atom.grammars.grammarForScopeName(scope))
+        afterEach ->
+          atom.packages.deactivatePackage(pack)
+
+        it "select if/else if/else from any row", ->
+          set
+            text: """
+
+            if (num === 1) {
+              console.log(1)
+            } else if (num === 2) {
+              console.log(2)
+            } else if (num === 3) {
+              console.log(3)
+            } else {
+              console.log(4)
+            }
+
+            """
+
+          selectedText = """
+          if (num === 1) {
+            console.log(1)
+          } else if (num === 2) {
+            console.log(2)
+          } else if (num === 3) {
+            console.log(3)
+          } else {
+            console.log(4)
+          }\n
+          """
+          set cursor: [1, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [2, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [3, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [4, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [5, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [6, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [7, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [8, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [9, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+
+        it "select try/catch/finally from any row", ->
+          set
+            text: """
+
+            try {
+              console.log(1);
+            } catch (e) {
+              console.log(2);
+            } finally {
+              console.log(3);
+            }
+
+            """
+
+          selectedText = """
+          try {
+            console.log(1);
+          } catch (e) {
+            console.log(2);
+          } finally {
+            console.log(3);
+          }\n
+          """
+          set cursor: [1, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [2, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [3, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [4, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [5, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [6, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+          set cursor: [7, 0]; ensure "v a z", {selectedText}; ensure "escape", mode: "normal"
+
+
   # Although following test picks specific language, other langauages are alsoe supported.
   describe 'Function', ->
     describe 'coffee', ->


### PR DESCRIPTION
- Old: `a-fold` just select current fold only.
- New: `a-fold` select all conjoined fold range.
  - select previous fold if previous fold end at startRow of current fold.
  - select next fold if next fold start at endRow of current fold.

```javascript
// `y z`(yank), `d z`(delete) whole if/else-if/else clause
if (num === 1) {
  console.log(1)

} else if (num === 2) {
  console.log(2)

} else if (num === 3) {
  console.log(3)

} else {
  console.log(4)

}

// `y z`(yank), `d z`(delete) whole try/catch/finall clause
try {
  console.log(1);

} catch (e) {
  console.log(2);

} finally {
  console.log(3);

}

```
