### PR TITLE
Implements support for custom surround pairs

### DIFF
--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -514,6 +514,11 @@ class SurroundBase extends TransformString {
   initialize () {
     this.replaceByDiff = this.getConfig('replaceByDiffOnSurround')
     this.stayByMarker = this.replaceByDiff
+
+    this.getConfig('customSurroundPairs').forEach((pair) => {
+      this.pairsByAlias[pair.alias] = [pair.start, pair.end]
+    })
+
     super.initialize()
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -354,6 +354,28 @@ module.exports = new Settings('vim-mode-plus', {
     description:
       'Comma separated list of character, which add space around surrounded text.<br>For vim-surround compatible behavior, set `(, {, [, <`.'
   },
+  customSurroundPairs: {
+    type: 'array',
+    default: [],
+    items: {
+      type: 'object',
+      properties: {
+        alias: {
+          name: 'Alias',
+          type: 'string'
+        },
+        start: {
+          name: 'Start text',
+          type: 'string'
+        },
+        end: {
+          name: 'End text',
+          type: 'string'
+        },
+      }
+    },
+    description: 'Custom pairs of surrounding objects. For example, setting this option to [{alias: "p", start: "<?php ", end: " ?>"}] would allow you to wrap the current word in a pair of PHP tags using the key sequence "y s i w p".'
+  },
   sequentialPaste: {
     default: false,
     description:

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -875,6 +875,26 @@ describe "Operator TransformString", ->
             it "c7", -> ensureWait 'y s i w <', text: "<abc>"
             it "c8", -> ensureWait 'y s i w a', text: "< abc >"
 
+    describe 'customSurroundPairs setting', ->
+      beforeEach ->
+        settings.set('customSurroundPairs', [{
+          alias: 'c',
+          start: '/* ',
+          end: ' */',
+        }])
+
+      it 'allow adding a surrounding custom pair', ->
+        set
+          textC: '|test'
+
+        ensureWait 'y s i w c', text: "/* test */"
+
+      it 'allow changing an existing surrounding pair to a custom pair', ->
+        set
+          textC: '(|test)'
+
+        ensureWait 'c s c', text: "/* test */"
+
     describe 'map-surround', ->
       beforeEach ->
         jasmine.attachToDOM(editorElement)


### PR DESCRIPTION
(This is my first `atom-vim-mode-plus` PR, so definitely let me know if I've missed something, or if there already exists similar feature to this :) )

This PR adds a config option `customSurroundPairs` that allows the user to define custom pairs of texts to be used with surround operators. 

## Example use case: Adding surrounding PHP tags

By setting `customSurroundPairs` to

```
[{alias: 'p', start: '<?php ', end: ' ?>'}]
```

the user can change (`|` for cursor)

```
so|mething
```

to

```
<?php so|mething ?>
```

using the key sequence `y s i w p`.

## Setting accessibility

Since the schema of this setting is rather complex (it is an array consisting of objects with certain properties), `atom-settings` will not render it in the settings panel. Instead, the only way to set it seems to be manually modifying the user's `config.cson` file. 

Should we switch to use a simpler config schema so that this option can be shown in the settings panel? For example, we can make the setting be an array of strings of format "trigger|start|end". 

Alternatively, we can keep the current schema. But in that case we might want to document this option somewhere since it's not gonna be in the settings panel.