### PR TITLE
Fix 'a-f' (a-function) commands in JS when using using tree-sitter

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -445,12 +445,20 @@ function isFunctionScope (editor, scope) {
 
 // Determine if TreeSitter's SyntaxNode is function-like node.
 // Parsed "type" field is unieque to each grammar, so need to add more grammars here.
+const SharedJsFunctionTypes = [
+  'arrow_function',
+  'class',
+  'function_declaration',
+  'function',
+  'method_definition'
+]
+
 const FunctionTypesByGrammar = {
   'source.go': ['function_declaration'],
-  'source.js': ['function', 'method_definition', 'class'],
-  'source.jsx': ['function', 'method_definition', 'class'],
-  'source.flow': ['function', 'method_definition', 'class'],
-  'source.ts': ['function', 'method_definition', 'class', 'abstract_class'],
+  'source.js': SharedJsFunctionTypes,
+  'source.jsx': SharedJsFunctionTypes,
+  'source.flow': SharedJsFunctionTypes,
+  'source.ts': [...SharedJsFunctionTypes, 'abstract_class'],
   'source.python': ['function_definition', 'class_definition'],
   'source.shell': ['function_definition'],
   'source.ruby': ['method', 'class', 'module'],
@@ -487,7 +495,8 @@ function findFunctionBodyNode (editor, node) {
     case 'source.js':
     case 'source.jsx':
     case 'source.ts':
-      if (node.type === 'function') {
+    case 'source.flow':
+      if (SharedJsFunctionTypes.includes(node.type)) {
         bodyNode = findChild('statement_block')
       }
       break

--- a/spec/text-object-spec.coffee
+++ b/spec/text-object-spec.coffee
@@ -1730,6 +1730,42 @@ describe "TextObject", ->
         it '[from param] i f', -> set cursor: [1, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
         it '[from  body] i f', -> set cursor: [3, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
 
+      describe 'anonymous function', ->
+        beforeEach ->
+          set
+            text: """
+
+            const f1 = function(a1) {
+              if (true) {
+                console.log("hello")
+              }
+            }
+
+            """
+
+        it '[from param] a f', -> set cursor: [1, 11]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from  body] a f', -> set cursor: [3, 0]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from param] i f', -> set cursor: [1, 11]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
+        it '[from  body] i f', -> set cursor: [3, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
+
+      describe 'arrow function', ->
+        beforeEach ->
+          set
+            text: """
+
+            const f1 = (a1) => {
+              if (true) {
+                console.log("hello")
+              }
+            }
+
+            """
+
+        it '[from param] a f', -> set cursor: [1, 11]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from  body] a f', -> set cursor: [3, 0]; ensure 'v a f', selectedBufferRange: rangeForRows(1, 5)
+        it '[from param] i f', -> set cursor: [1, 11]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
+        it '[from  body] i f', -> set cursor: [3, 0]; ensure 'v i f', selectedBufferRange: rangeForRows(2, 4)
+
       describe '[case-1]: multi-line-param-function', ->
         beforeEach ->
           set


### PR DESCRIPTION
This fixes the broken 'a-f' commands when editing JS/TS/JS+flow files when Tree-Sitter parsers are enabled. I think this is because of some changes to the tree-sitter parsers. Here is some output from the [tree-sitter playground](http://tree-sitter.github.io/tree-sitter/playground).

The main thing is that `function_declaration` is used for `function foo() {}` and `function` is used for anonymous functions. They have even added support for arrow functions, although the `a-f` selection range isn't perfect when the functions are formatted in weird ways. I added tests for very simple examples, and hopefully the more complicated ones can be addressed later.

Thanks and あけましておめでとう!

Input 
```js
function foo() {
	return '';
}

const foo = () => {
	return '';
}

const foo = function() {
	return '';
}

const methods = {
	foo() {
		return '';
	}
}
```

Output

```
program [0, 0] - [11, 0])
	
Named Function
  function_declaration [0, 0] - [2, 1])
    name: identifier [0, 9] - [0, 12])
    parameters: formal_parameters [0, 12] - [0, 14])
    body: statement_block [0, 15] - [2, 1])
      return_statement [1, 1] - [1, 11])
        string [1, 8] - [1, 10])

Arrow function
  lexical_declaration [4, 0] - [6, 1])
    variable_declarator [4, 6] - [6, 1])
      name: identifier [4, 6] - [4, 9])
      value: arrow_function [4, 12] - [6, 1])
        parameters: formal_parameters [4, 12] - [4, 14])
        body: statement_block [4, 18] - [6, 1])
          return_statement [5, 1] - [5, 11])
            string [5, 8] - [5, 10])

Anonymous function
  lexical_declaration [8, 0] - [10, 1])
    variable_declarator [8, 6] - [10, 1])
      name: identifier [8, 6] - [8, 9])
      value: function [8, 12] - [10, 1])
        parameters: formal_parameters [8, 20] - [8, 22])
        body: statement_block [8, 23] - [10, 1])
          return_statement [9, 1] - [9, 11])
            string [9, 8] - [9, 10])

Method
  lexical_declaration [12, 0] - [16, 1])
    variable_declarator [12, 6] - [16, 1])
      name: identifier [12, 6] - [12, 13])
      value: object [12, 16] - [16, 1])
        method_definition [13, 0] - [15, 1])
          name: property_identifier [13, 0] - [13, 3])
          parameters: formal_parameters [13, 3] - [13, 5])
          body: statement_block [13, 6] - [15, 1])
            return_statement [14, 0] - [14, 10])
              string [14, 7] - [14, 9])
```