### PR TITLE
Make ChangeCase not ignore non-ascii characters

### DIFF
--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -39,7 +39,8 @@ class ChangeCase extends TransformString {
     const functionName = this.functionName || changeCase.lowerCaseFirst(this.name)
     // HACK: IMO `changeCase` does aggressive transformation(remove punctuation, remove white spaces...)
     // make changeCase less aggressive by targeting narrower charset.
-    const regex = /\w+(:?[-./]?[\w+])*/g
+    const charset = '[\u00C0-\u02AF\u0386-\u0587\\w]'
+    const regex = new RegExp(`${charset}+(:?[-./]?${charset}+)*`, 'g')
     return text.replace(regex, match => changeCase[functionName](match))
   }
 }


### PR DESCRIPTION
By using `\w` to match characters, only ascii characters are transformed, ignoring characters with accents, etc.
This regex is much uglier but includes Latin characters with accents as well as Russian, Greek, Armenian, Coptic and more.
Solves #1054 