### PR TITLE
add custom surround inspired @isundaylee's PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 1.36.0:
+- New: custom surround #1104, #1102(inspirational PR by @isundaylee)
+  - New `customSurroundPairs` config is introduced, its value is JSON string with following key-value pair.
+    - key: char to access
+    - value: array `[openText:string, closeText:string, addSpace:boolean]`
+      - `addSpace` is optional, it control padding space.
+  - Custom surround can be used in all surround operation(`surround`, `delete-surround`, `change-surround`)
+  - Example configuration and possible operations
+    - Config
+      ```coffeescript
+      "vim-mode-plus":
+        customSurroundPairs: '''
+          {
+            "p": ["<?php", "?>", true],
+            "%": ["<%", "%>", true],
+            "=": ["<%=", "%>", true],
+            "s": ["\\"", "\\""]
+          }
+        '''
+      ```
+    - `y s c p`: `surround`(`y s`) `inner-word`(`c` or `i w`) with `p`(PHP tag)
+    - `c s p s`: `change-surround`(`c s`) from `p`(PHP tag) to `s`(double quotes)
+    - `d s =`: `delete-surround`(`d s`) of `=`(ruby-IRB tag)
+
 # 1.35.0: TreeSitter support
 - Support: Set minimum engines to `^1.31.0-beta1`.
 - Fix: TextObject function and fold now work with TreeSitter parser have enabled.

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,7 +77,8 @@ module.exports = {
           this.clearHighlightSearch()
         }
       }),
-      ...settings.observeConditionalKeymaps()
+      ...settings.observeConditionalKeymaps(),
+      settings.observeJSONconfig()
     )
 
     if (atom.inDevMode()) {

--- a/lib/operator-transform-string.js
+++ b/lib/operator-transform-string.js
@@ -503,8 +503,15 @@ class ReflowWithStay extends Reflow {
 class SurroundBase extends TransformString {
   static command = false
   surroundAction = null
-  pairs = [['(', ')'], ['{', '}'], ['[', ']'], ['<', '>']]
   pairsByAlias = {
+    '(': ['(', ')'],
+    ')': ['(', ')'],
+    '{': ['{', '}'],
+    '}': ['{', '}'],
+    '[': ['[', ']'],
+    ']': ['[', ']'],
+    '<': ['<', '>'],
+    '>': ['<', '>'],
     b: ['(', ')'],
     B: ['{', '}'],
     r: ['[', ']'],
@@ -518,13 +525,14 @@ class SurroundBase extends TransformString {
   }
 
   getPair (char) {
-    return char in this.pairsByAlias
-      ? this.pairsByAlias[char]
-      : [...this.pairs, [char, char]].find(pair => pair.includes(char))
+    const userConfig = this.getConfig('customSurroundPairs')
+    const customPairByAlias = JSON.parse(userConfig) || {}
+    console.log(customPairByAlias)
+    return customPairByAlias[char] || this.pairsByAlias[char] || [char, char]
   }
 
   surround (text, char, {keepLayout = false, selection} = {}) {
-    let [open, close] = this.getPair(char)
+    let [open, close, addSpace] = this.getPair(char)
     if (!keepLayout && text.endsWith('\n')) {
       const baseIndentLevel = this.editor.indentationForBufferRow(selection.getBufferRange().start.row)
       const indentTextStartRow = this.editor.buildIndentString(baseIndentLevel)
@@ -535,18 +543,23 @@ class SurroundBase extends TransformString {
       close = indentTextStartRow + close + '\n'
     }
 
-    if (this.getConfig('charactersToAddSpaceOnSurround').includes(char) && this.utils.isSingleLineText(text)) {
-      text = ' ' + text + ' '
+    if (this.utils.isSingleLineText(text)) {
+      if (addSpace || this.getConfig('charactersToAddSpaceOnSurround').includes(char)) {
+        text = ' ' + text + ' '
+      }
     }
-
     return open + text + close
   }
 
+  getTargetPair () {
+    if (this.target) {
+      return this.target.pair
+    }
+  }
+
   deleteSurround (text) {
-    // Assume surrounding char is one-char length.
-    const open = text[0]
-    const close = text[text.length - 1]
-    const innerText = text.slice(1, text.length - 1)
+    const [open, close] = this.getTargetPair() || [text[0], text[text.length - 1]]
+    const innerText = text.slice(open.length, text.length - close.length)
     return this.utils.isSingleLineText(text) && open !== close ? innerText.trim() : innerText
   }
 
@@ -613,7 +626,8 @@ class ChangeSurround extends DeleteSurround {
   // Override to show changing char on hover
   async focusInputPromised (...args) {
     const hoverPoint = this.mutationManager.getInitialPointForSelection(this.editor.getLastSelection())
-    this.vimState.hover.set(this.editor.getSelectedText()[0], hoverPoint)
+    const openSurrondText = this.getTargetPair() ? this.getTargetPair()[0] : this.editor.getSelectedText()[0]
+    this.vimState.hover.set(openSurrondText, hoverPoint)
     return super.focusInputPromised(...args)
   }
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -212,6 +212,22 @@ class Settings {
     // Return disposalbes to dispose config observation and conditional keymap.
     return Object.keys(conditionalKeymaps).map(observeConditionalKeymap)
   }
+
+  observeJSONconfig () {
+    return this.observe('customSurroundPairs', newValue => {
+      try {
+        JSON.parse(newValue)
+      } catch (e) {
+        const message = [
+          'vim-mode-plus: JSON format error in `customSurroundPairs` config.',
+          'Maybe missing comma?',
+          '',
+          '`' + newValue + '`'
+        ].join('<br>')
+        atom.notifications.addWarning(message, {dismissable: true})
+      }
+    })
+  }
 }
 
 module.exports = new Settings('vim-mode-plus', {
@@ -353,6 +369,12 @@ module.exports = new Settings('vim-mode-plus', {
     items: {type: 'string'},
     description:
       'Comma separated list of character, which add space around surrounded text.<br>For vim-surround compatible behavior, set `(, {, [, <`.'
+  },
+  customSurroundPairs: {
+    type: 'string',
+    default: '{}',
+    description:
+      'Custom surround in JSON string with following key value pair.<br>- key: character to map<br>- value: array with `[openText:string, closeText:string, addSpace:boolean]`<br><br>Pasting pre-formatted JSON text is way easier than directly edit here.<br><br>e.g. `{"p": ["<?php", "?>", true], "s": ["\\"", "\\""]}`<br>With above example and `y s` is mapped to `surround`, `y s i w p` surround word with PHP tag, also `y s i w s` surround word with double quotes without padding space.'
   },
   sequentialPaste: {
     default: false,

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -1058,6 +1058,34 @@ describe "Operator TransformString", ->
             it "case2", -> set textC: '|"  apple  "'; ensureWait 'c S " `', text: "`  apple  `"
             it "case3", -> set textC: '|"  apple  "'; ensureWait 'c S " \'', text: "'  apple  '"
 
+      describe 'customSurroundPairs setting', ->
+        beforeEach ->
+          constomSurround = '''
+            {
+              "p": ["<?php", "?>", true],
+              "%": ["<%", "%>", true],
+              "=": ["<%=", "%>", true],
+              "s": ["\\"", "\\""]
+            }
+          '''
+          settings.set('customSurroundPairs', constomSurround)
+
+        describe 'surround', ->
+          it "case1", -> set textC: "ap|ple"; ensureWait 'y s c p', text: "<?php apple ?>"
+          it "case2", -> set textC: "ap|ple"; ensureWait 'y s c %', text: "<% apple %>"
+          it "case2", -> set textC: "ap|ple"; ensureWait 'y s c =', text: "<%= apple %>"
+          it "case2", -> set textC: "ap|ple"; ensureWait 'y s c s', text: '"apple"'
+        describe 'delete-surround', ->
+          it "case1", -> set textC: "<?php ap|ple ?>"; ensureWait 'd S p', text: "apple"
+          it "case2", -> set textC: "<% ap|ple %>";    ensureWait 'd S %', text: "apple"
+          it "case2", -> set textC: "<%= ap|ple %>";   ensureWait 'd S =', text: "apple"
+          it "case2", -> set textC: '"ap|ple"';        ensureWait 'd S s', text: "apple"
+        describe 'change-surround', ->
+          it "case1", -> set textC: "<?php ap|ple ?>"; ensureWait 'c S p %', text: "<% apple %>"
+          it "case2", -> set textC: "<% ap|ple %>";    ensureWait 'c S % =', text: "<%= apple %>"
+          it "case2", -> set textC: "<%= ap|ple %>";   ensureWait 'c S = s', text: '"apple"'
+          it "case2", -> set textC: '"ap|ple"';        ensureWait 'c S s p', text: "<?php apple ?>"
+
     describe 'surround-word', ->
       beforeEach ->
         atom.keymaps.add "surround-test",


### PR DESCRIPTION
Inspired by and continuation of #1102

- New `customSurroundPairs` config is introduced, its value is JSON string with following key-value pair.
  - key: char to access
  - value: array `[openText:string, closeText:string, addSpace:boolean]`
    - `addSpace` is optional, it control padding space.
- Config can be edited in setting-view.
- These custom surround can be used in all surround operation shown below.
  - `surround`
  - `delete-surround`
  - `change-surround`
- JSON config is validated and user see warning dialog if it has error.

### Configuration example

```coffeescript
"vim-mode-plus":
  customSurroundPairs: '''
    {
      "p": ["<?php", "?>", true],
      "%": ["<%", "%>", true],
      "=": ["<%=", "%>", true],
      "s": ["\\"", "\\""]
    }
  '''
```

With the above example and `y s` is mapped to `surround` and `c S` is mapped to `change-surround`
- `y s i w p`:(surround inner-word p(PHP tag)).
- `c S p %`:(change p(PHP-tag) surround to %(Ruby-irb) tag.
