### PR TITLE
[default change] opinionated default setting part3.

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -308,7 +308,7 @@ module.exports = new Settings('vim-mode-plus', {
     default: false,
     description: '[Experimental] Automatically disable input method when leaving insert-mode'
   },
-  setCursorToStartOfChangeOnUndoRedo: true,
+  setCursorToStartOfChangeOnUndoRedo: false,
   setCursorToStartOfChangeOnUndoRedoStrategy: {
     default: 'smart',
     enum: ['smart', 'simple'],

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -360,9 +360,9 @@ module.exports = new Settings('vim-mode-plus', {
     description: 'Clear persistent selection on `escape` in normal-mode'
   },
   replaceByDiffOnSurround: {
-    default: false,
+    default: true,
     description:
-      '[EXPERIMENTAL] Replace only changed text by comparing old and new text, affects `surround`, `delete-surround`, `change-surround`'
+      'Replace only changed text by comparing old and new text, affects `surround`, `delete-surround`, `change-surround`'
   },
   charactersToAddSpaceOnSurround: {
     default: [],

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -180,7 +180,8 @@ describe "Operator general", ->
           selectedText: ""
 
       describe "with multiple cursors", ->
-        describe "setCursorToStartOfChangeOnUndoRedo is true(default)", ->
+        describe "setCursorToStartOfChangeOnUndoRedo is true", ->
+          settings.set('setCursorToStartOfChangeOnUndoRedo', true)
           it "clear multiple cursors and set cursor to start of changes of last cursor", ->
             set
               text: originalText

--- a/spec/operator-general-spec.coffee
+++ b/spec/operator-general-spec.coffee
@@ -181,7 +181,9 @@ describe "Operator general", ->
 
       describe "with multiple cursors", ->
         describe "setCursorToStartOfChangeOnUndoRedo is true", ->
-          settings.set('setCursorToStartOfChangeOnUndoRedo', true)
+          beforeEach ->
+            settings.set('setCursorToStartOfChangeOnUndoRedo', true)
+
           it "clear multiple cursors and set cursor to start of changes of last cursor", ->
             set
               text: originalText

--- a/spec/operator-transform-string-spec.coffee
+++ b/spec/operator-transform-string-spec.coffee
@@ -897,9 +897,9 @@ describe "Operator TransformString", ->
 
       it "surround text for each word in target case-1", ->
         ensureWait 'm s i p (',
-          text: """
+          textC: """
 
-          (apple)
+          (|apple)
           (pairs) (tomato)
           (orange)
           (milk)
@@ -911,7 +911,7 @@ describe "Operator TransformString", ->
           textC: """
 
           apple
-          <|pairs> <tomato>
+          <p|airs> <tomato>
           orange
           milk
 
@@ -924,7 +924,7 @@ describe "Operator TransformString", ->
           "apple"
           "pairs" "tomato"
           "orange"
-          |"milk"
+          "|milk"
 
           """
 


### PR DESCRIPTION
Continuation of #728

#### `replaceByDiffOnSurround`: now `true`

- Old: Replaced whole text. e.g. Replacing `word` with `(word)`
- New: Modify surrounding text only, intact inner text.

Benefit:
  - Better cursor placement and highlight
  - Since inner-text is NOT replaced, undo/redo cursor position become precise.
  - Also, flash highlight on `undo`/`redo` no longer highlight inner-text.

#### `setCursorToStartOfChangeOnUndoRedo`: now `false`

To say simply, this is just directly using atom's undo/redo marker for cursor placement.
To make this work well, careful marker snapshotting(transact, checkpoint) is crucial(#603).
I have been using vmp with this setting enabled for over 6 months.
And I really like it.
I can consider this change as part of default `stayOnXXX` = `true`.
The reason why I couldn't introduce this change is #617 was not fixed yet before.
