### PR TITLE
Add a helper package: no-evil-eol-newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ If you want to use the full power of vim-mode-plus, see and experiment with each
 Below is list of my packages which provide more vim-like experience.  
 Why I don't build in these features? Because it takes more time and some features are useful for non-vim user.
 
+- [no-evil-eol-newline](https://atom.io/packages/no-evil-eol-newline)
+Hide the last "empty line", like what Vim is doing.
 - [cursor-history](https://atom.io/packages/cursor-history)
 provides <kbd>c-i</kbd>, <kbd>c-o</kbd> to go/back in the cursor position history.
 - [open-this](https://atom.io/packages/open-this)


### PR DESCRIPTION
I'm selling my atom package [no-evil-eol-newline](https://atom.io/packages/no-evil-eol-newline) (also on [GitHub](https://github.com/b1f6c1c4/no-evil-eol-newline).) Introduction is copied here.

> Suppress display of end-of-file newlines as blank lines.
> A temporal fix for [Atom issue 7787](https://github.com/atom/atom/issues/7787).
> More precisely,
> - If a file ends with a `\n`, then the line number of the 'new line' is hidden (by css), just like what vim does.
> - If a file doesn't end with a `\n`, then the line number is shown in a bright color, indicating a missing `\n`.
> - Files that use `\r\n` as EOL simply work perfectly.
> 
> **Attention:**
> This package only deals with how things **appear**: it **never** modify any bit of your file content. Thus, this package:
>   - Is compatible with `whitespace`, `editorconfig`, and other packages.
>   - Works consistently on Linux, macOS, and Windows.

BTW, I'm wondering if I should add it to [ListOfVimModePlusPlugins](https://github.com/t9md/atom-vim-mode-plus/wiki/ListOfVimModePlusPlugins) and [DifferencesFromPureVim](https://github.com/t9md/atom-vim-mode-plus/wiki/DifferencesFromPureVim).