### PR TITLE
Hide all editor commands in command palette

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -123,7 +123,7 @@ module.exports = {
     const commands = {}
     const dispatcher = VimState.getDispatcher()
     require('./json/command-table.json').forEach(name => {
-      commands[name] = dispatcher
+      commands[name] = {hiddenInCommandPalette: true, didDispatch: dispatcher}
     })
     return atom.commands.add('atom-text-editor', commands)
   },


### PR DESCRIPTION
Count of 'vim-mode-plus:' commands which are shown in command palette is over 320. (gather from `command-table-pretty.json`)
Sometimes it is annoying when I open command palette. (I think it slows down fuzzy searching)

So I want to set `hiddenInCommandPalette: true`

ref: https://github.com/t9md/atom-vim-mode-plus/commit/e93bf233111e872f0cad354d8d143b0161335fd1 
