### PR TITLE
Replace text via diff on trasnsform string operator

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -313,4 +313,5 @@ module.exports = class Base {
   getFoldEndRowForRow(...args) { return this.utils.getFoldEndRowForRow(this.editor, ...args) } // prettier-ignore
   getBufferRows(...args) { return this.utils.getRows(this.editor, "buffer", ...args) } // prettier-ignore
   getScreenRows(...args) { return this.utils.getRows(this.editor, "screen", ...args) } // prettier-ignore
+  replaceTextInRangeViaDiff(...args) { return this.utils.replaceTextInRangeViaDiff(this.editor, ...args) } // prettier-ignore
 }

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -15,7 +15,7 @@ class TransformString extends Operator {
   stayOptionName = "stayOnTransformString"
   autoIndent = false
   autoIndentNewline = false
-  autoIndentAfterInsertText = false
+  replaceByDiff = false
 
   static registerToSelectList() {
     this.stringTransformers.push(this)
@@ -23,23 +23,12 @@ class TransformString extends Operator {
 
   mutateSelection(selection) {
     const text = this.getNewText(selection.getText(), selection)
+    console.log({replaceByDiff: this.replaceByDiff})
     if (text) {
-      let startRowIndentLevel
-      if (this.autoIndentAfterInsertText) {
-        const startRow = selection.getBufferRange().start.row
-        startRowIndentLevel = this.editor.indentationForBufferRow(startRow)
-      }
-      let range = selection.insertText(text, {autoIndent: this.autoIndent, autoIndentNewline: this.autoIndentNewline})
-
-      if (this.autoIndentAfterInsertText) {
-        // Currently used by SplitArguments and Surround( linewise target only )
-        if (this.target.isLinewise()) {
-          range = range.translate([0, 0], [-1, 0])
-        }
-        this.editor.setIndentationForBufferRow(range.start.row, startRowIndentLevel)
-        this.editor.setIndentationForBufferRow(range.end.row, startRowIndentLevel)
-        // Adjust inner range, end.row is already( if needed ) translated so no need to re-translate.
-        this.utils.adjustIndentWithKeepingLayout(this.editor, range.translate([1, 0], [0, 0]))
+      if (this.replaceByDiff) {
+        this.replaceTextInRangeViaDiff(selection.getBufferRange(), text)
+      } else {
+        selection.insertText(text, {autoIndent: this.autoIndent, autoIndentNewline: this.autoIndentNewline})
       }
     }
   }
@@ -146,6 +135,9 @@ class DecodeUriComponent extends TransformString {
 }
 
 class TrimString extends TransformString {
+  stayByMarker = true
+  replaceByDiff = true
+
   getNewText(text) {
     return text.trim()
   }
@@ -523,18 +515,28 @@ class SurroundBase extends TransformString {
     a: ["<", ">"],
   }
 
+  initialize() {
+    this.replaceByDiff = this.getConfig("replaceByDiffOnSurround")
+    this.stayByMarker = this.replaceByDiff
+    super.initialize()
+  }
+
   getPair(char) {
     return char in this.pairsByAlias
       ? this.pairsByAlias[char]
       : [...this.pairs, [char, char]].find(pair => pair.includes(char))
   }
 
-  surround(text, char, {keepLayout = false} = {}) {
+  surround(text, char, {keepLayout = false, selection} = {}) {
     let [open, close] = this.getPair(char)
     if (!keepLayout && text.endsWith("\n")) {
-      this.autoIndentAfterInsertText = true
-      open += "\n"
-      close += "\n"
+      const baseIndentLevel = this.editor.indentationForBufferRow(selection.getBufferRange().start.row)
+      const indentTextStartRow = this.editor.buildIndentString(baseIndentLevel)
+      const indentTextOneLevel = this.editor.buildIndentString(1)
+
+      open = indentTextStartRow + open + "\n"
+      text = text.replace(/^(.+)$/gm, m => indentTextInnerRow + m)
+      close = indentTextStartRow + close + "\n"
     }
 
     if (this.getConfig("charactersToAddSpaceOnSurround").includes(char) && this.utils.isSingleLineText(text)) {
@@ -552,9 +554,9 @@ class SurroundBase extends TransformString {
     return this.utils.isSingleLineText(text) && open !== close ? innerText.trim() : innerText
   }
 
-  getNewText(text) {
+  getNewText(text, selection) {
     if (this.surroundAction === "surround") {
-      return this.surround(text, this.input)
+      return this.surround(text, this.input, {selection})
     } else if (this.surroundAction === "delete-surround") {
       return this.deleteSurround(text)
     } else if (this.surroundAction === "change-surround") {
@@ -704,16 +706,20 @@ class SplitStringWithKeepingSplitter extends SplitString {
 
 class SplitArguments extends TransformString {
   keepSeparator = true
-  autoIndentAfterInsertText = true
 
-  getNewText(text) {
+  getNewText(text, selection) {
     const allTokens = this.utils.splitArguments(text.trim())
     let newText = ""
+
+    const baseIndentLevel = this.editor.indentationForBufferRow(selection.getBufferRange().start.row)
+    const indentTextStartRow = this.editor.buildIndentString(baseIndentLevel)
+    const indentTextInnerRows = this.editor.buildIndentString(baseIndentLevel + 1)
+
     while (allTokens.length) {
       const {text, type} = allTokens.shift()
-      newText += type === "separator" ? (this.keepSeparator ? text.trim() : "") + "\n" : text
+      newText += type === "separator" ? (this.keepSeparator ? text.trim() : "") + "\n" : indentTextInnerRows + text
     }
-    return `\n${newText}\n`
+    return `\n${newText}\n${indentTextStartRow}`
   }
 }
 

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -534,7 +534,7 @@ class SurroundBase extends TransformString {
       const indentTextOneLevel = this.editor.buildIndentString(1)
 
       open = indentTextStartRow + open + "\n"
-      text = text.replace(/^(.+)$/gm, m => indentTextInnerRow + m)
+      text = text.replace(/^(.+)$/gm, m => indentTextOneLevel + m)
       close = indentTextStartRow + close + "\n"
     }
 

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -23,7 +23,6 @@ class TransformString extends Operator {
 
   mutateSelection(selection) {
     const text = this.getNewText(selection.getText(), selection)
-    console.log({replaceByDiff: this.replaceByDiff})
     if (text) {
       if (this.replaceByDiff) {
         this.replaceTextInRangeViaDiff(selection.getBufferRange(), text)

--- a/lib/read-char.js
+++ b/lib/read-char.js
@@ -23,7 +23,7 @@ module.exports = function readChar(vimState, {onCancel, onConfirm}) {
 
 // Other
 // -------------------------
-// FIXME: I want to remove this dengerious approach, but I couldn't find the better way.
+// FIXME: I want to remove this dangerious approach, but I couldn't find the better way.
 function swapClassName(vimState, ...classNames) {
   const oldMode = vimState.mode
   vimState.editorElement.classList.remove("vim-mode-plus", oldMode + "-mode")

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -324,6 +324,11 @@ module.exports = new Settings("vim-mode-plus", {
     default: true,
     description: "Clear persistent selection on `escape` in normal-mode",
   },
+  replaceByDiffOnSurround: {
+    default: false,
+    description:
+      "[EXPERIMENTAL] Replace only changed text by comparing old and new text, affects `surround`, `delete-surround`, `change-surround`",
+  },
   charactersToAddSpaceOnSurround: {
     default: [],
     items: {type: "string"},

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1162,7 +1162,6 @@ function replaceTextInRangeViaDiff(editor, range, newText) {
 
   const oldText = editor.getTextInBufferRange(range)
   const changes = Diff.diffChars(oldText, newText)
-  console.log(changes)
   editor.transact(() => {
     for (const change of changes) {
       point[0] = row

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
-let fs, semver
+let fs, semver, Diff
 const settings = require("./settings")
 const {Range, Point} = require("atom")
+const NEWLINE_REG_EXP = /\n/g
 
 // [Borrowed from underscore/underscore-plus
 function escapeRegExp(s) {
@@ -659,7 +660,9 @@ const isNotEmpty = negateFunction(isEmpty)
 const isSingleLineRange = range => range.isSingleLine()
 const isNotSingleLineRange = negateFunction(isSingleLineRange)
 
-const isLeadingWhiteSpaceRange = (editor, range) => /^[\t ]*$/.test(editor.getTextInBufferRange(range))
+const isLeadingWhiteSpaceRange = (editor, range) => {
+  return range.start.column === 0 && /^[\t ]*$/.test(editor.getTextInBufferRange(range))
+}
 const isNotLeadingWhiteSpaceRange = negateFunction(isLeadingWhiteSpaceRange)
 
 function isEscapedCharRange(editor, range) {
@@ -984,21 +987,21 @@ function rangeContainsPointWithEndExclusive(range, point) {
 }
 
 function traverseTextFromPoint(point, text) {
-  return point.traverse(getTraversalForText(text))
+  return Point.fromObject(point).traverse(getTraversalForText(text))
 }
 
 function getTraversalForText(text) {
-  let row = 0,
-    column = 0
-  for (const char of text) {
-    if (char === "\n") {
-      row++
-      column = 0
-    } else {
-      column++
-    }
+  NEWLINE_REG_EXP.lastIndex = 0
+
+  let row = 0
+  let colum = 0
+
+  let lastIndex = 0
+  while (NEWLINE_REG_EXP.exec(text)) {
+    row++
+    lastIndex = NEWLINE_REG_EXP.lastIndex
   }
-  return new Point(row, column)
+  return new Point(row, text.length - lastIndex)
 }
 
 function getRowAmongFoldedRowIntersectsBufferRow(editor, bufferRow, which) {
@@ -1147,6 +1150,39 @@ function getHunkRangeAtBufferRow(editor, row) {
   }
 }
 
+// Replace given text by character based diff
+// Purpose: to minimize amount of range to be replaced, which lead cleaner flash highlight
+// On undo/redo highlight
+function replaceTextInRangeViaDiff(editor, range, newText) {
+  if (!Diff) Diff = require("diff")
+
+  let row = range.start.row
+  let column = range.start.column
+  const point = [0, 0]
+
+  const oldText = editor.getTextInBufferRange(range)
+  const changes = Diff.diffChars(oldText, newText)
+  console.log(changes)
+  editor.transact(() => {
+    for (const change of changes) {
+      point[0] = row
+      point[1] = column
+
+      if (change.added) {
+        const newPoint = editor.setTextInBufferRange([point, point], change.value).end
+        row = newPoint.row
+        column = newPoint.column
+      } else if (change.removed) {
+        editor.setTextInBufferRange([point, [row, column + change.count]], "")
+      } else {
+        const newPoint = traverseTextFromPoint(point, change.value)
+        row = newPoint.row
+        column = newPoint.column
+      }
+    }
+  })
+}
+
 module.exports = {
   assertWithException,
   getLast,
@@ -1245,4 +1281,5 @@ module.exports = {
   atomVersionSatisfies,
   getRowRangeForCommentAtBufferRow,
   getHunkRangeAtBufferRow,
+  replaceTextInRangeViaDiff,
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "atom-select-list": "^0.7.0",
     "change-case": "^3.0.1",
+    "diff": "^3.4.0",
     "fs-plus": "^2.8.1",
     "fuzzaldrin-plus": "^0.6.0",
     "grim": "^2.0.2",

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1582,9 +1582,9 @@ describe "Operator TransformString", ->
               {f1, f2, f3} = require('hello')
               f1(f2(1, "a, b, c"), 2, (arg) => console.log(arg))
               s = |`
-              abc
-              def
-              hij
+                abc
+                def
+                hij
               `
             }
             """


### PR DESCRIPTION
- Introduce new way of replace text for child of `TransformString` operators.
- When `replaceByDiff` props is set to `true`, replace text by diffing old and new text.
  - `false`: existing behavior, just replace old to new text
  - `true`: by diffing, replace minimum amount of ranges to leach to new text

- Pros
  - Cleaner undo/redo highlight
  - Cursor is not includes to mutated range, so staying at same position is more accurate, can further be improved in another PR.
- Cons
  - Old to new replace is broken into multiple patch, confusing?
  - When delete-surround on off-screen surround, user doesn't see flash highlight since highlight decoration happens very small range of text which is off-screen(This is big disadvantage).

# Which operators use this new mechanism

- Surround family: enabled by `replaceByDiffOnSurround` config(default `false`)
- TrimString(`g |`): enabled statically.
