### PR TITLE
Clearly and simply state what the ex-mode package adds to vim-mode-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,9 @@ See [DifferencesFromPureVim](https://github.com/t9md/atom-vim-mode-plus/wiki/Dif
 Not freezing, it's just VERY slow.  
 You can workaround by disabling some keymap. See [#214](https://github.com/t9md/atom-vim-mode-plus/issues/214).
 
-### ex-mode?
+### How can I use `:w` to save, `:10` to go to line ten, and `:$s/text/replacement/g`?
 
-- The [ex-mode](https://atom.io/packages/ex-mode) package has the most complete ex-mode support.
-- Very immature package [vim-mode-plus-ex-mode](https://atom.io/packages/vim-mode-plus-ex-mode) exists.
-- My thought for ex-mode is [here #52](https://github.com/t9md/atom-vim-mode-plus/issues/52).
+Install [ex-mode](https://atom.io/packages/ex-mode) package.  This provides various 'ex' commands when the colon (:) is typed in normal mode, including the ability to save a file and close the Atom tab with `:wq`.
 
 ### Want to suppress autocomplete-plus's auto suggestion except insert-mode.
 


### PR DESCRIPTION
No need to mention vim-mode-plus-ex-mode, it's deprecated in favor of ex-mode.

And if we want to link somewhere explaining the motivation behind keeping the packages separate / not making ex-mode a dependency when vim-mode-plus is installed, it should probably go in a concise wiki page; issue https://github.com/t9md/atom-vim-mode-plus/issues/52 is informative but a bit more than needs to be linked from the README.

Anyhow, a frequently asked question like this would have helped me a lot!  Probably this person - https://github.com/t9md/atom-vim-mode-plus/issues/328 - and many similar issues from the old vim-mode queue, too, such as https://github.com/atom/vim-mode/issues/50