### PR TITLE
[Experiment] autoDisableInputMethodWhenLeavingInsertMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.30.0:
+- New, Experiment: `autoDisableInputMethodWhenLeavingInsertMode` config to auto-disable IME when leaving `insert-mode`.
+  - Default `false`.
+  - Once this feature was brought by PR#151 then reverted because of unfixable BUG.
+  - Now retrying to bring same feature in different approach
+    - setting `readOnly` attribute to `false` than setting `input.type = "password"`.
+  - Credit: Borrowed whole idea from @frapples's `vim-mode-plus-patch-switch-ime` package. Thanks @frapples!!
+
 # 1.29.0:
 - New: `hideCommandsFromCommandPalette` config which hide commands from command-palette when set to `true` #1033, #1034
   - Default `false` to to make it compatible with older version.

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -288,6 +288,10 @@ module.exports = new Settings('vim-mode-plus', {
     description:
       'Hide most commands(such as `j`(`vim-mode-plus:move-down`)) from command-palette. Require restart to make change take effect.'
   },
+  autoDisableInputMethodWhenLeavingInsertMode: {
+    default: false,
+    description: '[Experimental] Automatically disable input method when leaving insert-mode'
+  },
   setCursorToStartOfChangeOnUndoRedo: true,
   setCursorToStartOfChangeOnUndoRedoStrategy: {
     default: 'smart',

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -240,6 +240,10 @@ module.exports = class VimState {
     this.subscriptions.dispose()
 
     if (this.editor.isAlive()) {
+      if (this.getConfig('autoDisableInputMethodWhenLeavingInsertMode')) {
+        // Force to reset to defaut value
+        this.editor.component.getHiddenInput().readOnly = false
+      }
       this.resetNormalMode()
       this.reset()
       if (this.editorElement.component) this.editorElement.component.setInputEnabled(true)
@@ -464,6 +468,10 @@ module.exports = class VimState {
     if (newMode === 'normal') this.activateNormalMode()
     else if (newMode === 'insert') this.editorElement.component.setInputEnabled(true)
     else if (newMode === 'visual') this.modeDeactivator = this.activateVisualMode(newSubmode)
+
+    if (this.getConfig('autoDisableInputMethodWhenLeavingInsertMode')) {
+      this.editor.component.getHiddenInput().readOnly = newMode !== 'insert'
+    }
 
     this.editorElement.classList.remove(`${this.mode}-mode`)
     this.editorElement.classList.remove(this.submode)

--- a/lib/vim-state.js
+++ b/lib/vim-state.js
@@ -241,8 +241,7 @@ module.exports = class VimState {
 
     if (this.editor.isAlive()) {
       if (this.getConfig('autoDisableInputMethodWhenLeavingInsertMode')) {
-        // Force to reset to defaut value
-        this.editor.component.getHiddenInput().readOnly = false
+        this.editor.component.getHiddenInput().readOnly = false // force reset to default
       }
       this.resetNormalMode()
       this.reset()


### PR DESCRIPTION
This is retry of #151.
Why? I found @frapples's [vim-mode-plus-patch-switch-ime](https://github.com/frapples/vim-mode-plus-patch-switch-ime).
It use `readOnly` attribute instead of setting input.type to `password` as in #151.
And as far as I checked, no [Cannot move tab when it is in normal mode #193](#193) issue as like it was in #151.

This time, I made this as opt-in configuration.
To use this feature, need to enable `autoDisableInputMethodWhenLeavingInsertMode`.

### History

- Ideally implement old feature request(atom/atom#1092) in atom-core is the best.
  - But it's not likely to happen soon.
- Once I merged PR #151, it seemed to work as we want.
- But removed this feature when I noticed [Cannot move tab when it is in normal mode #193](#193).
- After a while some plugin packages were released to tackle this issue
  - [vim-mode-plus-auto-ime](https://atom.io/packages/vim-mode-plus-auto-ime) invoke external command to manipulate IME.
  - [vim-mode-plus-patch-switch-ime](https://github.com/frapples/vim-mode-plus-patch-switch-ime) is like #151, but use `readOnly` attribute instead of set input's type t `password`.
