### PR TITLE
Avoid centering editor in editor

### DIFF
--- a/styles/vim-mode-plus.less
+++ b/styles/vim-mode-plus.less
@@ -294,7 +294,17 @@ atom-workspace.vim-mode-plus--pane-maximized {
   }
   &.vim-mode-plus--hide-tab-bar { .tab-bar { display: none; } }
   &.vim-mode-plus--hide-status-bar { .status-bar { display: none; } }
-  &.vim-mode-plus--pane-centered { atom-text-editor:not(.mini) { margin-left: 20%; } }
+  &.vim-mode-plus--pane-centered {
+    atom-text-editor:not(.mini) {
+      margin-left: 20%;
+      atom-text-editor {
+        // Some package embed another text-editor into normal text-editor by using block decoration.
+        // But we don't want this editor in editor centered again.
+        // E.g. git-diff-details, inline-git-diff
+        margin-left: 0%;
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
Red highlighted part is text-editor embedded into normal text-editor.
Package [git-diff-details][1] or [inline-git-diff][2](my fork of `git-diff-details`) embed another text-editor into normal text-editor by using block decoration.

[1]: https://github.com/samu/git-diff-details/
[2]: https://github.com/t9md/atom-inline-git-diff/

Previously when maximizing pane by `vim-mode-plus:maximize-pane`(`cmd-enter`), this editor-in-editor was centered again.
This PR avoid this unwanted centering.

- before
<img width="1164" alt="before" src="https://user-images.githubusercontent.com/155205/34661043-39eaa58c-f48a-11e7-9837-fda92a5ac631.png">

- after
<img width="1130" alt="after" src="https://user-images.githubusercontent.com/155205/34661032-2e1df7b8-f48a-11e7-95e7-f02c554fc1f4.png">
