### PR TITLE
hideCommandsFromCommandPalette config param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.29.0: WIP
+- New, Breaking: `hideCommandsFromCommandPalette` config which hide commands from command-palette when set to `true` #1033, #1034
+  - This feature is once implemented in #943 but reverted before releasing it. Because I find no big perf gain by this feature.
+  - But this time I changed mind, Because I got requested, plus getting thik to reducing noise when searching palette is good idea.
+
 # 1.28.1:
 - Diff: [here](https://github.com/t9md/atom-vim-mode-plus/compare/v1.28.0...v1.28.1)
 - FIX: Add `altgraph` using version of keymap to to workaround atom-keymap issue @lydell #661, #1031

--- a/lib/main.js
+++ b/lib/main.js
@@ -121,9 +121,12 @@ module.exports = {
 
   registerEditorCommands () {
     const commands = {}
-    const dispatcher = VimState.getDispatcher()
+    const spec = {
+      hiddenInCommandPalette: settings.get('hideCommandsFromCommandPalette'),
+      didDispatch: VimState.getDispatcher()
+    }
     require('./json/command-table.json').forEach(name => {
-      commands[name] = {hiddenInCommandPalette: true, didDispatch: dispatcher}
+      commands[name] = spec
     })
     return atom.commands.add('atom-text-editor', commands)
   },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -283,6 +283,11 @@ module.exports = new Settings('vim-mode-plus', {
     description:
       '[Can]: `I p`, `A p` to insert at start or end of `preset-occurrence` in paragraph(`p`).<br>`I` and `A` is operator which take target, you can combine it with any target like `I f`(`a-function`), `A z`(`a-fold`).<br>[Caution]: `I` and `A` behaves as operator as long as editor has `preset-occurrence`, even if there is no VISIBLE `preset-occurrence` in screen. You might want to `escape` to clear preset-occurrences on editor to make `I` and `A` behave normaly gain.<br>[Conflicts]: You cannot use normal `I` and `A` when `preset-occurrence` marker is exists.'
   },
+  hideCommandsFromCommandPalette: {
+    default: true,
+    description:
+      'Hide most commands(such as `j`(`vim-mode-plus:move-down`)) from command-palette. Require restart to make change take effect.'
+  },
   setCursorToStartOfChangeOnUndoRedo: true,
   setCursorToStartOfChangeOnUndoRedoStrategy: {
     default: 'smart',


### PR DESCRIPTION
hiding command feat was once implemented in https://github.com/t9md/atom-vim-mode-plus/pull/943.
but I reverted after noticing result was not as good as I expected(my interest at that time was palette's perf).
Now come back this feature based on request(#1033).
And this PR make this hiding behavior configurable.