### PR TITLE
[WIP] support function-text-object in TreeSitter

### DIFF
--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -603,10 +603,13 @@ class Function extends TextObject {
   getRangeWithTreeSitter (selection) {
     const editor = this.editor
     const cursorPosition = this.getCursorPositionForSelection(selection)
-    const startNode = editor.languageMode.getSyntaxNodeAtPosition(cursorPosition)
+    const firstCharacterPosition = this.utils.getFirstCharacterPositionForBufferRow(this.editor, cursorPosition.row)
+    const searchStartPoint = Point.max(firstCharacterPosition, cursorPosition)
+    const startNode = editor.languageMode.getSyntaxNodeAtPosition(searchStartPoint)
 
-    const nodeIsFoldable = node => editor.isFoldableAtBufferRow(node.range.start.row)
-    const node = this.utils.findParentNodeForFunctionType(editor, startNode, nodeIsFoldable)
+    // const nodeIsFoldable = node => editor.isFoldableAtBufferRow(node.range.start.row)
+    // const node = this.utils.findParentNodeForFunctionType(editor, startNode, nodeIsFoldable)
+    const node = this.utils.findParentNodeForFunctionType(editor, startNode)
     if (node) {
       let range = node.range
 

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -600,7 +600,28 @@ class Function extends TextObject {
     return false
   }
 
+  getRangeWithTreeSitter (selection) {
+    const editor = this.editor
+    const cursorPosition = this.getCursorPositionForSelection(selection)
+    const startNode = editor.languageMode.getSyntaxNodeAtPosition(cursorPosition)
+    const node = this.utils.findParentForFunctionType(editor, startNode)
+    if (node) {
+      let range = node.range
+
+      if (!this.isA()) {
+        const endRowTranslation = this.utils.doesRangeStartAndEndWithSameIndentLevel(editor, range) ? -1 : 0
+        range = range.translate([1, 0], [endRowTranslation, 0])
+      }
+      return this.utils.getBufferRangeForRowRange(editor, [range.start.row, range.end.row])
+    }
+  }
+
   getRange (selection) {
+    const useTreeSitter = this.utils.isUsingTreeSitter(selection.editor)
+    if (useTreeSitter) {
+      return this.getRangeWithTreeSitter(selection)
+    }
+
     const editor = this.editor
     const cursorRow = this.getCursorPositionForSelection(selection).row
     const bodyStartRegex = this.getFunctionBodyStartRegex(editor.getGrammar())

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -607,13 +607,16 @@ class Function extends TextObject {
     const searchStartPoint = Point.max(firstCharacterPosition, cursorPosition)
     const startNode = editor.languageMode.getSyntaxNodeAtPosition(searchStartPoint)
 
-    // const nodeIsFoldable = node => editor.isFoldableAtBufferRow(node.range.start.row)
-    // const node = this.utils.findParentNodeForFunctionType(editor, startNode, nodeIsFoldable)
     const node = this.utils.findParentNodeForFunctionType(editor, startNode)
     if (node) {
       let range = node.range
 
       if (!this.isA()) {
+        const bodyNode = this.utils.findFunctionBodyNode(editor, node)
+        if (bodyNode) {
+          range = bodyNode.range
+        }
+
         const endRowTranslation = this.utils.doesRangeStartAndEndWithSameIndentLevel(editor, range) ? -1 : 0
         range = range.translate([1, 0], [endRowTranslation, 0])
       }

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -604,7 +604,9 @@ class Function extends TextObject {
     const editor = this.editor
     const cursorPosition = this.getCursorPositionForSelection(selection)
     const startNode = editor.languageMode.getSyntaxNodeAtPosition(cursorPosition)
-    const node = this.utils.findParentForFunctionType(editor, startNode)
+
+    const nodeIsFoldable = node => editor.isFoldableAtBufferRow(node.range.start.row)
+    const node = this.utils.findParentNodeForFunctionType(editor, startNode, nodeIsFoldable)
     if (node) {
       let range = node.range
 

--- a/lib/text-object.js
+++ b/lib/text-object.js
@@ -617,7 +617,12 @@ class Function extends TextObject {
         const endRowTranslation = this.utils.doesRangeStartAndEndWithSameIndentLevel(editor, range) ? -1 : 0
         range = range.translate([1, 0], [endRowTranslation, 0])
       }
-      return this.utils.getBufferRangeForRowRange(editor, [range.start.row, range.end.row])
+      if (range.end.column !== 0) {
+        // The 'preproc_function_def' type used in C and C++ header's "#define" returns linewise range.
+        // In this case, we shouldn't translate to linewise since it already contains ending newline.
+        range = this.utils.getBufferRangeForRowRange(editor, [range.start.row, range.end.row])
+      }
+      return range
     }
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -518,14 +518,14 @@ function isFunctionType (editor, node) {
   return types && types.some(type => node.type === type)
 }
 
-function findParentForFunctionType (editor, startNode) {
+function findParentForFunctionType (editor, syntaxNode) {
   while (true) {
-    if (startNode.isNamed && isFunctionType(editor, startNode)) {
-      return startNode
+    if (syntaxNode.isNamed && isFunctionType(editor, syntaxNode)) {
+      return syntaxNode
     }
 
-    if (startNode && startNode.parent) {
-      return findParentForFunctionType(editor, startNode.parent)
+    if (syntaxNode && syntaxNode.parent) {
+      return findParentForFunctionType(editor, syntaxNode.parent)
     } else {
       break
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -513,14 +513,16 @@ const FunctionTypesByGrammar = {
 }
 FunctionTypesByGrammar['source.jsx'] = FunctionTypesByGrammar['source.js']
 
-function isFunctionType (editor, node) {
+function findParentNodeForFunctionType (editor, node, where = () => true) {
   const types = FunctionTypesByGrammar[editor.getGrammar().scopeName]
-  return types && types.some(type => node.type === type)
+  if (types) {
+    return findClosestNodeByType(node, types, where)
+  }
 }
 
-function findParentForFunctionType (editor, node) {
+function findClosestNodeByType (node, types, where) {
   while (node) {
-    if (node.isNamed && isFunctionType(editor, node)) {
+    if (node.isNamed && types.some(type => node.type === type) && where(node)) {
       return node
     }
 
@@ -1293,7 +1295,7 @@ function changeCharOrder (text, action) {
 }
 
 function isUsingTreeSitter (editor) {
-  return !!editor.languageMode.getRangeForSyntaxNodeContainingRange
+  return !!editor.languageMode.tree
 }
 
 module.exports = {
@@ -1343,7 +1345,7 @@ module.exports = {
   isIncludeFunctionScopeForRow,
   detectScopeStartPositionForScope,
   getRows,
-  findParentForFunctionType,
+  findParentNodeForFunctionType,
   smartScrollToBufferPosition,
   matchScopes,
   isSingleLineText,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -542,26 +542,33 @@ function findClosestNodeByType (node, types, where) {
 
 function findFunctionBodyNode (editor, node) {
   const findChild = childType => node.namedChildren.find(node => node.type === childType)
+  let bodyNode
 
   switch (editor.getGrammar().scopeName) {
     case 'source.js':
     case 'source.jsx':
     case 'source.ts':
-      if (node.type === 'function') return findChild('statement_block')
+      if (node.type === 'function') {
+        bodyNode = findChild('statement_block')
+      }
+      break
     case 'source.c':
     case 'source.cpp':
     case 'source.shell':
-      if (node.type === 'function_definition') return findChild('compound_statement')
+      if (node.type === 'function_definition') {
+        bodyNode = findChild('compound_statement')
+      }
+      break
     case 'source.python':
       if (node.type === 'function_definition') {
         const parameterNode = findChild('parameters')
-        return {
+        bodyNode = {
           range: new Range(parameterNode.range.end, node.lastChild.range.end)
         }
       }
-    default:
-      return null
+      break
   }
+  return bodyNode
 }
 
 // Scroll to bufferPosition with minimum amount to keep original visible area.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -540,6 +540,30 @@ function findClosestNodeByType (node, types, where) {
   }
 }
 
+function findFunctionBodyNode (editor, node) {
+  const findChild = childType => node.namedChildren.find(node => node.type === childType)
+
+  switch (editor.getGrammar().scopeName) {
+    case 'source.js':
+    case 'source.jsx':
+    case 'source.ts':
+      if (node.type === 'function') return findChild('statement_block')
+    case 'source.c':
+    case 'source.cpp':
+    case 'source.shell':
+      if (node.type === 'function_definition') return findChild('compound_statement')
+    case 'source.python':
+      if (node.type === 'function_definition') {
+        const parameterNode = findChild('parameters')
+        return {
+          range: new Range(parameterNode.range.end, node.lastChild.range.end)
+        }
+      }
+    default:
+      return null
+  }
+}
+
 // Scroll to bufferPosition with minimum amount to keep original visible area.
 // If target position won't fit within onePageUp or onePageDown, it center target point.
 function smartScrollToBufferPosition (editor, point) {
@@ -1352,6 +1376,7 @@ module.exports = {
   detectScopeStartPositionForScope,
   getRows,
   findParentNodeForFunctionType,
+  findFunctionBodyNode,
   smartScrollToBufferPosition,
   matchScopes,
   isSingleLineText,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -509,8 +509,12 @@ function isFunctionScope (editor, scope) {
 const FunctionTypesByGrammar = {
   'source.ts': ['method_definition', 'abstract_class', 'class', 'function'],
   'source.go': ['function_declaration'],
-  'source.js': ['function', 'method_definition', 'class']
+  'source.js': ['function', 'method_definition', 'class'],
+  'source.python': ['function_definition', 'class_definition'],
+  'source.shell': ['function_definition'],
+  'source.ruby': ['method', 'class', 'module']
 }
+
 FunctionTypesByGrammar['source.jsx'] = FunctionTypesByGrammar['source.js']
 
 function findParentNodeForFunctionType (editor, node, where = () => true) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -504,6 +504,35 @@ function isFunctionScope (editor, scope) {
   }
 }
 
+// Determine if TreeSitter's SyntaxNode is function-like node.
+// Parsed "type" field is unieque to each grammar, so need to add more grammars here.
+const FunctionTypesByGrammar = {
+  'source.ts': ['method_definition', 'abstract_class', 'class', 'function'],
+  'source.go': ['function_declaration'],
+  'source.js': ['function', 'method_definition', 'class']
+}
+FunctionTypesByGrammar['source.jsx'] = FunctionTypesByGrammar['source.js']
+
+function isFunctionType (editor, node) {
+  const types = FunctionTypesByGrammar[editor.getGrammar().scopeName]
+  return types && types.some(type => node.type === type)
+}
+
+function findParentForFunctionType (editor, startNode) {
+  while (true) {
+    if (startNode.isNamed && isFunctionType(editor, startNode)) {
+      return startNode
+    }
+
+    if (startNode && startNode.parent) {
+      return findParentForFunctionType(editor, startNode.parent)
+    } else {
+      break
+    }
+  }
+  return false
+}
+
 // Scroll to bufferPosition with minimum amount to keep original visible area.
 // If target position won't fit within onePageUp or onePageDown, it center target point.
 function smartScrollToBufferPosition (editor, point) {
@@ -1265,7 +1294,7 @@ function changeCharOrder (text, action) {
 }
 
 function isUsingTreeSitter (editor) {
-  return editor.languageMode.constructor.name === 'TreeSitterLanguageMode'
+  return !!editor.languageMode.getRangeForSyntaxNodeContainingRange
 }
 
 module.exports = {
@@ -1315,6 +1344,7 @@ module.exports = {
   isIncludeFunctionScopeForRow,
   detectScopeStartPositionForScope,
   getRows,
+  findParentForFunctionType,
   smartScrollToBufferPosition,
   matchScopes,
   isSingleLineText,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -507,15 +507,17 @@ function isFunctionScope (editor, scope) {
 // Determine if TreeSitter's SyntaxNode is function-like node.
 // Parsed "type" field is unieque to each grammar, so need to add more grammars here.
 const FunctionTypesByGrammar = {
-  'source.ts': ['method_definition', 'abstract_class', 'class', 'function'],
   'source.go': ['function_declaration'],
   'source.js': ['function', 'method_definition', 'class'],
+  'source.jsx': ['function', 'method_definition', 'class'],
+  'source.flow': ['function', 'method_definition', 'class'],
+  'source.ts': ['function', 'method_definition', 'class', 'abstract_class'],
   'source.python': ['function_definition', 'class_definition'],
   'source.shell': ['function_definition'],
-  'source.ruby': ['method', 'class', 'module']
+  'source.ruby': ['method', 'class', 'module'],
+  'source.c': ['function_definition', 'preproc_function_def'],
+  'source.cpp': ['function_definition', 'preproc_function_def', 'class_specifier']
 }
-
-FunctionTypesByGrammar['source.jsx'] = FunctionTypesByGrammar['source.js']
 
 function findParentNodeForFunctionType (editor, node, where = () => true) {
   const types = FunctionTypesByGrammar[editor.getGrammar().scopeName]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -518,19 +518,18 @@ function isFunctionType (editor, node) {
   return types && types.some(type => node.type === type)
 }
 
-function findParentForFunctionType (editor, syntaxNode) {
-  while (true) {
-    if (syntaxNode.isNamed && isFunctionType(editor, syntaxNode)) {
-      return syntaxNode
+function findParentForFunctionType (editor, node) {
+  while (node) {
+    if (node.isNamed && isFunctionType(editor, node)) {
+      return node
     }
 
-    if (syntaxNode && syntaxNode.parent) {
-      return findParentForFunctionType(editor, syntaxNode.parent)
+    if (node.parent) {
+      node = node.parent
     } else {
       break
     }
   }
-  return false
 }
 
 // Scroll to bufferPosition with minimum amount to keep original visible area.


### PR DESCRIPTION
WIP, Very rough state.

For #1095

Get function range of cursor position contained, by checking `node.type` of `node.parent` recursively up to rootNode.

## TODO

- [x] Precise recognition of function body on `inner-function`.
- [x] More language suport
  - list of tree-sitter supported grammar by `atom.grammars.treeSitterGrammarsById`
  - here is the current state.
    ```
    # TODO
    'source.c',
    'source.cpp',
    'source.ts',
    'source.flow'

    # DONE
    'source.js',
    'source.python',
    'source.shell',
    'source.go',
    'source.ruby',

    # SKIP
    'source.js.regexp',
    'text.html.basic',
    'text.html.ejs',
    'text.html.erb',
    ```
- [x] ~~Skip unfoldable inline-function(??)~~ decide don't skip to support variety of style of func declaration
- [x] Start searching from first char of that line where cursor is before first-char
  - Purpose for this is to get method `test` when cursor is at very beginning of 2nd line.
  ```ruby
  class ClassName
    def test
      puts "hello"
    end
  end
  ```
