### PR TITLE
honor the group changes config

### DIFF
--- a/lib/operator-insert.js
+++ b/lib/operator-insert.js
@@ -148,7 +148,7 @@ class ActivateInsertModeBase extends Operator {
       if (this.getConfig('clearMultipleCursorsOnEscapeInsertMode')) this.vimState.clearSelections()
 
       // grouping changes for undo checkpoint need to come last
-      this.groupChangesSinceBufferCheckpoint('undo')
+      if (this.getConfig('groupChangesWhenLeavingInsertMode')) this.groupChangesSinceBufferCheckpoint('undo')
 
       const preventIncorrectWrap = this.editor.hasAtomicSoftTabs()
       for (const cursor of this.editor.getCursors()) {


### PR DESCRIPTION
I think this line was deleted during the fix for https://github.com/t9md/atom-vim-mode-plus/issues/966 when it should not have been.  

This change re-adds the configuration option across all insert modes, not just when it it started with` InsertAboveWithNewline`