### PR TITLE
change order family work for char-by-char when list length is 1

### DIFF
--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -732,10 +732,21 @@ class SplitArgumentsOfInnerAnyPair extends SplitArguments {
 
 class ChangeOrder extends TransformString {
   static command = false
+  action = null
+  sortBy = null
+
   getNewText (text) {
     return this.target.isLinewise()
       ? this.getNewList(this.utils.splitTextByNewLine(text)).join('\n') + '\n'
       : this.sortArgumentsInTextBy(text, args => this.getNewList(args))
+  }
+
+  getNewList (rows) {
+    if (rows.length === 1) {
+      return [this.utils.changeCharOrder(rows[0], this.action, this.sortBy)]
+    } else {
+      return this.utils.changeArrayOrder(rows, this.action, this.sortBy)
+    }
   }
 
   sortArgumentsInTextBy (text, fn) {
@@ -758,9 +769,7 @@ class ChangeOrder extends TransformString {
 }
 
 class Reverse extends ChangeOrder {
-  getNewList (rows) {
-    return rows.reverse()
-  }
+  action = 'reverse'
 }
 
 class ReverseInnerAnyPair extends Reverse {
@@ -768,16 +777,11 @@ class ReverseInnerAnyPair extends Reverse {
 }
 
 class Rotate extends ChangeOrder {
-  backwards = false
-  getNewList (rows) {
-    if (this.backwards) rows.push(rows.shift())
-    else rows.unshift(rows.pop())
-    return rows
-  }
+  action = 'rotate-right'
 }
 
 class RotateBackwards extends ChangeOrder {
-  backwards = true
+  action = 'rotate-left'
 }
 
 class RotateArgumentsOfInnerPair extends Rotate {
@@ -789,21 +793,15 @@ class RotateArgumentsBackwardsOfInnerPair extends RotateArgumentsOfInnerPair {
 }
 
 class Sort extends ChangeOrder {
-  getNewList (rows) {
-    return rows.sort()
-  }
+  action = 'sort'
 }
 
-class SortCaseInsensitively extends ChangeOrder {
-  getNewList (rows) {
-    return rows.sort((rowA, rowB) => rowA.localeCompare(rowB, {sensitivity: 'base'}))
-  }
+class SortCaseInsensitively extends Sort {
+  sortBy = (rowA, rowB) => rowA.localeCompare(rowB, {sensitivity: 'base'})
 }
 
-class SortByNumber extends ChangeOrder {
-  getNewList (rows) {
-    return this._.sortBy(rows, row => Number.parseInt(row) || Infinity)
-  }
+class SortByNumber extends Sort {
+  sortBy = (rowA, rowB) => (Number.parseInt(rowA) || Infinity) - (Number.parseInt(rowB) || Infinity)
 }
 
 class NumberingLines extends TransformString {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1190,6 +1190,38 @@ function replaceTextInRangeViaDiff (editor, range, newText) {
   })
 }
 
+function changeArrayOrder (array, action, sortBy) {
+  if (array.length < 2) {
+    return array
+  }
+
+  array = array.slice() // copy
+  switch (action) {
+    case 'reverse': {
+      return array.reverse()
+    }
+    case 'sort': {
+      if (sortBy) {
+        return array.sort(sortBy)
+      } else {
+        return array.sort()
+      }
+    }
+    case 'rotate-right': {
+      const first = array.shift()
+      return [...array, first]
+    }
+    case 'rotate-left': {
+      const last = array.pop()
+      return [last, ...array]
+    }
+  }
+}
+
+function changeCharOrder (text, action) {
+  return changeArrayOrder(text.split(''), action).join('')
+}
+
 module.exports = {
   assertWithException,
   getLast,
@@ -1288,5 +1320,7 @@ module.exports = {
   atomVersionSatisfies,
   getRowRangeForCommentAtBufferRow,
   getHunkRangeAtBufferRow,
-  replaceTextInRangeViaDiff
+  replaceTextInRangeViaDiff,
+  changeCharOrder,
+  changeArrayOrder
 }

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1688,14 +1688,23 @@ describe "Operator TransformString", ->
               "[( d e f"    "(a, b, c)"
             )
             """
+        it "[text not separated] reverse text", ->
+          set textC_: " 12|345 "
+          ensure 'g r i w', textC_: " |54321 "
       describe "Sort", ->
         it "[comma separated] sort text", ->
           set textC: "   ( dog, ca|t, fish, rabbit, duck, gopher, squid )"
           ensure 'g s i (', textC: "   (| cat, dog, duck, fish, gopher, rabbit, squid )"
+        it "[text not separated] sort text", ->
+          set textC_: " fe|dcba "
+          ensure 'g s i w', textC_: " |abcdef "
       describe "SortByNumber", ->
         it "[comma separated] sort by number", ->
           set textC_: "___(9, 1, |10, 5)"
           ensure 'g S i (', textC_: "___(|1, 5, 9, 10)"
+        it "[text not separated] sort by number", ->
+          set textC_: " 91|3za87 "
+          ensure 'g s i w', textC_: " |13789az "
 
     describe "linewise target", ->
       beforeEach ->


### PR DESCRIPTION
- Old: only can change order of separated text(space or comma or new line char)
  - reverse: `a b c` get `c b a`
  - reverse: `a, b, c` get `c, b, a`
  - reverse: `abc` get `abc`(**do nothing**)

- New: can change order of non separated text
  - reverse: `a b c` get `c b a`
  - reverse: `a, b, c` get `c, b, a`
  - reverse: `abc` get `cba`(**this is new**)

- Affect child of `ChangeOrder` operators bellow.
  - `Reverse`
  - `ReverseInnerAnyPair`
  - `Rotate`
  - `RotateBackwards`
  - `RotateArgumentsOfInnerPair`
  - `RotateArgumentsBackwardsOfInnerPair`
  - `Sort`
  - `SortCaseInsensitively`
  - `SortByNumber`
